### PR TITLE
fix: token level tagging tasks

### DIFF
--- a/python/mead/config/twpos.json
+++ b/python/mead/config/twpos.json
@@ -65,6 +65,7 @@
         "mom": 0.9,
         "patience": 20,
         "early_stopping_metric": "acc",
+        "span_type": "token",
         "clip": 5.0
     }
 }


### PR DESCRIPTION
Right now when there is a token level task that is run via baseline tagger task we run the tokens through the iob span creating code. This generates a span per token and the f1 is calculated correctly. However in some datasets such as twpos there is a label that is `O`. This results in some of the tokens getting skipped.

This PR adds a new `span_type` called `tokens` where it forces each token to be a span even in the case that the label is `O`.

It also updates the iobes parsing code to detect a few more errors such as `B` followed by `O`, `B`, or `S` or having either a `B` or `I` as the final token.