### PR TITLE
WIP: Chore/weight tying

### DIFF
--- a/python/baseline/tf/seq2seq/decoders/v2.py
+++ b/python/baseline/tf/seq2seq/decoders/v2.py
@@ -109,7 +109,7 @@ class RNNDecoder(tf.keras.layers.Layer):
         self.dropout = tf.keras.layers.Dropout(pdrop)
         self.init_attn(**kwargs)
 
-        do_weight_tying = bool(kwargs.get('tie_weights', False))
+        do_weight_tying = bool(kwargs.get('tie_weights', True))
 
         if do_weight_tying:
             if self.hsz != self.tgt_embeddings.get_dsz():
@@ -257,7 +257,7 @@ class TransformerDecoderWrapper(tf.keras.layers.Layer):
             self.proj_to_hsz = tf.keras.layers.Dense(hsz)
             self.proj_to_dsz = tf.keras.layers.Dense(dsz)
 
-        do_weight_tying = bool(kwargs.get('tie_weights', False))
+        do_weight_tying = bool(kwargs.get('tie_weights', True))
 
         if do_weight_tying:
             if self.hsz != self.tgt_embeddings.get_dsz():

--- a/python/baseline/tf/seq2seq/decoders/v2.py
+++ b/python/baseline/tf/seq2seq/decoders/v2.py
@@ -110,15 +110,13 @@ class RNNDecoder(tf.keras.layers.Layer):
         self.init_attn(**kwargs)
 
         do_weight_tying = bool(kwargs.get('tie_weights', False))
-        is_valid_tying = self.hsz == self.tgt_embeddings.get_dsz()
 
-        self.preds = tf.keras.layers.Dense(self.tgt_embeddings.get_vsz())
         if do_weight_tying:
-            if is_valid_tying:
-                tie_weight(self.preds, self.tgt_embeddings.embeddings)
-            else:
-                raise ValueError("weight tying only valid when prediction projection \
-layer's hidden size == embedding weight dimensions")
+            if self.hsz != self.tgt_embeddings.get_dsz()
+                raise ValueError("weight tying requires hsz == embedding dsz, got {} hsz and {} dsz".format(self.hsz, self.tgt_embedding.get_dsz()))
+            self.preds = WeightTieDense(self.tgt_embeddings)
+        else:
+            self.preds = tf.keras.layers.Dense(self.tgt_embeddings.get_vsz())
 
     @staticmethod
     def _basic_input(dst_embed_i, _):

--- a/python/baseline/tf/seq2seq/encoders/v1.py
+++ b/python/baseline/tf/seq2seq/encoders/v1.py
@@ -13,10 +13,10 @@ exporter = export(__all__)
 RNNEncoderOutput = namedtuple("RNNEncoderOutput", ("output", "hidden"))
 
 @exporter
-class EncoderBase(object):
+class EncoderBase(tf.keras.layers.Layer):
 
-    def __init__(self, **kwargs):
-        pass
+    def __init__(self, name='encoder', **kwargs):
+        super().__init__(name=name)
 
     def encode(self, embed_in, src_len, pdrop, **kwargs):
         pass
@@ -25,41 +25,23 @@ class EncoderBase(object):
 @register_encoder(name='default')
 class RNNEncoder(EncoderBase):
 
-    def __init__(self, **kwargs):
-        super(RNNEncoder, self).__init__()
+    def __init__(self, name='encoder', pdrop=0.1, hsz=650, rnntype='blstm', layers=1, vdrop=False, scope='RNNEncoder', residual=False, **kwargs):
+        super().__init__()
+        Encoder = BiLSTMEncoderAll is rnntype == 'blstm' else LSTMEncoderALL
+        self.rnn = Encoder(None, hsz, layers, pdrop, vdrop, name=scope)
+        self.residual = residual
 
     @property
     def encoder_type(self):
         return 'default'
 
-    def encode(self, embed_in, src_len, pdrop, hsz=650, rnntype='blstm', layers=1, vdrop=False, **kwargs):
-
-        if rnntype == 'blstm':
-            rnn_fwd_cell = multi_rnn_cell_w_dropout(hsz//2, pdrop, rnntype, layers, variational=vdrop, training=TRAIN_FLAG())
-            rnn_bwd_cell = multi_rnn_cell_w_dropout(hsz//2, pdrop, rnntype, layers, variational=vdrop, training=TRAIN_FLAG())
-            rnn_enc_tensor, (fw_final_state, bw_final_state) = tf.nn.bidirectional_dynamic_rnn(rnn_fwd_cell, rnn_bwd_cell,
-                                                                                               embed_in,
-                                                                                               scope='brnn_enc',
-                                                                                               sequence_length=src_len,
-                                                                                               dtype=tf.float32)
-
-            rnn_enc_tensor = tf.concat(rnn_enc_tensor, -1)
-            encoder_state = []
-            for i in range(layers):
-                h = tf.concat([fw_final_state[i].h, bw_final_state[i].h], -1)
-                c = tf.concat([fw_final_state[i].c, bw_final_state[i].c], -1)
-                encoder_state.append(tf.contrib.rnn.LSTMStateTuple(h=h, c=c))
-            encoder_state = tuple(encoder_state)
-        else:
-
-            rnn_enc_cell = multi_rnn_cell_w_dropout(hsz, pdrop, rnntype, layers, variational=vdrop, training=TRAIN_FLAG())
-            rnn_enc_tensor, encoder_state = tf.nn.dynamic_rnn(rnn_enc_cell, embed_in,
-                                                              scope='rnn_enc',
-                                                              sequence_length=src_len,
-                                                              dtype=tf.float32)
+    def call(self, inputs, **kwargs):
+        embed_in, src_len = inputs
 
         # This comes out as a sequence T of (B, D)
-        return RNNEncoderOutput(output=rnn_enc_tensor, hidden=encoder_state)
+        output, hidden = self.rnn((embed_in, src_len))
+        output = output + embed_in if self.residual else output
+        return RNNEncoderOutput(output=output, hidden=hidden)
 
 
 TransformerEncoderOutput = namedtuple("TransformerEncoderOutput", ("output", "src_mask"))
@@ -68,32 +50,22 @@ TransformerEncoderOutput = namedtuple("TransformerEncoderOutput", ("output", "sr
 @register_encoder(name='transformer')
 class TransformerEncoder(EncoderBase):
 
-    def __init__(self, **kwargs):
-        super(TransformerEncoder, self).__init__()
+    def __init__(self, pdrop=0.1, hsz=650, num_heads=4, layers=1, scale=True, activation_type='relu', name="encode", d_ff=None, scope="TransformerEncoder", **kwargs):
+        super().__init__()
+        self.encoder = TransformerEncoderStack(hsz, num_heads, pdrop, scale, layers, activation_type, d_ff, name=scope)
 
     @property
     def encoder_type(self):
         return 'transformer'
 
-    def encode(self,
-               embed_in,
-               src_len,
-               pdrop,
-               hsz=650,
-               num_heads=4,
-               layers=1,
-               scale=True,
-               activation_type='relu',
-               scope='TransformerEncoder',
-               d_ff=None,
-               **kwargs):
+    def call(self, inputs, **kwargs):
+        embed_in, src_len = inputs
         T = get_shape_as_list(embed_in)[1]
         src_mask = tf.sequence_mask(src_len, T, dtype=tf.float32)
         shp = get_shape_as_list(src_mask)
         new_shp = [shp[0]] + [1, 1] + shp[1:]
         src_mask = tf.reshape(src_mask, new_shp)
-        encoder_output = transformer_encoder_stack(embed_in, src_mask, num_heads,
-                                                   pdrop, scale, layers, activation_type, scope, d_ff)
+        encoder_output = self.encoder((embed_in, src_mask))
         # This comes out as a sequence T of (B, D)
         return TransformerEncoderOutput(output=encoder_output, src_mask=src_mask)
 

--- a/python/baseline/tf/seq2seq/encoders/v2.py
+++ b/python/baseline/tf/seq2seq/encoders/v2.py
@@ -4,6 +4,7 @@ from baseline.tf.transformer import transformer_encoder_stack
 from baseline.utils import export, MAGIC_VARS
 from baseline.model import register_encoder
 from collections import namedtuple
+from eight_mile.tf.layers import *
 
 RNNEncoderOutput = namedtuple("RNNEncoderOutput", ("output", "hidden", "src_mask"))
 
@@ -17,7 +18,7 @@ def _make_src_mask(output, lengths):
 @register_encoder(name='default')
 class RNNEncoder(tf.keras.layers.Layer):
 
-    def __init__(self, dsz=None, hsz=None, rnntype='blstm', layers=1, pdrop=0.5, residual=False, create_src_mask=True, name='encoder', scope="RNNEncoder" **kwargs):
+    def __init__(self, dsz=None, hsz=None, rnntype='blstm', layers=1, pdrop=0.5, residual=False, create_src_mask=True, name='encoder', scope="RNNEncoder", **kwargs):
         super().__init__(name=name)
         self.residual = residual
         hidden = hsz if hsz is not None else dsz
@@ -39,7 +40,7 @@ TransformerEncoderOutput = namedtuple("TransformerEncoderOutput", ("output", "sr
 @register_encoder(name='transformer')
 class TransformerEncoderWrapper(tf.keras.layers.Layer):
 
-    def __init__(self, dsz, hsz=None, num_heads=4, layers=1, dropout=0.5, name='encoder', scope='TransformerEncoder' **kwargs):
+    def __init__(self, dsz, hsz=None, num_heads=4, layers=1, dropout=0.5, name='encoder', scope='TransformerEncoder', **kwargs):
         super().__init__(name=name)
         if hsz is None:
             hsz = dsz

--- a/python/baseline/tf/seq2seq/encoders/v2.py
+++ b/python/baseline/tf/seq2seq/encoders/v2.py
@@ -17,12 +17,12 @@ def _make_src_mask(output, lengths):
 @register_encoder(name='default')
 class RNNEncoder(tf.keras.layers.Layer):
 
-    def __init__(self, dsz=None, hsz=None, rnntype='blstm', layers=1, pdrop=0.5, residual=False, create_src_mask=True, **kwargs):
-        super().__init__()
+    def __init__(self, dsz=None, hsz=None, rnntype='blstm', layers=1, pdrop=0.5, residual=False, create_src_mask=True, name='encoder', scope="RNNEncoder" **kwargs):
+        super().__init__(name=name)
         self.residual = residual
         hidden = hsz if hsz is not None else dsz
         Encoder = LSTMEncoderAll if rnntype == 'lstm' else BiLSTMEncoderAll
-        self.rnn = Encoder(dsz, hidden, layers, pdrop)
+        self.rnn = Encoder(dsz, hidden, layers, pdrop, name=scope)
         self.src_mask_fn = _make_src_mask if create_src_mask is True else lambda x, y: None
 
     def call(self, inputs):
@@ -39,12 +39,12 @@ TransformerEncoderOutput = namedtuple("TransformerEncoderOutput", ("output", "sr
 @register_encoder(name='transformer')
 class TransformerEncoderWrapper(tf.keras.layers.Layer):
 
-    def __init__(self, dsz, hsz=None, num_heads=4, layers=1, dropout=0.5, **kwargs):
-        super().__init__()
+    def __init__(self, dsz, hsz=None, num_heads=4, layers=1, dropout=0.5, name='encoder', scope='TransformerEncoder' **kwargs):
+        super().__init__(name=name)
         if hsz is None:
             hsz = dsz
         self.proj = tf.keras.layers.Dense(hsz) if hsz != dsz else self._identity
-        self.transformer = TransformerEncoderStack(num_heads=num_heads, d_model=hsz, pdrop=dropout, scale=True, layers=layers)
+        self.transformer = TransformerEncoderStack(num_heads=num_heads, d_model=hsz, pdrop=dropout, scale=True, layers=layers, name=scope)
 
     def _identity(self, x):
         return x

--- a/python/baseline/tf/seq2seq/model.py
+++ b/python/baseline/tf/seq2seq/model.py
@@ -99,7 +99,6 @@ if get_version(tf) < 2:
                 tgt_embedding = reload_embeddings(tgt_embedding_info, basename)['tgt']
 
                 model = cls.create(src_embeddings, tgt_embedding, reload=True, **_state)
-                writer = tf.summary.FileWriter('seq2seq-reload', model.sess.graph)
                 model._state = _state
                 if kwargs.get('init', True):
                     model.sess.run(tf.global_variables_initializer())
@@ -166,8 +165,6 @@ if get_version(tf) < 2:
             embed_in = model.embed(**kwargs)
             encoder_output = model.encode(embed_in, **kwargs)
             model.decode(encoder_output, **kwargs)
-            if not kwargs.get('reload', False):
-                _ = tf.summary.FileWriter("seq2seq-create", model.sess.graph)
             return model
 
         def set_saver(self, saver):

--- a/python/baseline/tf/seq2seq/model.py
+++ b/python/baseline/tf/seq2seq/model.py
@@ -197,9 +197,8 @@ if get_version(tf) < 2:
                 self.decoder((encoder_output, tgt, self.src_len, self.tgt_len), **kwargs)
 
         def encode(self, embed_in, **kwargs):
-            with tf.variable_scope('encode'):
-                self.encoder = self.create_encoder(**kwargs)
-                return self.encoder.encode(embed_in, self.src_len, self.pdrop_value, **kwargs)
+            self.encoder = self.create_encoder(pdrop=self.pdrop_value, **kwargs)
+            return self.encoder((embed_in, self.src_len), **kwargs)
 
         def save(self, model_base):
             self.save_md(model_base)

--- a/python/eight_mile/tf/layers.py
+++ b/python/eight_mile/tf/layers.py
@@ -829,16 +829,16 @@ class BiLSTMEncoder1(tf.keras.layers.Layer):
         return self._requires_length
 
 
-class BiLSTMEncoder1(tf.keras.layers.Layer):
+class BiLSTMEncoderAll1(BiLSTMEncoder1):
 
     def call(self, inputs):
         inputs, lengths = tensor_and_lengths(inputs)
-        rnnout, (fwd_state, backward_state) = tf.nn.bidirectional_dynamic_rnn(self.fwd_rnn, self.bwd_rnn, inputs, sequence_length=lengths, dtype=tf.float32)
+        rnnout, (fwd_state, bwd_state) = tf.nn.bidirectional_dynamic_rnn(self.fwd_rnn, self.bwd_rnn, inputs, sequence_length=lengths, dtype=tf.float32)
         rnnout = tf.concat(axis=2, values=rnnout)
         encoder_state = []
         for i in range(self.layers):
-            h = tf.concat([fw_state[i].h, bw_state[i].h], -1)
-            c = tf.concat([fw_state[i].c, bw_state[i].c], -1)
+            h = tf.concat([fwd_state[i].h, bwd_state[i].h], -1)
+            c = tf.concat([fwd_state[i].c, bwd_state[i].c], -1)
             encoder_state.append(tf.contrib.rnn.LSTMStateTuple(h=h, c=c))
         encoder_state = tuple(encoder_state)
         return self.output_fn(rnnout, encoder_state)
@@ -911,7 +911,7 @@ if get_version(tf) < 2:
     BiLSTMEncoderSequence = BiLSTMEncoderSequence1
     BiLSTMEncoderHidden = BiLSTMEncoderHidden1
     BiLSTMEncoderHiddenContext = BiLSTMEncoderHiddenContext1
-    BiLSTMEncoderAll = None #BiLSTMEncoderAll1
+    BiLSTMEncoderAll = BiLSTMEncoderAll1
     from tensorflow.contrib.crf import crf_decode, crf_log_norm, crf_unary_score, crf_binary_score
     def crf_sequence_score(inputs, tag_indices, sequence_lengths, transition_params):
         """Computes the unnormalized score for a tag sequence.

--- a/python/eight_mile/tf/layers.py
+++ b/python/eight_mile/tf/layers.py
@@ -943,10 +943,12 @@ else:
     LSTMEncoderWithState = LSTMEncoderWithState2
     LSTMEncoderHidden = LSTMEncoderHidden2
     LSTMEncoderHiddenContext = LSTMEncoderHiddenContext2
+    LSTMEncoderAll = LSTMEncoderAll2
     BiLSTMEncoder = BiLSTMEncoder2
     BiLSTMEncoderSequence = BiLSTMEncoderSequence2
     BiLSTMEncoderHidden = BiLSTMEncoderHidden2
     BiLSTMEncoderHiddenContext = BiLSTMEncoderHiddenContext2
+    BiLSTMEncoderAll = BiLSTMEncoderAll2
     from tensorflow_addons.text.crf import crf_decode, crf_sequence_score, crf_log_norm
 
 

--- a/python/eight_mile/tf/layers.py
+++ b/python/eight_mile/tf/layers.py
@@ -964,6 +964,33 @@ class EmbeddingsStack(tf.keras.layers.Layer):
         return self.dsz
 
 
+class WeightTieDense(tf.keras.layers.Layer):
+    def __init__(self, tied, name="weight-tied"):
+        super().__init__(name=name)
+        self.tied = tied
+
+    def build(self, input_shape):
+        emb = getattr(self.tied, 'embedding_layer', None)
+        if emb is not None:
+            self.W = getattr(emb, 'W')
+            super().build(input_shape)
+            return
+        W = getattr(self.tied, 'W', None)
+        if W is not None:
+            self.W = w
+            super().build(input_shape)
+            return
+        self.W = getattr(self.tied, 'kernel')
+        super().build()
+
+    def call(self, inputs):
+        shape = tf.shape(inputs)
+        inputs = tf.reshape(inputs, [-1, shape[-1]])
+        outs = tf.matmul(inputs, self.W, transpose_b=True)
+        new_shape = tf.concat([shape[:-1], tf.constant([-1])], axis=0)
+        return tf.reshape(outs, new_shape)
+
+
 class DenseStack(tf.keras.layers.Layer):
 
     def __init__(self, insz, hsz, activation='relu', pdrop_value=0.5, init=None, name=None, **kwargs):

--- a/python/mead/config/reverse-transformer.json
+++ b/python/mead/config/reverse-transformer.json
@@ -29,7 +29,7 @@
     "model": {
         "encoder_type": "transformer",
         "decoder_type": "transformer",
-        "hsz": 256,
+        "hsz": 128,
         "dropout": 0.1,
         "layers": 4
     },

--- a/python/tests/test_decoders_pytorch.py
+++ b/python/tests/test_decoders_pytorch.py
@@ -33,7 +33,7 @@ def test_rnn_decode_shapes():
     encoder.output = encoder.output
     encoder.src_mask = torch.zeros(batchsz, temporal).byte()
     tgt_embed = LookupTableEmbeddingsModel.create(wv, 'output')
-    decoder = RNNDecoder(tgt_embed, hsz=hsz)
+    decoder = RNNDecoder(tgt_embed, hsz=hsz, tie_weights=False)
     decode_start = torch.full((batchsz, temporal_output), Offsets.GO, dtype=torch.long)
     output = decoder(encoder, decode_start)
     assert output.shape[0] == batchsz
@@ -67,7 +67,7 @@ def test_rnn_attn_decode_shapes():
     encoder.src_mask = torch.zeros(batchsz, temporal).byte()
 
     tgt_embed = LookupTableEmbeddingsModel.create(wv, 'output')
-    decoder = RNNDecoderWithAttn(tgt_embed, hsz=hsz)
+    decoder = RNNDecoderWithAttn(tgt_embed, hsz=hsz, tie_weights=False)
     decode_start = torch.full((batchsz, temporal_output), Offsets.GO, dtype=torch.long)
     output = decoder(encoder, decode_start)
     assert output.shape[0] == batchsz

--- a/python/tests/test_decoders_tensorflow.py
+++ b/python/tests/test_decoders_tensorflow.py
@@ -33,7 +33,7 @@ def test_rnn_decode_shapes():
                       tf.cast(np.random.randn(layers, batchsz, hsz), dtype=tf.float32))
     encoder.src_mask = np.zeros((batchsz, temporal), dtype=np.uint8)
     tgt_embed = LookupTableEmbeddingsModel.create(wv, 'output')
-    decoder = RNNDecoder(tgt_embed, hsz=hsz)
+    decoder = RNNDecoder(tgt_embed, hsz=hsz, tie_weights=False)
     decode_start = np.full((batchsz, temporal_output), Offsets.GO, dtype=np.int64)
     output = decoder(encoder, decode_start)
     assert output.shape[0] == batchsz
@@ -63,7 +63,7 @@ def test_rnn_attn_decode_shapes():
                       tf.cast(np.random.randn(layers, batchsz, hsz), dtype=tf.float32))
     encoder.src_mask = np.zeros((batchsz, temporal), dtype=np.uint8)
     tgt_embed = LookupTableEmbeddingsModel.create(wv, 'output')
-    decoder = RNNDecoderWithAttn(tgt_embed, hsz=hsz, attn_type='sdpx')
+    decoder = RNNDecoderWithAttn(tgt_embed, hsz=hsz, attn_type='sdpx', tie_weights=False)
     decode_start = np.full((batchsz, temporal_output), Offsets.GO, dtype=np.int64)
     output = decoder(encoder, decode_start)
     assert output.shape[0] == batchsz


### PR DESCRIPTION
This PR is adding weight tying back to the tf seq2seq models. This works better than the old version where we are actually tying them instead of just using the other value to init it.

This requires re-writing the decoder as an `tf.keras.layers.Layer` so we can access the weight we will tie in the build, it wouldn't be available otherwise

To Do:

- [x] TF1 Transformer

- [x] TF1 RNN

- [x] TF2 Transformer

- [x] TF2 RNN

- [x] Pyt Transformer

- [x] Pyt RNN