### PR TITLE
Updates for LM pretraining and finetuning

### DIFF
--- a/api-examples/pretrain-transformer-lm.py
+++ b/api-examples/pretrain-transformer-lm.py
@@ -165,7 +165,9 @@ class BPEVectorizer1D(AbstractVectorizer):
 
     def _next_element(self, tokens, vocab):
         for atom in self.iterable(tokens):
-            value = vocab.get(atom, 0)  # This shouldnt actually happen
+            value = vocab.get(atom)
+            if value is None:
+                value = vocab[Offsets.VALUES[Offsets.UNK]]  # This shouldnt actually happen
             yield value
 
     def run(self, tokens, vocab):

--- a/api-examples/pretrain-transformer-lm.py
+++ b/api-examples/pretrain-transformer-lm.py
@@ -134,7 +134,7 @@ class BPEVectorizer1D(AbstractVectorizer):
         self.vocab = {k: i for i, k in enumerate(self.read_vocab(self.vocab_file))}
 
     def read_vocab(self, s):
-        vocab = [] + Offsets.VALUES
+        vocab = [] + Offsets.VALUES + ['[CLS]']
         with open(s, "r") as f:
             for line in f.readlines():
                 token = line.split()[0].strip()
@@ -200,7 +200,13 @@ class WordPieceVectorizer1D(AbstractVectorizer):
         from pytorch_pretrained_bert import BertTokenizer
         self.max_seen = 128
         handle = kwargs.get('embed_file')
-        self.tokenizer = BertTokenizer.from_pretrained(handle, do_lower_case=False)
+        custom_vocab = kwargs.get('vocab_file')
+        if custom_vocab is None:
+            self.tokenizer = BertTokenizer.from_pretrained(handle, do_lower_case=False)
+        else:
+            special_tokens = kwargs.get('special_tokens')
+            never_split = ('[UNK]', '[SEP]', '[PAD]', '[CLS]', '[MASK]') + special_tokens
+            self.tokenizer = BertTokenizer(custom_vocab, do_basic_tokenize=True, never_split=never_split)
         self.mxlen = kwargs.get('mxlen', -1)
 
     @property
@@ -222,10 +228,6 @@ class WordPieceVectorizer1D(AbstractVectorizer):
                 yield '[UNK]'
             elif tok == '<EOS>':
                 yield '[SEP]'
-            elif tok == '<BOQ>':
-                yield '[BOQ]'
-            elif tok == '<EOQ>':
-                yield '[EOQ]'
             else:
                 for subtok in self.tokenizer.tokenize(tok):
                     yield subtok
@@ -297,7 +299,7 @@ class TensorDatasetReaderBase(object):
 class TensorWordDatasetReader(TensorDatasetReaderBase):
     """Read each word, and produce a tensor of x and y that are identical
     """
-    def __init__(self, nctx, use_subword=None, model_file=None, vocab_file=None):
+    def __init__(self, nctx, use_subword=None, model_file=None, vocab_file=None, special_tokens=None):
         """Create a reader with a context window that reads words
 
         :param nctx: The context window length
@@ -308,7 +310,8 @@ class TensorWordDatasetReader(TensorDatasetReaderBase):
         if self.use_subword == 'bpe':
             vectorizer = BPEVectorizer1D(model_file=model_file, vocab_file=vocab_file)
         elif self.use_subword == 'wordpiece':
-            vectorizer = WordPieceVectorizer1D(embed_file=model_file)
+            vectorizer = WordPieceVectorizer1D(embed_file=model_file, vocab_file=vocab_file,
+                                               special_tokens=special_tokens)
         else:
             vectorizer = Token1DVectorizer(transform_fn=baseline.lowercase)
         super(TensorWordDatasetReader, self).__init__(nctx, {'x': vectorizer})
@@ -366,7 +369,7 @@ def load_data(token_type, reader, dataset, file_key, vocabs, caching):
     return loaded
 
 
-def create_reader(token_type, nctx, chars_per_word, subword_model_file, subword_vocab_file):
+def create_reader(token_type, nctx, chars_per_word, subword_model_file, subword_vocab_file, subword_special_tokens):
     if token_type == "chars":
         logger.info("Using character input")
         reader = TensorCharDatasetReader(nctx, chars_per_word)
@@ -375,7 +378,8 @@ def create_reader(token_type, nctx, chars_per_word, subword_model_file, subword_
         reader = TensorWordDatasetReader(nctx)
     else:
         logger.info("Using subword ({}) input".format(token_type))
-        reader = TensorWordDatasetReader(nctx, token_type, subword_model_file, subword_vocab_file)
+        reader = TensorWordDatasetReader(nctx, token_type, subword_model_file, subword_vocab_file,
+                                         subword_special_tokens)
     return reader
 
 
@@ -480,8 +484,9 @@ def train():
     parser.add_argument("--batch_size", type=int, default=8, help="Batch Size")
     parser.add_argument("--tokens", choices=["words", "chars", "bpe", "wordpiece"], default="wordpiece",
                         help="What tokens to use")
-    parser.add_argument("--subword_model_file", type=str, help="If using subwords, pass this", default='bert-base-cased')
+    parser.add_argument("--subword_model_file", type=str, help="If using subwords, pass this", default='bert-base-uncased')
     parser.add_argument("--subword_vocab_file", type=str, help="If using subwords with separate vocab file, pass here")
+    parser.add_argument("--subword_special_tokens", type=str, nargs='*')
     parser.add_argument("--dropout", type=float, default=0.1, help="Dropout")
     parser.add_argument("--lr", type=float, default=4.0e-4, help="Learning rate")
     parser.add_argument("--clip", type=float, default=0.25, help="Clipping gradient norm")
@@ -555,7 +560,12 @@ def train():
         dataset = {'train_file': args.train_file, 'valid_file': args.valid_file}
     else:
         dataset = DataDownloader(DATASETS[args.dataset_key], args.dataset_cache).download()
-    reader = create_reader(args.tokens, args.nctx, args.chars_per_word, args.subword_model_file, args.subword_vocab_file)
+    if args.subword_special_tokens is None:
+        special_tokens = ()
+    else:
+        special_tokens = tuple(args.subword_special_tokens)
+    reader = create_reader(args.tokens, args.nctx, args.chars_per_word, args.subword_model_file,
+                           args.subword_vocab_file, special_tokens)
 
     preproc_data = load_embed_and_vocab(args.tokens, reader, dataset, args.dataset_key, args.d_model, args.cache_features)
 

--- a/python/addons/embed_tlm_pytorch.py
+++ b/python/addons/embed_tlm_pytorch.py
@@ -15,7 +15,7 @@ from pytorch_pretrained_bert.modeling import BertModel
 from baseline.pytorch.torchy import *
 
 
-@register_vectorizer(name='tlm-subwords')
+@register_vectorizer(name='tlm-wordpiece')
 class WordPieceVectorizer1D(AbstractVectorizer):
     """Define a Baseline Vectorizer that can do WordPiece with BERT tokenizer
 
@@ -60,6 +60,101 @@ class WordPieceVectorizer1D(AbstractVectorizer):
             value = vocab.get(atom)
             if value is None:
                 value = vocab['[UNK]']
+            yield value
+
+    def run(self, tokens, vocab):
+        if self.mxlen < 0:
+            self.mxlen = self.max_seen
+        vec1d = np.zeros(self.mxlen, dtype=np.long)
+        for i, atom in enumerate(self._next_element(tokens, vocab)):
+            if i == self.mxlen:
+                i -= 1
+                vec1d[i] = vocab.get('[CLS]')
+                break
+            vec1d[i] = atom
+        valid_length = i + 1
+        return vec1d, valid_length
+
+    def get_dims(self):
+        return self.mxlen,
+
+
+class SavableFastBPE(object):
+    def __init__(self, codes_path, vocab_path):
+        from fastBPE import fastBPE
+        self.codes = open(codes_path, 'rb').read()
+        self.vocab = open(vocab_path, 'rb').read()
+        self.bpe = fastBPE(codes_path, vocab_path)
+
+    def __getstate__(self):
+        return {'codes': self.codes, 'vocab': self.vocab}
+
+    def __setstate__(self, state):
+        with tempfile.NamedTemporaryFile() as codes, tempfile.NamedTemporaryFile() as vocab:
+            codes.write(state['codes'])
+            vocab.write(state['vocab'])
+            self.bpe = fastBPE(codes.name, vocab.name)
+
+    def apply(self, sentences):
+        return self.bpe.apply(sentences)
+
+
+@register_vectorizer(name='tlm-bpe')
+class BPEVectorizer1D(AbstractVectorizer):
+    """Define a Baseline Vectorizer for BPE using fastBPE (https://github.com/glample/fastBPE)
+
+    If you use tokens=bpe, this vectorizer is used, and so then there is a
+    dependency on fastBPE
+
+    To use BPE, we assume that a Dictionary of codes and vocab was already created
+
+    """
+    def __init__(self, **kwargs):
+        """Loads a BPE tokenizer"""
+        super(BPEVectorizer1D, self).__init__(kwargs.get('transform_fn'))
+        self.max_seen = 128
+        self.model_file = kwargs.get('model_file')
+        self.vocab_file = kwargs.get('vocab_file')
+        self.tokenizer = SavableFastBPE(self.model_file, self.vocab_file)
+        self.mxlen = kwargs.get('mxlen', -1)
+        self.vocab = {k: i for i, k in enumerate(self.read_vocab(self.vocab_file))}
+
+    def read_vocab(self, s):
+        vocab = [] + Offsets.VALUES + ['[CLS]']
+        with open(s, "r") as f:
+            for line in f.readlines():
+                token = line.split()[0].strip()
+                vocab.append(token)
+        return vocab
+
+    def count(self, tokens):
+        seen = 0
+        counter = Counter()
+        for tok in self.iterable(tokens):
+            counter[tok] += 1
+            seen += 1
+        self.max_seen = max(self.max_seen, seen)
+        return counter
+
+    def iterable(self, tokens):
+        for t in tokens:
+            if t in Offsets.VALUES:
+                yield t
+            elif t == '<unk>':
+                yield Offsets.VALUES[Offsets.UNK]
+            elif t == '<eos>':
+                yield Offsets.VALUES[Offsets.EOS]
+            else:
+                subwords = self.tokenizer.apply([t])[0].split()
+                for x in subwords:
+                    yield x
+        yield '[CLS]'
+
+    def _next_element(self, tokens, vocab):
+        for atom in self.iterable(tokens):
+            value = vocab.get(atom)
+            if value is None:
+                value = vocab[Offsets.VALUES[Offsets.UNK]]
             yield value
 
     def run(self, tokens, vocab):


### PR DESCRIPTION
This PR makes some changes for lm pretraining and finetuning: 
- add an option to use customized vocabulary for wordpiece tokenizer, as well as the option of adding some special tokens to the `never_split` list of `BertTokenizer`. 
- add "[CLS]" to the BPE vocabulary in pretraining
- add BPE vectorizer to addon `embed_tlm_pytorch.py` to be used in finetuning. 
