### PR TITLE
Update tagger to get path scores

### DIFF
--- a/api-examples/tag-text-with-scores.py
+++ b/api-examples/tag-text-with-scores.py
@@ -1,0 +1,70 @@
+import os
+import argparse
+import baseline as bl
+from baseline.utils import str2bool, read_conll
+from addons.tagger_with_scores_service import TaggerWithScoresService
+
+
+parser = argparse.ArgumentParser(description='Tag text with a model')
+parser.add_argument('--model', help='A tagger model with extended features', required=True, type=str)
+parser.add_argument('--text', help='raw value', type=str)
+parser.add_argument('--conll', help='is file type conll?', type=str2bool, default=False)
+parser.add_argument('--features', help='(optional) features in the format feature_name:index (column # in conll) or '
+                                       'just feature names (assumed sequential)', default=[], nargs='+')
+parser.add_argument('--backend', help='backend', default='tf')
+parser.add_argument('--device', help='device')
+parser.add_argument('--remote', help='(optional) remote endpoint', type=str) # localhost:8500
+parser.add_argument('--name', help='(optional) signature name', type=str)
+parser.add_argument('--preproc', help='(optional) where to perform preprocessing', choices={'client', 'server'}, default='client')
+parser.add_argument('--export_mapping', help='mapping between features and the fields in the grpc/ REST '
+                                                         'request, eg: token:word ner:ner. This should match with the '
+                                                         '`exporter_field` definition in the mead config',
+                    default=[], nargs='+')
+args = parser.parse_args()
+
+
+def create_export_mapping(feature_map_strings):
+    feature_map_strings = [x.strip() for x in feature_map_strings if x.strip()]
+    if not feature_map_strings:
+        return {}
+    else:
+        return {x[0]: x[1] for x in [y.split(':') for y in feature_map_strings]}
+
+
+def feature_index_mapping(features):
+    if not features:
+        return {}
+    elif ':' in features[0]:
+        return {feature.split(':')[0]: int(feature.split(':')[1]) for feature in features}
+    else:
+        return {feature: index for index, feature in enumerate(features)}
+
+
+if os.path.exists(args.text) and os.path.isfile(args.text):
+    texts = []
+    if args.conll:
+        feature_indices = feature_index_mapping(args.features)
+        for sentence in read_conll(args.text):
+            if feature_indices:
+                texts.append([{k: line[v] for k, v in feature_indices.items()} for line in sentence])
+            else:
+                texts.append([line[0] for line in sentence])
+    else:
+        with open(args.text, 'r') as f:
+            for line in f:
+                text = line.strip().split()
+                texts += [text]
+else:
+    texts = [args.text.split()]
+
+m = TaggerWithScoresService.load(args.model, backend=args.backend, remote=args.remote,
+                          name=args.name, preproc=args.preproc, device=args.device)
+
+paths, scores = m.predict(texts, export_mapping=create_export_mapping(args.export_mapping))
+
+for i, (sen, score) in enumerate(zip(paths, scores)):
+    print(f"Score: {score.item()}")
+    for word_tag in sen:
+        print(f"{word_tag['text']} {word_tag['label']}")
+    if i != len(paths) -1:
+        print()

--- a/python/addons/tagger_with_scores.py
+++ b/python/addons/tagger_with_scores.py
@@ -2,7 +2,6 @@ import tensorflow as tf
 from baseline.utils import get_version
 from baseline.model import register_model
 from baseline.tf.tagger.model import RNNTaggerModel
-from baseline.services import TaggerService
 
 
 @register_model(task='tagger', name='with-scores')
@@ -18,21 +17,3 @@ class RNNTaggerWithScores(RNNTaggerModel):
         assert self.impl.path_scores is not None, "Sequence scores are not being calculated, you need to use a CRF or constrained decoding to do this."
         scores = self.impl.path_scores
         return bestv, scores.numpy()
-
-
-class TaggerWithScoresService(TaggerService):
-
-    def predict(self, tokens, **kwargs):
-        export_mapping = kwargs.get('export_mapping', {})  # if empty dict argument was passed
-        if not export_mapping:
-            export_mapping = {'tokens': 'text'}
-        label_field = kwargs.get('label', 'label')
-        tokens_batch = self.batch_input(tokens)
-        self.prepare_vectorizers(tokens_batch)
-        examples = self.vectorize(tokens_batch)
-        outcomes = self.model.predict_with_scores(examples)
-        return self.format_output(outcomes, tokens_batch=tokens_batch, label_field=label_field)
-    def format_output(self, predicted, **kwargs):
-        predicted, scores = predicted
-        paths = super().format_output(predicted, **kwargs)
-        return paths, scores

--- a/python/addons/tagger_with_scores.py
+++ b/python/addons/tagger_with_scores.py
@@ -1,0 +1,38 @@
+import tensorflow as tf
+from baseline.utils import get_version
+from baseline.model import register_model
+from baseline.tf.tagger.model import RNNTaggerModel
+from baseline.services import TaggerService
+
+
+@register_model(task='tagger', name='with-scores')
+class RNNTaggerWithScores(RNNTaggerModel):
+
+    def predict_with_scores(self, batch_dict):
+        lengths = batch_dict[self.lengths_key]
+        batch_dict = self.make_input(batch_dict)
+        if get_version(tf) < 2:
+            assert self.impl.path_scores is not None, "Sequence scores are not being calculated, you need to use a CRF or constrained decoding to do this."
+            return self.sess.run([self.best, self.impl.path_scores], feed_dict=batch_dict)
+        bestv = self(batch_dict).numpy()
+        assert self.impl.path_scores is not None, "Sequence scores are not being calculated, you need to use a CRF or constrained decoding to do this."
+        scores = self.impl.path_scores
+        return bestv, scores.numpy()
+
+
+class TaggerWithScoresService(TaggerService):
+
+    def predict(self, tokens, **kwargs):
+        export_mapping = kwargs.get('export_mapping', {})  # if empty dict argument was passed
+        if not export_mapping:
+            export_mapping = {'tokens': 'text'}
+        label_field = kwargs.get('label', 'label')
+        tokens_batch = self.batch_input(tokens)
+        self.prepare_vectorizers(tokens_batch)
+        examples = self.vectorize(tokens_batch)
+        outcomes = self.model.predict_with_scores(examples)
+        return self.format_output(outcomes, tokens_batch=tokens_batch, label_field=label_field)
+    def format_output(self, predicted, **kwargs):
+        predicted, scores = predicted
+        paths = super().format_output(predicted, **kwargs)
+        return paths, scores

--- a/python/addons/tagger_with_scores_service.py
+++ b/python/addons/tagger_with_scores_service.py
@@ -1,0 +1,35 @@
+import os
+from baseline.services import TaggerService
+from baseline.utils import unzip_files, find_model_basename, read_json, write_json, normalize_backend
+
+
+class TaggerWithScoresService(TaggerService):
+    @classmethod
+    def load(cls, bundle, **kwargs):
+        be = normalize_backend(kwargs.get('backend', 'tf'))
+        if be == 'tf':
+           bundle = bundle if os.path.isdir(bundle) else unzip_files(bundle)
+           model_basename = find_model_basename(bundle)
+           state = read_json(f"{model_basename}.state")
+           state['type'] = 'with-scores'
+           state['module'] = 'addons.tagger_with_scores'
+           state['class'] = 'RNNTaggerWithScores'
+           write_json(state, f"{model_basename}.state")
+        return super().load(bundle)
+
+
+    def predict(self, tokens, **kwargs):
+        export_mapping = kwargs.get('export_mapping', {})  # if empty dict argument was passed
+        if not export_mapping:
+            export_mapping = {'tokens': 'text'}
+        label_field = kwargs.get('label', 'label')
+        tokens_batch = self.batch_input(tokens)
+        self.prepare_vectorizers(tokens_batch)
+        examples = self.vectorize(tokens_batch)
+        outcomes = self.model.predict_with_scores(examples)
+        return self.format_output(outcomes, tokens_batch=tokens_batch, label_field=label_field)
+
+    def format_output(self, predicted, **kwargs):
+        predicted, scores = predicted
+        paths = super().format_output(predicted, **kwargs)
+        return paths, scores

--- a/python/baseline/tf/tagger/model.py
+++ b/python/baseline/tf/tagger/model.py
@@ -271,13 +271,9 @@ class TaggerModelBase(tf.keras.Model, TaggerModel):
         lengths = batch_dict[self.lengths_key]
         batch_dict = self.make_input(batch_dict)
         if get_version(tf) < 2:
-            bestv = self.sess.run(self.best, feed_dict=batch_dict)
-            return [pij[:sl] for pij, sl in zip(bestv, lengths)]
+            return self.sess.run(self.best, feed_dict=batch_dict)
         else:
-            bestv = self(batch_dict)
-            return [pij[:sl].numpy() for pij, sl in zip(bestv, lengths)]
-
-
+            return self(batch_dict).numpy()
 
     def embed(self, **kwargs):
         """This method performs "embedding" of the inputs.  The base method here then concatenates along depth

--- a/python/eight_mile/pytorch/layers.py
+++ b/python/eight_mile/pytorch/layers.py
@@ -999,9 +999,9 @@ class TaggerGreedyDecoder(nn.Module):
         if self.constraint_mask is not None:
             probv = self.to_time_first(unaries)
             probv = F.log_softmax(probv, dim=-1)
-            preds, _ = viterbi(probv, self.constraint_mask, lengths, Offsets.GO, Offsets.EOS, norm=F.log_softmax)
+            preds, scores = viterbi(probv, self.constraint_mask, lengths, Offsets.GO, Offsets.EOS, norm=F.log_softmax)
             if self.batch_first:
-                return tbh2bth(preds)
+                return tbh2bth(preds), scores
         else:
             # Decoding doesn't care about batch/time first
             _, preds = torch.max(unaries, -1)
@@ -1009,7 +1009,7 @@ class TaggerGreedyDecoder(nn.Module):
             # The mask gets generated as batch first
             mask = mask if self.batch_first else mask.transpose(0, 1)
             preds = preds.masked_fill(mask == 0, 0)
-        return preds
+        return preds, None
 
     def extra_repr(self):
         str_ = f"n_tags={self.num_tags}, batch_first={self.batch_first}"
@@ -1163,7 +1163,7 @@ class CRF(nn.Module):
             return self._forward_alg(unary, lengths)
 
         with torch.no_grad():
-            return self.decode(unary, lengths)[0]
+            return self.decode(unary, lengths)
 
     def decode(self, unary, lengths):
         """Do Viterbi decode on a batch.
@@ -1216,12 +1216,13 @@ class TagSequenceModel(SequenceModel):
     def __init__(self, nc, embeddings, transducer, decoder=None):
         decoder_model = CRF(nc, batch_first=False) if decoder is None else decoder
         super().__init__(nc, embeddings, transducer, decoder_model)
+        self.path_scores = None
 
     def neg_log_loss(self, unary, tags, lengths):
         return self.decoder_model.neg_log_loss(unary, tags, lengths)
 
     def forward(self, inputs):
-        time_first = super().forward(inputs)
+        time_first, self.path_scores = super().forward(inputs)
         return time_first.transpose(0, 1)
 
 

--- a/python/eight_mile/tf/layers.py
+++ b/python/eight_mile/tf/layers.py
@@ -1190,10 +1190,10 @@ class TaggerGreedyDecoder(tf.keras.layers.Layer):
             gos = tf.constant(np_gos)
             start = tf.tile(gos, [bsz, 1, 1])
             probv = tf.concat([start, unary], axis=1)
-            viterbi, _ = crf_decode(probv, self.transitions, lengths + 1)
-            return tf.identity(viterbi[:, 1:], name="best")
+            viterbi, path_scores = crf_decode(probv, self.transitions, lengths + 1)
+            return tf.identity(viterbi[:, 1:], name="best"), path_scores
         else:
-            return tf.argmax(self.probs, 2, name="best")
+            return tf.argmax(self.probs, 2, name="best"), None
 
 
 class CRF(tf.keras.layers.Layer):
@@ -1229,8 +1229,6 @@ class CRF(tf.keras.layers.Layer):
 
         :return: torch.FloatTensor: [B]
         """
-        #unary = tf.Print(unary, [tf.shape(unary)])
-        #tags = tf.Print(tags, [tf.shape(tags)])
         return crf_sequence_score(unary, tf.cast(tags, tf.int32), tf.cast(lengths, tf.int32), self.transitions)
 
     def call(self, inputs, training=False):
@@ -1261,8 +1259,8 @@ class CRF(tf.keras.layers.Layer):
 
         probv = tf.concat([start, unary], axis=1)
 
-        viterbi, _ = crf_decode(probv, self.transitions, lengths + 1)
-        return tf.identity(viterbi[:, 1:], name="best")
+        viterbi, path_scores = crf_decode(probv, self.transitions, lengths + 1)
+        return tf.identity(viterbi[:, 1:], name="best"), path_scores
 
     def neg_log_loss(self, unary, tags, lengths):
         """Neg Log Loss with a Batched CRF.
@@ -1319,6 +1317,7 @@ class TagSequenceModel(tf.keras.Model):
         else:
             assert isinstance(embeddings, EmbeddingsStack)
             self.embed_model = embeddings
+        self.path_scores = None
         self.transducer_model = transducer
         self.proj_layer = TimeDistributedProjection(nc)
         decoder_model = CRF(nc) if decoder is None else decoder
@@ -1333,7 +1332,8 @@ class TagSequenceModel(tf.keras.Model):
         return transduced
 
     def decode(self, transduced, lengths):
-        return self.decoder_model((transduced, lengths))
+        path, self.path_scores = self.decoder_model((transduced, lengths))
+        return path
 
     def call(self, inputs, training=None):
         transduced = self.transduce(inputs)


### PR DESCRIPTION
This PR does a few things:

 * Standardize the return values of our tagger decoders (CRF, Greedy/Constrained Decoder)
    * They all return a tuple of paths, scores
 * Standardize the return values of our TagSequenceModels They all return the paths as a dense tensor of `[B, MxLen]. They also store the path scores as an attr
 * Standardize the return values of our TaggerModels They return a dense tensor as a numpy array
 * move the part of services that convert from the `model.predict` format into our output format (list of tuples for classification, list of dict for tagger, etc) into it's own method
 * Create an addon model and service that can return both the path and the path score