### PR TITLE
fix: don't miss single sentence final docs in conlls

### DIFF
--- a/python/baseline/utils.py
+++ b/python/baseline/utils.py
@@ -1020,7 +1020,7 @@ def read_conll_docs(f, doc_pattern="# begin doc", delim=None):
                 sentence = []
             continue
         sentence.append(line.split(delim))
-    if doc:
+    if doc or sentence:
         if sentence:
             doc.append(sentence)
         yield doc
@@ -1064,7 +1064,7 @@ def read_conll_docs_md(f, doc_pattern="# begin doc", delim=None):
                 sentence, meta = [], []
             continue
         sentence.append(line.split(delim))
-    if doc:
+    if doc or sentence:
         if sentence:
             doc.append(sentence)
             sent_meta.append(meta)


### PR DESCRIPTION
When there was a single sentence in a conll document at the end of the file it gets missed. This is because without an empty line the sentence isn't added to the document. So we end up with an empty document but a sentence so this wasn't getting yielded. Now that we check for either the final document is yielded correctly.