### PR TITLE
fix: don't install tf2 for pyt tests

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -65,7 +65,7 @@ jobs:
     - name: Install Baseline
       run: |
         cd python
-        pip install -e .[test,yaml,tf2]
+        pip install -e .[test,yaml]
     - name: Unit Test PyTorch ${{matrix.pyt-version}}
       run: |
         cd python


### PR DESCRIPTION
The pytorch unit tests were failing when run by the github actions because it was trying to install tensorflow_addons in the pytorch containers. This updates removes that.