### PR TITLE
fix: use correct output delimiter when input delim is none in conll converter

### DIFF
--- a/api-examples/bio_to_iobes.py
+++ b/api-examples/bio_to_iobes.py
@@ -10,24 +10,28 @@ parser.add_argument('--valid_file', help='Validation file relative name', defaul
 parser.add_argument('--test_file', help='Test file relative name', default='eng.testb.bio')
 parser.add_argument('--suffix', help='Suffix to append', default='.iobes')
 parser.add_argument("--fields", help="The fields to convert", default=[-1], type=int, nargs="+")
-parser.add_argument("--delim", help="delimiter for the fields", default=' ', type=str)
+parser.add_argument("--delim", help="delimiter for the fields")
 
 args = parser.parse_args()
 
+train_output = args.train_file[:-4] if args.train_file.endswith(".bio") else args.train_file
+valid_output = args.valid_file[:-4] if args.valid_file.endswith(".bio") else args.valid_file
+test_output = args.test_file[:-4] if args.test_file.endswith(".bio") else args.test_file
+
 convert_bio_conll_to_iobes(
-    os.path.join(args.io_dir, args.train_file), os.path.join(args.io_dir, args.train_file[:-4] + args.suffix),
+    os.path.join(args.io_dir, args.train_file), os.path.join(args.io_dir, train_output + args.suffix),
     fields=args.fields,
     delim=args.delim
 )
 
 convert_bio_conll_to_iobes(
-    os.path.join(args.io_dir, args.valid_file), os.path.join(args.io_dir, args.valid_file[:-4] + args.suffix),
+    os.path.join(args.io_dir, args.valid_file), os.path.join(args.io_dir, valid_output + args.suffix),
     fields=args.fields,
     delim=args.delim
 )
 
 convert_bio_conll_to_iobes(
-    os.path.join(args.io_dir, args.test_file), os.path.join(args.io_dir, args.test_file[:-4] + args.suffix),
+    os.path.join(args.io_dir, args.test_file), os.path.join(args.io_dir, test_output + args.suffix),
     fields=args.fields,
     delim=args.delim
 )

--- a/python/baseline/utils.py
+++ b/python/baseline/utils.py
@@ -1086,6 +1086,7 @@ def convert_conll_file(ifile, ofile, convert, fields=[-1], delim=None):
     :param fields: `List[int]` The columns to convert.
     :param delim: `str` The symbol that separates the columns.
     """
+    output_delim = ' ' if delim is None else delim
     conll_length = _sniff_conll_file(ifile, delim)
     fields = set(normalize_indices(fields, conll_length))
     for lines, md in read_conll_sentences_md(ifile, delim=delim):
@@ -1094,7 +1095,7 @@ def convert_conll_file(ifile, ofile, convert, fields=[-1], delim=None):
         if md:
             ofile.write('\n'.join(md) + '\n')
         # Write out the lines
-        ofile.write('\n'.join(delim.join(l).rstrip() for l in lines) + '\n\n')
+        ofile.write('\n'.join(output_delim.join(l).rstrip() for l in lines) + '\n\n')
 
 
 @exporter


### PR DESCRIPTION
The bug that [this PR](https://github.com/dpressel/mead-baseline/pull/403) was fixing was that when the delimiter passed to the conll converter was `None` then when writing the output file it try to join on a None which would fail. The fix above was to pass a delimiter that defaults to space.

This makes the script more annoying to use because it no longer handles both space separated and tab separated conll files transparently. Defaulting the delim to `' '` causes `\t` delimited files to fail. This change leaves the ability to pass a delimiter via command line (it isn't clear how you would pass a tab though) but it defaults it to `None`. It fixes the original bug in the actual converter code itself, if there is no delimiter (which is fine for reading the conll file) it defaults to using a space for the output delimiter. This fixes the same bug without breaking the ability to handle tab separated conll files. 

Also the changes in that PR we removing the last 4 characters from the input file name before adding the suffix (`.iobes`) to the file. This seems to be for removing the `.bio` at the end of a file. This seems overly zealous and is you pass in a file like `example.conll` you get an output file of `example.c.iobes`. This PR updates it so it only does this striping if the file actually ends with `.bio`