### PR TITLE
Fixes to pyt tagger and services

### DIFF
--- a/python/baseline/pytorch/seq2seq/encoders.py
+++ b/python/baseline/pytorch/seq2seq/encoders.py
@@ -2,6 +2,7 @@ from collections import namedtuple
 from baseline.pytorch.torchy import sequence_mask, pytorch_linear, pytorch_lstm
 from baseline.pytorch.transformer import TransformerEncoderStack
 from baseline.model import register_encoder
+from eight_mile.pytorch.layers import *
 import torch
 
 
@@ -21,16 +22,15 @@ class RNNEncoder(torch.nn.Module):
         super(RNNEncoder, self).__init__()
         self.residual = residual
         hidden = hsz if hsz is not None else dsz
-        self.rnn = pytorch_lstm(dsz, hidden, rnntype, layers, pdrop)
+        Encoder = LSTMEncoderWithState if rnntype == 'lstm' else BiLSTMEncoderWithState
+        self.rnn = Encoder(dsz, hidden, layers, pdrop)
         self.src_mask_fn = _make_src_mask if create_src_mask is True else lambda x, y: None
 
     def forward(self, btc, lengths):
         # Do all our RNN stuff as TBC
-        tbc = btc.transpose(0, 1)
-        packed = torch.nn.utils.rnn.pack_padded_sequence(tbc, lengths.tolist())
-        output, hidden = self.rnn(packed)
-        output, _ = torch.nn.utils.rnn.pad_packed_sequence(output)
-        output = output.transpose(0, 1)
+        tbc = bth2tbh(btc)
+        output, hidden = self.rnn((tbc, lengths))
+        output = tbh2bth(output)
         return RNNEncoderOutput(output=output + btc if self.residual else output,
                                 hidden=hidden,
                                 src_mask=self.src_mask_fn(output, lengths))

--- a/python/baseline/pytorch/seq2seq/train.py
+++ b/python/baseline/pytorch/seq2seq/train.py
@@ -27,6 +27,7 @@ class Seq2SeqTrainerPyTorch(Trainer):
         self._input = model.make_input
         self._predict = model.predict
         self.tgt_rlut = kwargs['tgt_rlut']
+        self.gpus = kwargs.get('gpus', 1)
 
         if self.gpus > 0:
             self.crit = model.create_loss().cuda()

--- a/python/baseline/pytorch/tagger/model.py
+++ b/python/baseline/pytorch/tagger/model.py
@@ -151,8 +151,8 @@ class RNNTaggerModel(TaggerModelBase):
         hsz = int(kwargs['hsz'])
         weight_init = kwargs.get('weight_init', 'uniform')
         rnntype = kwargs.get('rnntype', 'blstm')
-        Encoder = LSTMEncoder if rnntype == 'lstm' else BiLSTMEncoder
-        return Encoder(input_sz, hsz, layers, pdrop, unif=unif, initializer=weight_init, output_fn=rnn_signal)
+        Encoder = LSTMEncoderSequence if rnntype == 'lstm' else BiLSTMEncoderSequence
+        return Encoder(input_sz, hsz, layers, pdrop, unif=unif, initializer=weight_init)
 
 
 @register_model(task='tagger', name='cnn')

--- a/python/baseline/services.py
+++ b/python/baseline/services.py
@@ -464,7 +464,7 @@ class EncoderDecoderService(Service):
         kwargs['beam'] = int(kwargs.get('beam', 30))
         return super().load(bundle, **kwargs)
 
-    def vectorize(self, tokens_seq):
+    def vectorize(self, tokens_batch):
         examples = defaultdict(list)
         for i, tokens in enumerate(tokens_seq):
             for k, vectorizer in self.src_vectorizers.items():

--- a/python/baseline/utils.py
+++ b/python/baseline/utils.py
@@ -26,6 +26,9 @@ MAGIC_VARS = ['sess', 'tgt', 'y', 'lengths']
 exporter = export(__all__)
 
 
+exporter(str2bool)
+
+
 @exporter
 def normalize_backend(name):
     allowed_backends = {'tf', 'pytorch'}

--- a/python/eight_mile/pytorch/layers.py
+++ b/python/eight_mile/pytorch/layers.py
@@ -566,6 +566,10 @@ class BiLSTMEncoder(nn.Module):
         return self._requires_length
 
 
+class BiLSTMEncoderWithState(BiLSTMEncoder):
+    def output_fn(self, output, state):
+        return output, concat_state_dirs(state)
+
 
 class BiLSTMEncoderSequence(BiLSTMEncoder):
 
@@ -754,7 +758,7 @@ class BaseAttention(nn.Module):
         c_t = torch.bmm(a, values_bth).squeeze(1)
 
         attended = torch.cat([c_t, query_t], -1)
-        attended = F.tanh(self.W_c(attended))
+        attended = torch.tanh(self.W_c(attended))
         return attended
 
 
@@ -808,7 +812,7 @@ class BahdanauAttention(BaseAttention):
         B, T, H = keys_bth.shape
         q = self.W_a(query_t.view(-1, self.hsz)).view(B, 1, H)
         u = self.E_a(keys_bth.contiguous().view(-1, self.hsz)).view(B, T, H)
-        z = F.tanh(q + u)
+        z = torch.tanh(q + u)
         a = self.v(z.view(-1, self.hsz)).view(B, T)
         a.masked_fill(keys_mask == 0, -1e9)
         a = F.softmax(a, dim=-1)


### PR DESCRIPTION
This PR includes a few fixes that I had to make when testing the services.

 * pytorch 1.2 vs < 1.2 type fix from master is added to the seq2seq
 * pytorch BiLSTMEncoderWithState is added and used for seq2seq
 * pytorch tagger uses the correct LSTM subclass ((Bi)?LSTMEncoderSequence)
 * utils from `eight_mile.utils` are not being added to the `__all__` list of `baseline.utils` so the `ed-text.py` api-example was erroring. I fixed that specific case but it seems like we might need to either stop using the exporter (which would make really cluttered namespaces because we use `from ___ import *` so much) or a function that will add everything in one modules `__all__` to their own `__all__`