### PR TITLE
chore: moved attention out of mha and re-enabled tests

### DIFF
--- a/python/baseline/tf/seq2seq/decoders/v2.py
+++ b/python/baseline/tf/seq2seq/decoders/v2.py
@@ -248,6 +248,7 @@ class TransformerDecoderWrapper(tf.keras.layers.Layer):
         dsz = self.tgt_embeddings.get_dsz()
         if hsz is None:
             hsz = dsz
+        self.hsz = hsz
 
         self.transformer_decoder = TransformerDecoderStack(d_model=hsz, num_heads=num_heads, pdrop=dropout, scale=scale, layers=layers)
 

--- a/python/baseline/tf/seq2seq/training/eager.py
+++ b/python/baseline/tf/seq2seq/training/eager.py
@@ -245,7 +245,7 @@ def fit_eager(model_params, ts, vs, es=None, **kwargs):
 
     best_metric = 0
     if do_early_stopping:
-        early_stopping_metric = kwargs.get('early_stopping_metric', 'avg_loss')
+        early_stopping_metric = kwargs.get('early_stopping_metric', 'bleu')
         early_stopping_cmp, best_metric = get_metric_cmp(early_stopping_metric, kwargs.get('early_stopping_cmp'))
         patience = kwargs.get('patience', epochs)
         print('Doing early stopping on [%s] with patience [%d]' % (early_stopping_metric, patience))

--- a/python/mead/config/reverse.json
+++ b/python/mead/config/reverse.json
@@ -32,6 +32,7 @@
         "hsz": 64,
         "dropout": 0.5,
         "attn_type": "concat",
+        "tie_weights": false,
         "layers": 2
     },
     "train": {

--- a/python/tests/test_tf_transformer.py
+++ b/python/tests/test_tf_transformer.py
@@ -1,9 +1,9 @@
 import os
 import pytest
-pytest.skip("Transformer tests broken because the attention calculations are inside MHA for now", allow_module_level=True)
 import numpy as np
 tf = pytest.importorskip('tensorflow')
-from baseline.tf.transformer import dot_product_attention, subsequent_mask
+from eight_mile.utils import get_version
+from eight_mile.tf.layers import SeqDotProductAttention, SeqScaledDotProductAttention, subsequent_mask
 
 
 @pytest.fixture(scope="module")
@@ -13,18 +13,13 @@ def set_cpu():
     del os.environ['CUDA_VISIBLE_DEVICES']
 
 
-@pytest.fixture(scope="function")
-def reset():
-    tf.reset_default_graph()
-
-
 @pytest.fixture
 def qkv():
     with tf.device('/cpu:0'):
         dim = np.random.randint(5, 10, size=4)
-        q = tf.random_normal(shape=dim)
-        k = tf.random_normal(shape=dim)
-        v = tf.random_normal(shape=dim)
+        q = tf.random.normal(shape=dim)
+        k = tf.random.normal(shape=dim)
+        v = tf.random.normal(shape=dim)
     return q, k, v
 
 
@@ -32,9 +27,13 @@ def test_attn_value(qkv):
     q, k, v = qkv
     with tf.device('/cpu:0'):
         q = tf.zeros_like(q)
-        res = dot_product_attention(q, k, v)
-        with tf.Session() as sess:
-            res, gold = sess.run([res, v])
+        dot_product_attention = SeqDotProductAttention(0.0)
+        res = dot_product_attention((q, k, v, None))
+        if get_version(tf) < 2:
+            with tf.Session() as sess:
+                res, gold = sess.run([res, v])
+        else:
+            res, gold = res.numpy(), v.numpy()
         B, H, T, _ = q.get_shape().as_list()
         for b in range(B):
             for h in range(H):
@@ -42,6 +41,7 @@ def test_attn_value(qkv):
                     np.testing.assert_allclose(res[b, h, t, :], np.mean(gold, axis=2)[b, h, :], atol=1e-5)
 
 
+@pytest.mark.skipif(get_version(tf) < 2, reason="needs tf2")
 def test_attn_value_seq_mask(qkv):
     q, k, v = qkv
     with tf.device('/cpu:0'):
@@ -50,25 +50,77 @@ def test_attn_value_seq_mask(qkv):
         lens = np.random.randint(1, T, size=B).astype(np.int32)
         tf_lens = tf.constant(lens)
         mask = tf.expand_dims(tf.expand_dims(tf.sequence_mask(tf_lens, T, dtype=tf.float32), 1), 1)
-        res = dot_product_attention(q, k, v, mask=mask)
-        with tf.Session() as sess:
-            res, gold = sess.run([res, v])
+        dot_product_attention = SeqDotProductAttention(0.0)
+        res = dot_product_attention((q, k, v, mask))
+        res, gold = res.numpy(), v.numpy()
         for b in range(B):
             for h in range(H):
                 for t in range(T):
-                    print(b, h, t)
                     np.testing.assert_allclose(res[b, h, t, :], np.mean(gold[:, :, :lens[b], :], axis=2)[b, h, :], atol=1e-5)
 
 
+@pytest.mark.skipif(get_version(tf) < 2, reason="needs tf2")
 def test_attn_value_sub_mask(qkv):
     q, k, v = qkv
     with tf.device('/cpu:0'):
         B, H, T, _ = q.get_shape().as_list()
         q = tf.zeros_like(q)
         mask = subsequent_mask(T)
-        res = dot_product_attention(q, k, v, mask=mask)
-        with tf.Session() as sess:
-            res, gold = sess.run([res, v])
+        dot_product_attention = SeqDotProductAttention(0.0)
+        res = dot_product_attention((q, k, v, mask))
+        res, gold = res.numpy(), v.numpy()
+        for b in range(B):
+            for h in range(H):
+                for t in range(T):
+                    np.testing.assert_allclose(res[b, h, t, :], np.mean(gold[:, :, :t+1, :], axis=2)[b, h, :], atol=1e-5)
+
+
+def test_scaled_attn_value(qkv):
+    q, k, v = qkv
+    with tf.device('/cpu:0'):
+        q = tf.zeros_like(q)
+        scaled_dot_product_attention = SeqScaledDotProductAttention(0.0)
+        res = scaled_dot_product_attention((q, k, v, None))
+        if get_version(tf) < 2:
+            with tf.Session() as sess:
+                res, gold = sess.run([res, v])
+        else:
+            res, gold = res.numpy(), v.numpy()
+        B, H, T, _ = q.get_shape().as_list()
+        for b in range(B):
+            for h in range(H):
+                for t in range(T):
+                    np.testing.assert_allclose(res[b, h, t, :], np.mean(gold, axis=2)[b, h, :], atol=1e-5)
+
+
+@pytest.mark.skipif(get_version(tf) < 2, reason="needs tf2")
+def test_scaled_attn_value_seq_mask(qkv):
+    q, k, v = qkv
+    with tf.device('/cpu:0'):
+        B, H, T, _ = q.get_shape().as_list()
+        q = tf.zeros_like(q)
+        lens = np.random.randint(1, T, size=B).astype(np.int32)
+        tf_lens = tf.constant(lens)
+        mask = tf.expand_dims(tf.expand_dims(tf.sequence_mask(tf_lens, T, dtype=tf.float32), 1), 1)
+        scaled_dot_product_attention = SeqScaledDotProductAttention(0.0)
+        res = scaled_dot_product_attention((q, k, v, mask))
+        res, gold = res.numpy(), v.numpy()
+        for b in range(B):
+            for h in range(H):
+                for t in range(T):
+                    np.testing.assert_allclose(res[b, h, t, :], np.mean(gold[:, :, :lens[b], :], axis=2)[b, h, :], atol=1e-5)
+
+
+@pytest.mark.skipif(get_version(tf) < 2, reason="needs tf2")
+def test_scaled_attn_value_sub_mask(qkv):
+    q, k, v = qkv
+    with tf.device('/cpu:0'):
+        B, H, T, _ = q.get_shape().as_list()
+        q = tf.zeros_like(q)
+        mask = subsequent_mask(T)
+        scaled_dot_product_attention = SeqScaledDotProductAttention(0.0)
+        res = scaled_dot_product_attention((q, k, v, mask))
+        res, gold = res.numpy(), v.numpy()
         for b in range(B):
             for h in range(H):
                 for t in range(T):


### PR DESCRIPTION
This PR pulls the seq attention out of the multiheaded attention models, this will let up pass it in later and makes it easier to test