### PR TITLE
Fix/service-vectorizer

### DIFF
--- a/api-examples/lm-text.py
+++ b/api-examples/lm-text.py
@@ -1,9 +1,10 @@
 import baseline as bl
 import argparse
 import os
-parser = argparse.ArgumentParser(description='Classify text with a model')
-parser.add_argument('--model', help='A classifier model', required=True, type=str)
-parser.add_argument('--text', help='raw value', type=str)
+parser = argparse.ArgumentParser(description='Generate subsequent text by repeatedly predicting the next word from a '
+                                             'language model')
+parser.add_argument('--model', help='A language model', required=True, type=str)
+parser.add_argument('--text', help='raw value, a string', type=str)
 parser.add_argument('--device', help='device')
 
 
@@ -14,7 +15,7 @@ if os.path.exists(args.text) and os.path.isfile(args.text):
     with open(args.text, 'r') as f:
         for line in f:
             text = line.strip().split()
-            texts += [text]
+            texts += text  # consider the whole file as a long sequence input
 
 else:
     texts = args.text.split()

--- a/api-examples/lm-text.py
+++ b/api-examples/lm-text.py
@@ -6,6 +6,7 @@ parser = argparse.ArgumentParser(description='Generate subsequent text by repeat
 parser.add_argument('--model', help='A language model', required=True, type=str)
 parser.add_argument('--text', help='raw value, a string', type=str)
 parser.add_argument('--device', help='device')
+parser.add_argument('--mxlen', type=int, help='how many tokens will be generated', default=10)
 
 
 args = parser.parse_known_args()[0]
@@ -15,7 +16,7 @@ if os.path.exists(args.text) and os.path.isfile(args.text):
     with open(args.text, 'r') as f:
         for line in f:
             text = line.strip().split()
-            texts += text  # consider the whole file as a long sequence input
+            texts += [text]
 
 else:
     texts = args.text.split()
@@ -23,4 +24,4 @@ else:
 print(texts)
 
 m = bl.LanguageModelService.load(args.model, device=args.device)
-print(m.predict(texts))
+print(m.predict(texts, mxlen=args.mxlen))

--- a/api-examples/pretrain-transformer-lm.py
+++ b/api-examples/pretrain-transformer-lm.py
@@ -134,10 +134,10 @@ class BPEVectorizer1D(AbstractVectorizer):
         for t in tokens:
             if t in Offsets.VALUES:
                 yield t
-            if t == '<unk>':
-                yield Offsets.UNK
-            if t == '<eos>':
-                yield Offsets.EOS
+            elif t == '<unk>':
+                yield Offsets.VALUES[Offsets.UNK]
+            elif t == '<eos>':
+                yield Offsets.VALUES[Offsets.EOS]
             else:
                 subwords = self.tokenizer.apply([t])[0].split()
                 for x in subwords:

--- a/python/addons/custom_vectorizers.py
+++ b/python/addons/custom_vectorizers.py
@@ -1,5 +1,6 @@
 import numpy as np
 from collections import Counter
+import tempfile
 from baseline.utils import Offsets
 from baseline.vectorizers import register_vectorizer, AbstractVectorizer
 
@@ -82,7 +83,6 @@ class SavableFastBPE(object):
 
     def __setstate__(self, state):
         from fastBPE import fastBPE
-        import tempfile
         with tempfile.NamedTemporaryFile() as codes, tempfile.NamedTemporaryFile() as vocab:
             codes.write(state['codes'])
             vocab.write(state['vocab'])
@@ -132,10 +132,10 @@ class BPEVectorizer1D(AbstractVectorizer):
         for t in tokens:
             if t in Offsets.VALUES:
                 yield t
-            if t == '<unk>':
-                yield Offsets.UNK
-            if t == '<eos>':
-                yield Offsets.EOS
+            elif t == '<unk>':
+                yield Offsets.VALUES[Offsets.UNK]
+            elif t == '<eos>':
+                yield Offsets.VALUES[Offsets.EOS]
             else:
                 subwords = self.tokenizer.apply([t])[0].split()
                 for x in subwords:

--- a/python/addons/custom_vectorizers.py
+++ b/python/addons/custom_vectorizers.py
@@ -1,13 +1,42 @@
 import numpy as np
 from collections import Counter
 from baseline.utils import Offsets
-from embed_bert import WordpieceTokenizer, WordPieceVectorizer1D
+# from embed_bert import WordpieceTokenizer, WordPieceVectorizer1D
 from baseline.vectorizers import register_vectorizer, AbstractVectorizer
 
 
-@register_vectorizer(name='wordpiece1dlm')
-class WordPieceVectorizer1DLM(WordPieceVectorizer1D):
-    # override iterable function for continuous sequence data (typically for lm)
+@register_vectorizer(name='wordpiece1d')
+class WordPieceVectorizer1D(AbstractVectorizer):
+    """Define a Baseline Vectorizer that can do WordPiece with BERT tokenizer
+
+    this vectorizer has a dependency on bert_pretrained_pytorch
+    """
+
+    def __init__(self, pytorch_pretrained_bert=None, **kwargs):
+        """Loads a BertTokenizer using bert_pretrained_pytorch
+
+        :param kwargs:
+        """
+        super(WordPieceVectorizer1D, self).__init__(kwargs.get('transform_fn'))
+        from pytorch_pretrained_bert import BertTokenizer
+        self.max_seen = 128
+        handle = kwargs.get('embed_file', 'bert-base-cased')
+        self.tokenizer = BertTokenizer.from_pretrained(handle, do_lower_case=False)
+        self.mxlen = kwargs.get('mxlen', -1)
+
+    @property
+    def vocab(self):
+        return self.tokenizer.vocab
+
+    def count(self, tokens):
+        seen = 0
+        counter = Counter()
+        for tok in self.iterable(tokens):
+            counter[tok] += 1
+            seen += 1
+        self.max_seen = max(self.max_seen, seen)
+        return counter
+
     def iterable(self, tokens):
         for tok in tokens:
             if tok == '<unk>':
@@ -15,16 +44,37 @@ class WordPieceVectorizer1DLM(WordPieceVectorizer1D):
             elif tok == '<EOS>':
                 yield '[SEP]'
             else:
-                for subtok in self.wordpiece_tok.tokenize(tok):
+                for subtok in self.tokenizer.tokenize(tok):
                     yield subtok
+
+    def _next_element(self, tokens, vocab):
+        for atom in self.iterable(tokens):
+            value = vocab.get(atom)
+            if value is None:
+                value = vocab['[UNK]']
+            yield value
+
+    def run(self, tokens, vocab):
+        if self.mxlen < 0:
+            self.mxlen = self.max_seen
+        vec1d = np.zeros(self.mxlen, dtype=np.long)
+        for i, atom in enumerate(self._next_element(tokens, vocab)):
+            if i == self.mxlen:
+                i -= 1
+                break
+            vec1d[i] = atom
+        valid_length = i + 1
+        return vec1d, valid_length
+
+    def get_dims(self):
+        return self.mxlen,
 
 
 @register_vectorizer(name='bpe1d')
 class BPEVectorizer1D(AbstractVectorizer):
     """Define a Baseline Vectorizer for BPE using fastBPE (https://github.com/glample/fastBPE)
 
-    If you use tokens=bpe, this vectorizer is used, and so then there is a
-    dependency on fastBPE
+    this vectorizer has a dependency on fastBPE
 
     To use BPE, we assume that a Dictionary of codes and vocab was already created
 

--- a/python/addons/custom_vectorizers.py
+++ b/python/addons/custom_vectorizers.py
@@ -1,0 +1,91 @@
+import numpy as np
+from collections import Counter
+from baseline.utils import Offsets
+from embed_bert import WordpieceTokenizer, WordPieceVectorizer1D
+from baseline.vectorizers import register_vectorizer, AbstractVectorizer
+
+
+@register_vectorizer(name='wordpiece1dlm')
+class WordPieceVectorizer1DLM(WordPieceVectorizer1D):
+    # override iterable function for continuous sequence data (typically for lm)
+    def iterable(self, tokens):
+        for tok in tokens:
+            if tok == '<unk>':
+                yield '[UNK]'
+            elif tok == '<EOS>':
+                yield '[SEP]'
+            else:
+                for subtok in self.wordpiece_tok.tokenize(tok):
+                    yield subtok
+
+
+@register_vectorizer(name='bpe1d')
+class BPEVectorizer1D(AbstractVectorizer):
+    """Define a Baseline Vectorizer for BPE using fastBPE (https://github.com/glample/fastBPE)
+
+    If you use tokens=bpe, this vectorizer is used, and so then there is a
+    dependency on fastBPE
+
+    To use BPE, we assume that a Dictionary of codes and vocab was already created
+
+    """
+    def __init__(self, **kwargs):
+        """Loads a BPE tokenizer"""
+        super(BPEVectorizer1D, self).__init__(kwargs.get('transform_fn'))
+        from fastBPE import fastBPE
+        self.max_seen = 128
+        self.model_file = kwargs.get('model_file')
+        self.vocab_file = kwargs.get('vocab_file')
+        self.tokenizer = fastBPE(self.model_file, self.vocab_file)
+        self.mxlen = kwargs.get('mxlen', -1)
+        self.vocab = {k: i for i, k in enumerate(self.read_vocab(self.vocab_file))}
+
+    def read_vocab(self, s):
+        vocab = [] + Offsets.VALUES
+        with open(s, "r") as f:
+            for line in f.readlines():
+                token = line.split()[0].strip()
+                vocab.append(token)
+        return vocab
+
+    def count(self, tokens):
+        seen = 0
+        counter = Counter()
+        for tok in self.iterable(tokens):
+            counter[tok] += 1
+            seen += 1
+        self.max_seen = max(self.max_seen, seen)
+        return counter
+
+    def iterable(self, tokens):
+        for t in tokens:
+            if t in Offsets.VALUES:
+                yield t
+            if t == '<unk>':
+                yield Offsets.UNK
+            if t == '<eos>':
+                yield Offsets.EOS
+            else:
+                subwords = self.tokenizer.apply([t])[0].split()
+                for x in subwords:
+                    yield x
+
+    def _next_element(self, tokens, vocab):
+        for atom in self.iterable(tokens):
+            value = vocab.get(atom, 0)  # This shouldnt actually happen
+            yield value
+
+    def run(self, tokens, vocab):
+        if self.mxlen < 0:
+            self.mxlen = self.max_seen
+        vec1d = np.zeros(self.mxlen, dtype=np.long)
+        for i, atom in enumerate(self._next_element(tokens, vocab)):
+            if i == self.mxlen:
+                i -= 1
+                break
+            vec1d[i] = atom
+        valid_length = i + 1
+        return vec1d, valid_length
+
+    def get_dims(self):
+        return self.mxlen,

--- a/python/addons/custom_vectorizers.py
+++ b/python/addons/custom_vectorizers.py
@@ -81,6 +81,8 @@ class SavableFastBPE(object):
         return {'codes': self.codes, 'vocab': self.vocab}
 
     def __setstate__(self, state):
+        from fastBPE import fastBPE
+        import tempfile
         with tempfile.NamedTemporaryFile() as codes, tempfile.NamedTemporaryFile() as vocab:
             codes.write(state['codes'])
             vocab.write(state['vocab'])

--- a/python/addons/embed_bert.py
+++ b/python/addons/embed_bert.py
@@ -1249,6 +1249,19 @@ class WordPieceVectorizer1D(AbstractVectorizer):
         self.wordpiece_tok = WordpieceTokenizer(load_vocab(kwargs.get('vocab_file')))
         self.mxlen = kwargs.get('mxlen', -1)
 
+    def count(self, tokens):
+        seen = 0
+        counter = collections.Counter()
+        for tok in self.iterable(tokens):
+            counter[tok] += 1
+            seen += 1
+        self.max_seen = max(self.max_seen, seen)
+        return counter
+
+    def reset(self):
+        self.mxlen = -1
+        self.max_seen = 0
+
     def iterable(self, tokens):
         yield '[CLS]'
         for tok in tokens:

--- a/python/addons/embed_bert.py
+++ b/python/addons/embed_bert.py
@@ -1249,19 +1249,6 @@ class WordPieceVectorizer1D(AbstractVectorizer):
         self.wordpiece_tok = WordpieceTokenizer(load_vocab(kwargs.get('vocab_file')))
         self.mxlen = kwargs.get('mxlen', -1)
 
-    def count(self, tokens):
-        seen = 0
-        counter = collections.Counter()
-        for tok in self.iterable(tokens):
-            counter[tok] += 1
-            seen += 1
-        self.max_seen = max(self.max_seen, seen)
-        return counter
-
-    def reset(self):
-        self.mxlen = -1
-        self.max_seen = 0
-
     def iterable(self, tokens):
         yield '[CLS]'
         for tok in tokens:
@@ -1292,6 +1279,9 @@ class WordPieceVectorizer1D(AbstractVectorizer):
             vec1d[i] = atom
         valid_length = i + 1
         return vec1d, valid_length
+
+    def get_dims(self):
+        return self.mxlen,
 
 class WordpieceTokenizer(object):
     """Runs WordPiece tokenziation."""

--- a/python/baseline/data.py
+++ b/python/baseline/data.py
@@ -278,12 +278,14 @@ class SeqWordCharDataFeed(DataFeed):
         self.tgt_key = 'x' if tgt_key is None else tgt_key
         num_examples = examples['{}_dims'.format(tgt_key)][0]
         rest = num_examples // batchsz
-        self.steps = rest // nctx
+
         # if num_examples is divisible by batchsz * nctx (equivalent to rest is divisible by nctx), we
         # have a problem. reduce rest in that case.
 
         if rest % nctx == 0:
             rest = rest-1
+
+        self.steps = rest // nctx
 
         for k in examples.keys():
             if k.endswith('_dims'):

--- a/python/baseline/services.py
+++ b/python/baseline/services.py
@@ -386,8 +386,6 @@ class LanguageModelService(Service):
         mxwlen = kwargs.get('mxwlen', 40)
 
         for k, vectorizer in self.vectorizers.items():
-            if hasattr(vectorizer, 'mxlen') and vectorizer.mxlen == -1:
-                vectorizer.mxlen = mxlen
             if hasattr(vectorizer, 'mxwlen') and vectorizer.mxwlen == -1:
                 vectorizer.mxwlen = mxwlen
 
@@ -397,7 +395,8 @@ class LanguageModelService(Service):
         for i in range(mxlen):
 
             for k, vectorizer in self.vectorizers.items():
-                vectorizer.mxlen = len(token_buffer)
+                vectorizer.reset()
+                _ = vectorizer.count(token_buffer)
                 vec, length = vectorizer.run(token_buffer, self.vocabs[k])
                 if k in examples:
                     examples[k] = np.append(examples[k], vec)

--- a/python/baseline/vectorizers.py
+++ b/python/baseline/vectorizers.py
@@ -80,6 +80,10 @@ class Token1DVectorizer(AbstractVectorizer):
         self.max_seen = max(self.max_seen, seen)
         return counter
 
+    def reset(self):
+        self.mxlen = -1
+        self.max_seen = 0
+
     def run(self, tokens, vocab):
 
         if self.mxlen < 0:
@@ -189,6 +193,12 @@ class Char2DVectorizer(AbstractCharVectorizer):
         self.max_seen_tok = max(self.max_seen_tok, seen_tok)
         return counter
 
+    def reset(self):
+        self.mxlen = -1
+        self.mxwlen = -1
+        self.max_seen_tok = 0
+        self.max_seen_char = 0
+
     def run(self, tokens, vocab):
 
         if self.mxlen < 0:
@@ -265,6 +275,10 @@ class Char1DVectorizer(AbstractCharVectorizer):
 
         self.max_seen_tok = max(self.max_seen_tok, seen_tok)
         return counter
+
+    def reset(self):
+        self.mxlen = -1
+        self.max_seen_tok = 0
 
     def run(self, tokens, vocab):
 

--- a/python/baseline/vectorizers.py
+++ b/python/baseline/vectorizers.py
@@ -60,17 +60,6 @@ class AbstractVectorizer(Vectorizer):
                     break
             yield value
 
-
-@exporter
-@register_vectorizer(name='token1d')
-class Token1DVectorizer(AbstractVectorizer):
-
-    def __init__(self, **kwargs):
-        super(Token1DVectorizer, self).__init__(kwargs.get('transform_fn'))
-        self.time_reverse = kwargs.get('rev', False)
-        self.mxlen = kwargs.get('mxlen', -1)
-        self.max_seen = 0
-
     def count(self, tokens):
         seen = 0
         counter = collections.Counter()
@@ -82,6 +71,17 @@ class Token1DVectorizer(AbstractVectorizer):
 
     def reset(self):
         self.mxlen = -1
+        self.max_seen = 0
+
+
+@exporter
+@register_vectorizer(name='token1d')
+class Token1DVectorizer(AbstractVectorizer):
+
+    def __init__(self, **kwargs):
+        super(Token1DVectorizer, self).__init__(kwargs.get('transform_fn'))
+        self.time_reverse = kwargs.get('rev', False)
+        self.mxlen = kwargs.get('mxlen', -1)
         self.max_seen = 0
 
     def run(self, tokens, vocab):


### PR DESCRIPTION
This PR fixes the max-length problem for vectorizers like wordpiece and BPE. Changes:
- Add a `reset` method to subclasses of `Vectorizer` that have a `count` method. This function resets `mxlen` to -1, and `max_seen` to 0. 
- In `services.py`, remove the `set_vectorizer_len` function, and replace it with calling `reset` and then `count` method on vectorizers. The `batch_input` function doesn't keep track of `mxlen` any more. 
- Remove the truncation in `batch_input` function, as well as `get_vectorizer_len` function. 
- Add `count` and `reset` to the wordpiece1d vectorizer of the `embed_bert.py`. 

The changes are tested on classifier, tagger, embedding and encoder-decoder services, as well as the new bert addon. The LM part of the `services.py` was not touched. 