### PR TITLE
WIP: A bert ner implementation in pytorch

### DIFF
--- a/python/addons/embed_bert_pytorch.py
+++ b/python/addons/embed_bert_pytorch.py
@@ -5,14 +5,18 @@ import collections
 import unicodedata
 import six
 import numpy as np
-from baseline.utils import write_json
-from baseline.embeddings import register_embeddings
-from baseline.pytorch.embeddings import PyTorchEmbeddings
-from baseline.vectorizers import register_vectorizer, AbstractVectorizer
+from baseline.model import register_model
+from baseline.reader import register_reader, CONLLSeqReader
+from baseline.utils import write_json, listify
+from eight_mile.embeddings import register_embeddings
+from eight_mile.pytorch.embeddings import PyTorchEmbeddings
+from baseline.vectorizers import register_vectorizer, AbstractVectorizer, _token_iterator
 from pytorch_pretrained_bert.tokenization import BertTokenizer
 from pytorch_pretrained_bert.file_utils import PYTORCH_PRETRAINED_BERT_CACHE
 from pytorch_pretrained_bert.modeling import BertModel
 from baseline.pytorch.torchy import *
+from baseline.pytorch.tagger.model import TaggerModelBase
+from eight_mile.pytorch.layers import tensor_and_lengths
 import copy
 import json
 import math
@@ -20,7 +24,6 @@ import re
 
 
 BERT_TOKENIZER = None
-
 
 
 @register_vectorizer(name='wordpiece1d')
@@ -35,6 +38,15 @@ class WordPieceVectorizer1D(AbstractVectorizer):
             BERT_TOKENIZER = BertTokenizer.from_pretrained(handle)
         self.tokenizer = BERT_TOKENIZER
         self.mxlen = kwargs.get('mxlen', -1)
+
+    def count(self, tokens):
+        seen = 0
+        counter = collections.Counter()
+        for tok in self.iterable(tokens):
+            counter[tok] += 1
+            seen += 1
+        self.max_seen = max(self.max_seen, seen)
+        return counter
 
     def iterable(self, tokens):
         yield '[CLS]'
@@ -70,6 +82,263 @@ class WordPieceVectorizer1D(AbstractVectorizer):
     def get_dims(self):
         return self.mxlen,
 
+    def reset(self):
+        self.mxlen = -1
+        self.max_seen = 0
+
+
+@register_vectorizer(name="dict-wordpiece1d")
+class DictWordPieceVectoizer1D(WordPieceVectorizer1D):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.fields = listify(kwargs.get('fields', 'text'))
+        self.delim = kwargs.get('token_delim', '~~')
+
+    def iterable(self, tokens):
+        return super().iterable(_token_iterator(self, tokens))
+
+
+def mask_to_index(mask):
+    """Convert a 1d mask to a 1d list of indices of the 1's. the result is the same shape as the mask."""
+    idx = mask.nonzero()[0]
+    return np.concatenate((idx, np.zeros((len(mask) - len(idx),), dtype=mask.dtype)))
+
+
+@register_vectorizer(name='wordpiece1d-with-heads')
+class WordPieceVectorizer1DWithHeads(WordPieceVectorizer1D):
+    """This vectorizer produces the tokens and the index of the heads at the same time.
+
+    This outputs a matrix of size [2, T] where [0, T] is the tokens and [1, T] is the mask
+    """
+
+    def iterable(self, tokens):
+        yield '[CLS]', 0
+        for tok in tokens:
+            if tok == '<unk>':
+                yield '[UNK]', 1
+            elif tok == '<EOS>':
+                yield '[SEP]', 0
+            else:
+                for i, subtok in enumerate(self.tokenizer.tokenize(tok)):
+                    if i == 0:
+                        yield subtok, 1
+                    else:
+                        yield subtok, 0
+        yield '[SEP]', 0
+
+    def _next_element(self, tokens, vocab):
+        for atom, head in self.iterable(tokens):
+            value = vocab.get(atom, vocab['[UNK]'])
+            yield value, head
+
+    def run(self, tokens, vocab):
+        self.mxlen = self.max_seen if self.mxlen < 0 else self.mxlen
+        vec1d = np.zeros(self.mxlen, dtype=np.long)
+        heads = np.zeros(self.mxlen, dtype=np.long)
+        for i, (atom, head) in enumerate(self._next_element(tokens, vocab)):
+            if i == self.mxlen:
+                i -= 1
+                break
+            vec1d[i] = atom
+            heads[i] = head
+        heads = mask_to_index(heads)
+        valid_length = i + 1
+        return np.stack((vec1d, heads)), valid_length
+
+
+@register_vectorizer(name="dict-wordpiece1d-with-heads")
+class DictWordPieceVectoizer1DWithHeads(WordPieceVectorizer1DWithHeads):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.fields = listify(kwargs.get('fields', 'text'))
+        self.delim = kwargs.get('token_delim', '~~')
+
+    def iterable(self, tokens):
+        return super().iterable(_token_iterator(self, tokens))
+
+
+@register_vectorizer(name='wordpiece1d-with-heads-dict')
+class WordPieceVectorizer1DWithHeadsDict(WordPieceVectorizer1D):
+    """This vectorizer produces the tokens and the index of the heads at the same time.
+
+    In this one the results are output as a dict
+    """
+
+    def iterable(self, tokens):
+        yield '[CLS]', 0
+        for tok in tokens:
+            if tok == '<unk>':
+                yield '[UNK]', 1
+            elif tok == '<EOS>':
+                yield '[SEP]', 0
+            else:
+                for i, subtok in enumerate(self.tokenizer.tokenize(tok)):
+                    if i == 0:
+                        yield subtok, 1
+                    else:
+                        yield subtok, 0
+        yield '[SEP]', 0
+
+    def _next_element(self, tokens, vocab):
+        for atom, head in self.iterable(tokens):
+            value = vocab.get(atom, vocab['[UNK]'])
+            yield value, head
+
+    def run(self, tokens, vocab):
+        self.mxlen = self.max_seen if self.mxlen < 0 else self.mxlen
+        vec1d = np.zeros(self.mxlen, dtype=np.long)
+        heads = np.zeros(self.mxlen, dtype=np.long)
+        for i, (atom, head) in enumerate(self._next_element(tokens, vocab)):
+            if i == self.mxlen:
+                i -= 1
+                break
+            vec1d[i] = atom
+            heads[i] = head
+        heads = mask_to_index(heads)
+        valid_length = i + 1
+        return {'tokens': vec1d, 'heads': heads}, valid_length
+
+
+@register_vectorizer(name="dict-wordpiece1d-with-heads-dict")
+class DictWordPieceVectoizer1DWithHeadsDict(WordPieceVectorizer1DWithHeadsDict):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.fields = listify(kwargs.get('fields', 'text'))
+        self.delim = kwargs.get('token_delim', '~~')
+
+    def iterable(self, tokens):
+        return super().iterable(_token_iterator(self, tokens))
+
+
+@register_vectorizer(name='heads-wordpiece1d')
+class HeadedWordPieceVectorizer1D(WordPieceVectorizer1D):
+    """Output a list of indices that are the heads of the subword tokens."""
+
+    def iterable(self, tokens):
+        j = 1  # Don't point at [CLS]
+        for tok in tokens:
+            # Unk is something we want to label
+            if tok == '<unk>':
+                yield j
+            # We don't want to label [SEP]
+            elif tok == '<EOS>':
+                pass
+            else:
+                for i, subtok in enumerate(self.tokenizer.tokenize(tok)):
+                    if i == 0:
+                        yield j  # Head
+                    else:
+                        j += 1
+            j += 1
+
+    def _next_element(self, tokens, vocab):
+        for atom in self.iterable(tokens):
+            yield atom
+
+    def run(self, tokens, vocab):
+        if self.mxlen < 0:
+            self.mxlen = self.max_seen
+        vec1d = np.zeros(self.mxlen, dtype=np.long)
+        for i, atom in enumerate(self._next_element(tokens, vocab)):
+            if i == self.mxlen:
+                i -= 1
+                break
+            vec1d[i] = atom
+        valid_length = i + 1
+        return vec1d, valid_length
+
+    def get_dims(self):
+        return self.mxlen,
+
+    def count(self, tokens):
+        seen = 0
+        counter = collections.Counter()
+        # Count the mxlen of the actual text otherwise we are to short
+        # If this was a mask we wouldn't have this issue
+        for tok in super().iterable(tokens):
+            counter[tok] += 1
+            seen += 1
+        self.max_seen = max(self.max_seen, seen)
+        return counter
+
+
+@register_vectorizer(name='dict-heads-wordpiece1d')
+class DictHeadedWordPieceVectorizer1D(HeadedWordPieceVectorizer1D):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.fields = listify(kwargs.get('fields', 'text'))
+        self.delim = kwargs.get('token_delim', '@@')
+
+    def iterable(self, tokens):
+        return super().iterable(_token_iterator(self, tokens))
+
+    def count(self, tokens):
+        return super().count(_token_iterator(self, tokens))
+
+
+class LabelHeadedWordPieceVectorizer1D(DictHeadedWordPieceVectorizer1D):
+    """Convert labels so just the heads have labels, other labels are PAD"""
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.fields = listify(kwargs.get('fields', ['text', 'y']))
+        self.delim = kwargs.get('token_delim', '~~')
+
+    def count(self, tokens):
+        seen = 0
+        counter = collections.Counter()
+        for tok in self.iterable(tokens):
+            # Don't include the pad in the output because it is already in the vocab
+            if tok != Offsets.VALUES[Offsets.PAD]:
+                counter[tok] += 1
+            seen += 1
+        self.max_seen = max(self.max_seen, seen)
+        return counter
+
+    def _next_element(self, tokens, vocab):
+        for atom in self.iterable(tokens):
+            value = vocab.get(atom)
+            if value is None:
+                value = vocab['[UNK]']
+            yield value
+
+    def iterable(self, tokens):
+        yield Offsets.VALUES[Offsets.PAD]
+        for tok in _token_iterator(self, tokens):
+            text, label = tok.split(self.delim)
+            if text == '<unk>':
+                yield label
+            elif text == '<EOS>':
+                yield label
+            else:
+                for i, subtok in enumerate(self.tokenizer.tokenize(text)):
+                    if i == 0:
+                        yield label
+                        continue
+                    yield Offsets.VALUES[Offsets.PAD]
+        yield Offsets.VALUES[Offsets.PAD]
+
+    def run(self, tokens, vocab):
+        if self.mxlen < 0:
+            self.mxlen = self.max_seen
+        vec1d = np.zeros(self.mxlen, dtype=np.long)
+        for i, atom in enumerate(self._next_element(tokens, vocab)):
+            if i == self.mxlen:
+                i -= 1
+                break
+            vec1d[i] = atom
+        valid_length = i + 1
+        # This is the actual number of tags, aka the number of tokens before the wordpiece
+        valid_length = np.sum(vec1d != Offsets.PAD)
+        return vec1d, valid_length
+
+
+@register_reader(task='tagger', name='bert')
+class BERTCONLLReader(CONLLSeqReader):
+    def __init__(self, vectorizers, trim=False, truncate=False, mxlen=-1, **kwargs):
+        super().__init__(vectorizers, trim, truncate, mxlen, **kwargs)
+        self.named_fields = kwargs.get('named_fields', {})
+        self.label_vectorizer = LabelHeadedWordPieceVectorizer1D(fields=['text', 'y'], mxlen=mxlen)
+
 
 class BERTBaseEmbeddings(PyTorchEmbeddings):
 
@@ -82,7 +351,6 @@ class BERTBaseEmbeddings(PyTorchEmbeddings):
         self.model = BertModel.from_pretrained(kwargs.get('embed_file'))
         self.vocab = BERT_TOKENIZER.vocab
         self.vsz = len(BERT_TOKENIZER.vocab)  # 30522 self.model.embeddings.word_embeddings.num_embeddings
-
 
     def get_vocab(self):
         return self.vocab
@@ -110,6 +378,10 @@ class BERTBaseEmbeddings(PyTorchEmbeddings):
 
 @register_embeddings(name='bert')
 class BERTEmbeddings(BERTBaseEmbeddings):
+    """BERT sequence embeddings, used for a feature-ful representation of finetuning sequence tasks.
+
+    If operator == 'concat' result is [B, T, #Layers * H] other size the layers are meaned and the shape is [B, T, H]
+    """
 
     def __init__(self, name, **kwargs):
         """BERT sequence embeddings, used for a feature-ful representation of finetuning sequence tasks.
@@ -127,8 +399,8 @@ class BERTEmbeddings(BERTBaseEmbeddings):
         else:
             layers = [all_layers[layer_index].detach() for layer_index in self.layer_indices]
         if self.operator != 'concat':
-            z = torch.cat([l.unsqueeze(-1) for l in layers])
-            z = torch.mead(z, dim=-1)
+            z = torch.cat([l.unsqueeze(-1) for l in layers], dim=-1)
+            z = torch.mean(z, dim=-1)
         else:
             z = torch.cat(layers, dim=-1)
         return z
@@ -146,3 +418,218 @@ class BERTPooledEmbeddings(BERTBaseEmbeddings):
     def get_output(self, all_layers, pooled):
         return pooled
 
+
+class IdentityTransducer(nn.Module):
+    """A module that just passes tensor but also has an output shape."""
+    def __init__(self, input_sz):
+        super().__init__()
+        self.output_dim = input_sz
+
+    def forward(self, inputs):
+        inputs, _ = tensor_and_lengths(inputs)
+        return inputs
+
+
+def select_heads(outputs, head_idx, dim=1):
+    """Select the heads of wordpiece spans.
+
+    :param outputs: The Bert logits, Tensor[B, T, H]
+    :param head_idx: The head indices, Tensor[B, T2]
+    :param dim: The Time dimension.
+    :returns: The logits for the heads, Tensor[B, T2, H]
+    """
+    idx = head_idx.unsqueeze(-1).expand(list(head_idx.shape) + [outputs.size(-1)])
+    return torch.gather(outputs, dim, idx)
+
+
+@register_model(task='tagger', name='bert')
+class BertTaggerModel(TaggerModelBase):
+
+    def init_encoder(self, input_sz, **kwargs):
+        return IdentityTransducer(input_sz)
+
+    def make_input(self, batch_dict):
+
+        example_dict = dict({})
+        lengths = torch.from_numpy(batch_dict[self.lengths_key])
+        lengths, perm_idx = lengths.sort(0, descending=True)
+
+        if self.gpu:
+            lengths = lengths.cuda()
+        example_dict['lengths'] = lengths
+        # The vectorizer outputs a [2, T] tensor which is stacked into [B, 2, T].
+        # The first index in the 2 dim is the tokens and the second is the heads
+        for key in self.embeddings.keys():
+            example_dict[key] = self.input_tensor(key, batch_dict, perm_idx)
+
+        # This assumes all heads are aligned
+        heads = [k for k in batch_dict.keys() if k.endswith('_heads')][0]
+        example_dict['heads'] = torch.from_numpy(batch_dict[heads])[perm_idx]
+        if self.gpu:
+            example_dict['heads'] = example_dict['heads'].cuda()
+
+
+        y = batch_dict.get('y')
+        if y is not None:
+            y = torch.from_numpy(y)[perm_idx]
+            if self.gpu:
+                y = y.cuda()
+            # We generated the tags with gaps so non-heads have a value of Offsets.PAD
+            # Here we select only the tags for heads. This results in a tag seq so the
+            # beginning of the list is the tags for the heads and the pad tags are moved
+            # to the back. This lets use use the normal evaluation code
+            y = select_heads(y.unsqueeze(-1), example_dict['heads']).squeeze(-1)
+            example_dict['y'] = y
+
+        # Add y_lengths to the dict so it gets sorted correctly
+        y_lengths = batch_dict.get('y_lengths')
+        if y_lengths is not None:
+            y_lengths = torch.from_numpy(y_lengths)[perm_idx]
+            example_dict['y_lengths'] = y_lengths
+
+        ids = batch_dict.get('ids')
+        if ids is not None:
+            ids = torch.from_numpy(ids)[perm_idx]
+            if self.gpu:
+                ids = ids.cuda()
+            example_dict['ids'] = ids
+
+        return example_dict
+
+    def compute_loss(self, inputs):
+        tags = inputs['y']
+        lengths = inputs['lengths']
+        unaries = self.layers.transduce(inputs)
+        # Select only the heads of the subword spans
+        unaries = select_heads(unaries, inputs['heads'])
+        assert unaries.shape[:2] == tags.shape
+        return self.layers.neg_log_loss(unaries, tags, lengths)
+
+    def input_tensor(self, key, batch_dict, perm_idx):
+        tensor = torch.from_numpy(batch_dict[key])
+        tensor = self.drop_inputs(key, tensor)
+        tensor = tensor[perm_idx]
+        if self.gpu:
+            tensor = tensor.cuda()
+        return tensor
+
+    def forward(self, input):
+        unaries = self.layers.transduce(input)
+        unaries = select_heads(unaries, input['heads'])
+        # This is the same calculation as the y_heads tensor
+        lengths = torch.sum(input['heads'] != 0, dim=1)
+        longest = torch.max(lengths)
+        unaries = unaries[:, :longest, ...]
+        return self.layers.decode(unaries, lengths)
+
+
+@register_model(task='tagger', name='bert2')
+class BertTaggerVectWithHeads(BertTaggerModel):
+    """This is a version of the tagger where the token values and heads are computed together and separated in the make_intput
+    """
+
+    def make_input(self, batch_dict):
+
+        example_dict = dict({})
+        lengths = torch.from_numpy(batch_dict[self.lengths_key])
+        lengths, perm_idx = lengths.sort(0, descending=True)
+
+        if self.gpu:
+            lengths = lengths.cuda()
+        example_dict['lengths'] = lengths
+        # The vectorizer outputs a [2, T] tensor which is stacked into [B, 2, T].
+        # The first index in the 2 dim is the tokens and the second is the heads
+        for key in self.embeddings.keys():
+            batch_dict[f'{key}_heads'] = batch_dict[key][:, 1, ...]
+            batch_dict[key] = batch_dict[key][:, 0, ...]
+            example_dict[key] = self.input_tensor(key, batch_dict, perm_idx)
+
+        # This assumes all heads are aligned
+        heads = [k for k in batch_dict.keys() if k.endswith('_heads')][0]
+        example_dict['heads'] = torch.from_numpy(batch_dict[heads])[perm_idx]
+        if self.gpu:
+            example_dict['heads'] = example_dict['heads'].cuda()
+
+
+        y = batch_dict.get('y')
+        if y is not None:
+            y = torch.from_numpy(y)[perm_idx]
+            if self.gpu:
+                y = y.cuda()
+            # We generated the tags with gaps so non-heads have a value of Offsets.PAD
+            # Here we select only the tags for heads. This results in a tag seq so the
+            # beginning of the list is the tags for the heads and the pad tags are moved
+            # to the back. This lets use use the normal evaluation code
+            y = select_heads(y.unsqueeze(-1), example_dict['heads']).squeeze(-1)
+            example_dict['y'] = y
+
+        # Add y_lengths to the dict so it gets sorted correctly
+        y_lengths = batch_dict.get('y_lengths')
+        if y_lengths is not None:
+            y_lengths = torch.from_numpy(y_lengths)[perm_idx]
+            example_dict['y_lengths'] = y_lengths
+
+        ids = batch_dict.get('ids')
+        if ids is not None:
+            ids = torch.from_numpy(ids)[perm_idx]
+            if self.gpu:
+                ids = ids.cuda()
+            example_dict['ids'] = ids
+
+        return example_dict
+
+
+@register_model(task='tagger', name='bert-dict')
+class BertTaggerVectWithHeadsDict(BertTaggerModel):
+    """This is a version of the tagger where the token values and heads are computed together and separated in the make_intput this was a first attempt and ended up bing slow af
+    """
+
+    def make_input(self, batch_dict):
+
+        example_dict = dict({})
+        lengths = torch.from_numpy(batch_dict[self.lengths_key])
+        lengths, perm_idx = lengths.sort(0, descending=True)
+
+        if self.gpu:
+            lengths = lengths.cuda()
+        example_dict['lengths'] = lengths
+        # The batcher auto stacks the datafeed for each key, because we have a dict
+        # as the value it gets stacked into a array of objects. Here we separate them
+        for key in self.embeddings.keys():
+            if batch_dict[key].dtype == np.dtype('O'):
+                batch_dict[f'{key}_heads'] = np.stack([x['heads'] for x in batch_dict[key]])
+                batch_dict[key] = np.stack([x['tokens'] for x in batch_dict[key]])
+            example_dict[key] = self.input_tensor(key, batch_dict, perm_idx)
+
+        # This assumes all heads are aligned
+        heads = [k for k in batch_dict.keys() if k.endswith('_heads')][0]
+        example_dict['heads'] = torch.from_numpy(batch_dict[heads])[perm_idx]
+        if self.gpu:
+            example_dict['heads'] = example_dict['heads'].cuda()
+
+        y = batch_dict.get('y')
+        if y is not None:
+            y = torch.from_numpy(y)[perm_idx]
+            if self.gpu:
+                y = y.cuda()
+            # We generated the tags with gaps so non-heads have a value of Offsets.PAD
+            # Here we select only the tags for heads. This results in a tag seq so the
+            # beginning of the list is the tags for the heads and the pad tags are moved
+            # to the back. This lets use use the normal evaluation code
+            y = select_heads(y.unsqueeze(-1), example_dict['heads']).squeeze(-1)
+            example_dict['y'] = y
+
+        # Add y_lengths to the dict so it gets sorted correctly
+        y_lengths = batch_dict.get('y_lengths')
+        if y_lengths is not None:
+            y_lengths = torch.from_numpy(y_lengths)[perm_idx]
+            example_dict['y_lengths'] = y_lengths
+
+        ids = batch_dict.get('ids')
+        if ids is not None:
+            ids = torch.from_numpy(ids)[perm_idx]
+            if self.gpu:
+                ids = ids.cuda()
+            example_dict['ids'] = ids
+
+        return example_dict

--- a/python/baseline/pytorch/tagger/model.py
+++ b/python/baseline/pytorch/tagger/model.py
@@ -110,6 +110,12 @@ class TaggerModelBase(nn.Module, TaggerModel):
                 y = y.cuda()
             example_dict['y'] = y
 
+        # Add y_lengths to the dict so it gets sorted correctly
+        y_lengths = batch_dict.get('y_lengths')
+        if y_lengths is not None:
+            y_lengths = torch.from_numpy(y_lengths)[perm_idx]
+            example_dict['y_lengths'] = y_lengths
+
         ids = batch_dict.get('ids')
         if ids is not None:
             ids = torch.from_numpy(ids)[perm_idx]

--- a/python/baseline/pytorch/tagger/train.py
+++ b/python/baseline/pytorch/tagger/train.py
@@ -99,7 +99,10 @@ class TaggerTrainerPyTorch(EpochReportingTrainer):
 
             inputs = self.model.make_input(batch_dict)
             y = inputs.pop('y')
-            lengths = inputs['lengths']
+            # It is possible with new wordpiece based tokens that the lengths of the data
+            # Is longer than the length of the labels so we will use the label lengths to
+            # cut the data for eval
+            lengths = inputs.get('y_lengths', inputs['lengths'])
             ids = inputs['ids']
             with torch.no_grad():
                 pred = self.model(inputs)

--- a/python/baseline/reader.py
+++ b/python/baseline/reader.py
@@ -335,7 +335,7 @@ class SeqPredictReader(object):
         for i, example_tokens in enumerate(texts):
             example = {}
             for k, vectorizer in self.vectorizers.items():
-                example[k], lengths = vectorizer.run(example_tokens, vocabs[k])
+                example[k], lengths = vectorizer.run(example_tokens, vocabs.get(k))
                 if lengths is not None:
                     example['{}_lengths'.format(k)] = lengths
             example['y'], lengths = self.label_vectorizer.run(example_tokens, self.label2index)

--- a/python/baseline/utils.py
+++ b/python/baseline/utils.py
@@ -14,6 +14,7 @@ import numpy as np
 import collections
 #from eight_mile.utils import export, optional_params
 from eight_mile.utils import *
+from eight_mile.utils import read_config_file
 from functools import partial, update_wrapper, wraps
 
 __all__ = []

--- a/python/mead/config/conll-bert.yml
+++ b/python/mead/config/conll-bert.yml
@@ -1,0 +1,51 @@
+version: 2
+modules: [embed_bert_pytorch]
+task: tagger
+conll_output: conll-bert-iobes.conll
+unif: 0.1
+
+preproc:
+    mxlen: -1
+features:
+ - name: bert
+   vectorizer:
+     type: dict-wordpiece1d
+     embed_file: bert-base-uncased
+   embeddings:
+     type: bert
+     dsz: 768
+     finetune: true
+     operator: 'mean'
+     layers:
+         - -1
+     embed_file: bert-base-uncased
+ - name: bert_heads
+   vectorizer:
+     type: dict-heads-wordpiece1d
+     embed_file: bert-base-uncased
+   embeddings: null
+
+
+backend: pytorch
+dataset: conll-iobes
+
+loader:
+    reader_type: bert
+    named_fields:
+       "0": text
+       "-1": y
+
+model:
+    model_type: bert
+    dropout: 0.1
+    reduction: 'token'
+
+train:
+    epochs: 5
+    optim: adam
+    eta: 1.0e-5
+    patience: 5
+    early_stopping_metric: f1
+    clip: 5.0
+    batchsz: 32
+    span_type: iobes

--- a/python/mead/config/conll-bert2.yml
+++ b/python/mead/config/conll-bert2.yml
@@ -1,0 +1,47 @@
+version: 2
+modules: [embed_bert_pytorch]
+task: tagger
+conll_output: conll-bert-iobes.conll
+unif: 0.1
+
+preproc:
+    mxlen: -1
+    mxwlen: -1
+features:
+ - name: bert
+   vectorizer:
+     type: dict-wordpiece1d-with-heads
+     embed_file: bert-base-uncased
+   embeddings:
+     type: bert
+     dsz: 768
+     finetune: true
+     operator: 'mean'
+     layers:
+         - -1
+     embed_file: bert-base-uncased
+
+
+backend: pytorch
+dataset: conll-iobes
+
+loader:
+    reader_type: bert
+    named_fields:
+       "0": text
+       "-1": y
+
+model:
+    model_type: bert2
+    dropout: 0.1
+    reduction: "token"
+
+train:
+    epochs: 10
+    optim: adam
+    eta: 1.0e-5
+    patience: 5
+    early_stopping_metric: f1
+    clip: 5.0
+    batchsz: 32
+    span_type: iobes

--- a/python/mead/tasks.py
+++ b/python/mead/tasks.py
@@ -326,6 +326,8 @@ class Task(object):
         out_vocabs = {}
         for feature in features:
             embeddings_section = feature['embeddings']
+            if embeddings_section is None:
+                continue
             name = feature['name']
             embed_label = embeddings_section.get('label', None)
             embed_type = embeddings_section.get('type', 'default')


### PR DESCRIPTION
This is a bert model that can do NER as they do in the paper where there is a linear layer on top of the model and the label is read from the starting token.

This is accomplished via a few custom vectorizers. There is a new label vectorizer that when it outputs labels it outputs the true label of the first token in a subword string and `PAD` for the rest of them. There is also a custom vectorizers that outputs a list of indices that point to the first token in each word. The normal vectorizer produces the tokens that bert expects to see. The index vector pointing at the start words is used in a `torch.gather` to select the starting tokens (or their associated vector from the unaries) from the other tenors. This results in a `[B, T, H]` matrix where the tokens are only in T if they are a staring token.

Doing this gather (instead of just relaying on the masking in the tags in conjunction with the `padding_index` in the loss to only count the heads) give us a nice advantage that the outputs can be feed into things like the constrained decoder and they just work. It also means that the labels output are aligned with the real tokens (before wordpiece breaks them up) so we don't need to do any sort of detokeniztion in the service to label the words.

This model works when it is reloaded as a service but I had to make most of the change from [this PR](https://github.com/dpressel/mead-baseline/pull/353) to get it to work.

There are also a few bug fixes included that were needed to make it run

 * The TaggerGreedyDecoder was doing the softmax on the wrong dim making the mask all zero
 * The mask above was getting unsqueezed twice so it was the wrong shape
 * The TaggerGreedyDecoder wasn't using the SequenceCriterion that handles folding the B, T correctly
 * The SequenceCriterion in the TaggerGreedyDecoder was hard coded to do batch loss but in bert they mostly do token loss so I had to expose that
 * The way the preds were created in the TaggerGreedyDocder were generated ragged batches so I updated that to create a [B, T] one.
 * The Bert Embedding that returned sequences was hard coded to detach the vectors (no fine tuning) I make this changeable via the config file
 * There was a bug in Bert Embedding that returned Sequences where the multiple layers would be concatenated and means on the last dim if the operator was not `concat`. This results in tensor with the shape `[B, T, 1]` which isn't what you want. I updated it so if we are taking the mean of the vector across the selected layers we do an unsqeeze before the concat, this creates a vector of shape `[B, T, H, #Layers]` then a mean on the last dim (the layers) gives us `[B, T, H]` which is what we want. 

There were a few tiny tweaks I had to make to baseline proper for this to work.

 * When evaluation the tagger I had to use the `y_lengths` instead of the lengths to know where to cut the batch. This is because the lengths key is about the size of the input but the eval needs to know the size of the output. This is normally the same but in a case where the vectorizer can expand the number of tokens in the input it is not.I left a backoff to the `lengths` for backwards compat
 * I needed a way to get the start of token indices (called head indices in the code) into the batch_dict but I didin't want them to be embeddinged (even if I made a passthrough embedding they would still get concatenated on the bert embeddings which I don't want) so I made a few tweaks so that is a vectorizer says its embeddings is `None` then its output just gets added to the batch_dict but not the embeddings dict. If we don't like this change I explored having the vectorizer output both the token and if it was the start or not and then in the `make_input` it would extract this into two different tensors. This can be seen in the `bert2` model. This way was very slow howeverm a single epoch took about 950 seconds compared to 170 the `bert` tagger with multiple vectorizers takes

I haven't done a large parameter sweep yet but just using some hps in the range they mention in the paper (using `bert-base-uncased`) I was seeing dev score in the 95, this isn't at the level of their paper but I think with tweaks on the HPs and using `bert-large` (and maybe the cased version) we should see better results.

One question I haven't decided on yet is what to do about the `do_basic_tokenization` parameter that the `pytorch_pretrained_bert` tokenizer has. Currently that param is one and it results in things like `3/1/97` which is a token in conll become `['3', '/', '1', '/', '97']`. The output is still aligned because the vectorizers treat this like the token was split by wordpiece but it might make more sense to turn this parameter off and just like the wordpiece handle it?

Implementing this model and tracking all the indices and what not is rather complex, if someone has a simpler solution I would love to discuss it.