### PR TITLE
fix: grads and variables could get unaligned

### DIFF
--- a/python/eight_mile/tf/optz.py
+++ b/python/eight_mile/tf/optz.py
@@ -327,6 +327,6 @@ class EagerOptimizer(object):
         with tf.GradientTape() as tape:
             loss_value = self.loss(model, x, y)
         grads = tape.gradient(loss_value, model.trainable_variables)
-        self.optimizer.apply_gradients(zip(grads, model.variables), self.global_step)
+        self.optimizer.apply_gradients(zip(grads, model.trainable_variables), self.global_step)
         return loss_value
 


### PR DESCRIPTION
Right now if there is an non trainable variable in the model then the grads and the variables can become unaligned when you zip the grads and the variables, we should zip with the trainable variables.