### PR TITLE
Blester/fix/no lengths for preproc

### DIFF
--- a/python/baseline/tf/classify/model.py
+++ b/python/baseline/tf/classify/model.py
@@ -310,6 +310,8 @@ class ClassifierModelBase(ClassifierModel):
                 if k in kwargs:
                     _state[k] = kwargs[k]
             # TODO: convert labels into just another vocab and pass number of labels to models.
+            if 'lengths' in kwargs:
+                _state['lengths'] = kwargs['lengths']
             labels = read_json("{}.labels".format(basename))
             model = cls.create(embeddings, labels, **_state)
             model._state = _state

--- a/python/baseline/tf/remote.py
+++ b/python/baseline/tf/remote.py
@@ -36,15 +36,10 @@ class RemoteModelGRPCTensorFlowPreproc(RemoteModelGRPCTensorFlow):
 
         for key in examples:
             if key.endswith('lengths'):
-                shape = examples[key].shape
-                tensor_proto = tf.contrib.util.make_tensor_proto(examples[key], shape=shape, dtype=tf.int32)
-                request.inputs[key].CopyFrom(
-                    tensor_proto
-                )
-            else:
-                request.inputs[key].CopyFrom(
-                    tf.contrib.util.make_tensor_proto(examples[key], shape=[len(examples[key]), 1])
-                )
+                continue
+            request.inputs[key].CopyFrom(
+                tf.contrib.util.make_tensor_proto(examples[key], shape=[len(examples[key]), 1])
+            )
         return request
 
 

--- a/python/baseline/tf/tagger/model.py
+++ b/python/baseline/tf/tagger/model.py
@@ -130,6 +130,8 @@ class TaggerModelBase(TaggerModel):
             if _state.get('constraint') is not None:
                 # Dummy constraint values that will be filled in by the check pointing
                 _state['constraint'] = [tf.zeros((len(labels), len(labels))) for _ in range(2)]
+            if 'lengths' in kwargs:
+                _state['lengths'] = kwargs['lengths']
             model = cls.create(embeddings, labels, **_state)
             model._state = _state
             model.create_loss()

--- a/python/mead/tf/preproc_exporters.py
+++ b/python/mead/tf/preproc_exporters.py
@@ -158,7 +158,7 @@ class ClassifyTensorFlowPreProcExporter(ClassifyTensorFlowExporter):
         embedding_inputs = {}
         for feature in preprocessed:
             embedding_inputs[feature] = preprocessed[feature]
-        model, classes, values = self._create_model(sess, model_file, lengths=lengths **embedding_inputs)
+        model, classes, values = self._create_model(sess, model_file, lengths=lengths, **embedding_inputs)
         sig_input = {x: tf.saved_model.utils.build_tensor_info(tf_example[x]) for x in pc.FIELD_NAMES}
         sig_output = SignatureOutput(classes, values)
         sig_name = 'predict_text'

--- a/python/tests/export-config-classify-grpc.yml
+++ b/python/tests/export-config-classify-grpc.yml
@@ -9,15 +9,14 @@ NUM_LINES_TO_REMOVE_SERVE: 0
 DRIVER: ${BASELINE_DIR}/api-examples/classify-text.py
 TEST_FILE: ${PWD}/stsa.binary.test
 TEST_FILE_LINK: https://www.dropbox.com/s/zm6y79wczkaliat/stsa.binary.test?dl=1
-MODEL_FILE: ${PWD}/sst2-6475.zip
-MODEL_FILE_LINK: https://www.dropbox.com/s/pmeips3phwhmqbv/sst2-6475.zip?dl=1
+MODEL_FILE: ${PWD}/sst2-8519.zip
+MODEL_FILE_LINK: https://www.dropbox.com/s/l3y8oi62le0uczc/sst2-8519.zip?dl=1
 CONFIG_FILE: ${PWD}/sst2-comb.json
 CONFIG_FILE_LINK: https://www.dropbox.com/s/77m4xjpb6rpm2fx/sst2-comb.json?dl=1
 MODEL_NAME: sst2
 EXPORT_DIR: ${PWD}/models
 EXPORT_DIR_PREPROC: ${PWD}/models-preproc
 EXPORT_SETTINGS_MEAD: ${BASELINE_DIR}/python/mead/config/mead-settings.json
-EXPORT_SETTINGS_DATASETS: ${BASELINE_DIR}/python/mead/config/datasets.json
 MODEL_VERSION: 1
 IS_REMOTE: false
 RETURN_LABELS: true

--- a/python/tests/export-config-tagger-grpc.yml
+++ b/python/tests/export-config-tagger-grpc.yml
@@ -11,15 +11,14 @@ TEST_FILE: eng.testb.small
 TEST_FILE_LINK: https://www.dropbox.com/s/pp3pcq5q5ko1df6/eng.testb.small?dl=1
 CONLL: false
 FEATURES: text
-MODEL_FILE: ${PWD}/conll-11083.zip
-MODEL_FILE_LINK: https://www.dropbox.com/s/ftv4amoq7dzxnxo/conll-11083.zip?dl=1
+MODEL_FILE: ${PWD}/conll-19231.zip
+MODEL_FILE_LINK: https://www.dropbox.com/s/agft8f1gbyt1w76/conll-19231.zip?dl=1
 CONFIG_FILE: ${PWD}/conll-tf.json
 CONFIG_FILE_LINK: https://www.dropbox.com/s/97bi7qy15usmvb2/conll-tf.json?dl=1
 MODEL_NAME: conll
 EXPORT_DIR: ${PWD}/models
 EXPORT_DIR_PREPROC: ${PWD}/models-preproc
 EXPORT_SETTINGS_MEAD: ${BASELINE_DIR}/python/mead/config/mead-settings.json
-EXPORT_SETTINGS_DATASETS: ${BASELINE_DIR}/python/mead/config/datasets.json
 MODEL_VERSION: 1
 IS_REMOTE: false
 RETURN_LABELS: true

--- a/python/tests/test_exporters.sh
+++ b/python/tests/test_exporters.sh
@@ -46,7 +46,7 @@ function get_file {
 }
 
 function mead_export {
-    mead-export --config ${CONFIG_FILE} --settings ${EXPORT_SETTINGS_MEAD} --datasets ${EXPORT_SETTINGS_DATASETS} --task ${TASK} --exporter_type ${1} --model ${MODEL_FILE} --model_version ${MODEL_VERSION} --output_dir $2 --is_remote ${IS_REMOTE} --return_labels ${3}
+    mead-export --config ${CONFIG_FILE} --settings ${EXPORT_SETTINGS_MEAD} --task ${TASK} --exporter_type ${1} --model ${MODEL_FILE} --model_version ${MODEL_VERSION} --output_dir $2 --is_remote ${IS_REMOTE} --return_labels ${3}
 }
 
 function file_empty_or_does_not_exist {


### PR DESCRIPTION
This change makes it possible for utterance lengths not be sent. I have tested by running `./test_exporters.sh` (which was modified to be compatible for changes in `mead-export`)