### PR TITLE
fix: yield single sentence document when last

### DIFF
--- a/python/eight_mile/utils.py
+++ b/python/eight_mile/utils.py
@@ -778,7 +778,7 @@ def read_conll_docs(f, doc_pattern="# begin doc", delim=None):
                 sentence = []
             continue
         sentence.append(line.split(delim))
-    if doc:
+    if doc or sentence:
         if sentence:
             doc.append(sentence)
         yield doc
@@ -822,7 +822,7 @@ def read_conll_docs_md(f, doc_pattern="# begin doc", delim=None):
                 sentence, meta = [], []
             continue
         sentence.append(line.split(delim))
-    if doc:
+    if doc or sentence:
         if sentence:
             doc.append(sentence)
             sent_meta.append(meta)


### PR DESCRIPTION
When there was a single sentence in a conll document at the end of the file it gets missed. This is because without an empty line the sentence isn't added to the document. So we end up with an empty document but a sentence so this wasn't getting yielded. Now that we check for either the final document is yielded correctly.