### PR TITLE
fix: get the other tf classify models running

### DIFF
--- a/api-examples/eager-tagger.py
+++ b/api-examples/eager-tagger.py
@@ -1,4 +1,5 @@
 
+import os
 from eight_mile.utils import listify
 import baseline
 import eight_mile.tf.layers as L
@@ -55,11 +56,11 @@ def to_tensors(ts):
     return np.stack(X), np.stack(Xch), np.stack(y)
 
 
-VSM_MODEL = '/home/dpressel/.bl-data/dce69c404025a8312c323197347695e81fd529fc/glove.twitter.27B.200d.txt'
+VSM_MODEL = os.path.expanduser('~/.bl-data/dce69c404025a8312c323197347695e81fd529fc/glove.twitter.27B.200d.txt')
 
-TS = '/home/dpressel/dev/work/baseline/data/oct27.train'
-VS = '/home/dpressel/dev/work/baseline/data/oct27.dev'
-ES = '/home/dpressel/dev/work/baseline/data/oct27.test'
+TS = os.path.expanduser('~/dev/work/baseline/data/oct27.train')
+VS = os.path.expanduser('~/dev/work/baseline/data/oct27.dev')
+ES = os.path.expanduser('~/dev/work/baseline/data/oct27.test')
 
 
 feature_desc = {

--- a/python/addons/embed_bert.py
+++ b/python/addons/embed_bert.py
@@ -1063,7 +1063,7 @@ def load_vocab(vocab_file):
 
     vocab = collections.OrderedDict()
     index = 0
-    with tf.gfile.GFile(vocab_file, "r") as reader:
+    with tf.compat.v1.gfile.GFile(vocab_file, "r") as reader:
         while True:
             token = convert_to_unicode(reader.readline())
             if not token:

--- a/python/baseline/tf/classify/model.py
+++ b/python/baseline/tf/classify/model.py
@@ -467,7 +467,7 @@ class NBowMaxModel(NBowBase):
     def __init__(self):
         super(NBowMaxModel, self).__init__()
 
-    def pool(self, word_embeddings, dsz, init, **kwargs):
+    def pool(self, dsz, **kwargs):
         """Do max pooling on input embeddings, yielding a `dsz` output layer
 
         :param word_embeddings: The word embedding input
@@ -513,9 +513,7 @@ class CompositePoolingModel(EmbedPoolStackClassifier):
         :return: A pooled composite output
         """
         SubModels = [eval(model) for model in kwargs.get('sub')]
-        pooling = []
+        models = []
         for SubClass in SubModels:
-            pooling.append(SubClass.pool(self, dsz, **kwargs))
-        return tf.concat(pooling, -1)
-
-
+            models.append(SubClass.pool(self, dsz, **kwargs))
+        return CompositeModel(models)

--- a/python/baseline/tf/classify/training/eager.py
+++ b/python/baseline/tf/classify/training/eager.py
@@ -104,7 +104,7 @@ class ClassifyTrainerEagerTf(EpochReportingTrainer):
         SET_TRAIN_FLAG(True)
 
         for features, y in pg(loader):
-            lossv = self.optimizer.update(self.model, features, y)
+            lossv = self.optimizer.update(self.model, features, y).numpy()
             batchsz = y.shape[0]
             report_lossv = lossv * batchsz
             epoch_loss += report_lossv
@@ -153,7 +153,7 @@ class ClassifyTrainerEagerTf(EpochReportingTrainer):
             logits = self.model(features)
             y_ = tf.argmax(logits, axis=1, output_type=tf.int32)
             cm.add_batch(y, y_)
-            lossv = tf.compat.v1.losses.sparse_softmax_cross_entropy(labels=y, logits=logits)
+            lossv = tf.compat.v1.losses.sparse_softmax_cross_entropy(labels=y, logits=logits).numpy()
             batchsz = y.shape[0]
             assert len(y_) == batchsz
             total_loss += lossv * batchsz

--- a/python/eight_mile/embeddings.py
+++ b/python/eight_mile/embeddings.py
@@ -1,16 +1,19 @@
 import numpy as np
 from eight_mile.utils import (
-    optional_params
+    optional_params,
+    export
 )
 from eight_mile.w2v import PretrainedEmbeddingsModel, RandomInitVecModel
 
 __all__ = []
+exporter = export(__all__)
 
 
 MEAD_LAYERS_EMBEDDINGS = {}
 MEAD_LAYERS_EMBEDDINGS_LOADERS = {}
 
 
+@exporter
 @optional_params
 def register_embeddings(cls, name=None):
     """Register a function as a plug-in"""
@@ -27,12 +30,14 @@ def register_embeddings(cls, name=None):
     return cls
 
 
+@exporter
 def create_embeddings(**kwargs):
     embed_type = kwargs.get('embed_type', 'default')
     Constructor = MEAD_LAYERS_EMBEDDINGS.get(embed_type)
     return Constructor(**kwargs)
 
 
+@exporter
 def load_embeddings(name, **kwargs):
     """This method negotiates loading an embeddings sub-graph AND a corresponding vocabulary (lookup from word to int)
 

--- a/python/eight_mile/tf/layers.py
+++ b/python/eight_mile/tf/layers.py
@@ -1319,6 +1319,28 @@ class FineTuneModel(tf.keras.Model):
         return {} # base_config
 
 
+class CompositeModel(tf.keras.Model):
+    def __init__(self, models):
+        super().__init__()
+        self.models = models
+        self._requires_length = any(getattr(m, 'requires_length', False) for m in self.models)
+        # self.output_dim = sum(m.output_dim for m in self.models)
+
+    def call(self, inputs, training=None, mask=None):
+        inputs, lengths = tensor_and_lengths(inputs)
+        pooled = []
+        for m in self.models:
+            if getattr(m, 'requires_length', False):
+                pooled.append(m((inputs, lengths)))
+            else:
+                pooled.append(m(inputs))
+        return tf.concat(pooled, -1)
+
+    @property
+    def requires_length(self):
+        return self._requires_length
+
+
 def highway_conns(inputs, wsz_all, n):
     """Produce one or more highway connection layers
 


### PR DESCRIPTION
This PR updates the tf classify models to fix the nbowmax and composite models.

I was able to get them to train with both tf2 and tf1

I also tested and it is working where the pool model is a mix of models that need lengths and those that don't