### PR TITLE
chore stop illegal outputs in the last position of the tf tagger

### DIFF
--- a/python/eight_mile/tf/layers.py
+++ b/python/eight_mile/tf/layers.py
@@ -1493,7 +1493,7 @@ class TaggerGreedyDecoder(tf.keras.layers.Layer):
         if self.inv_mask is not None:
             probv, lengths = TaggerGreedyDecoder.add_go_eos(unary, lengths)
             viterbi, path_scores = crf_decode(probv, self.transitions, lengths)
-            return tf.identity(viterbi[:, 1:], name="best"), path_scores
+            return tf.identity(viterbi[:, 1:-1], name="best"), path_scores
         else:
             return tf.argmax(unary, 2, name="best"), None
 


### PR DESCRIPTION
In IOBES tagging there are only a subset of tags that can be the
last tag in a sequence, for example you can't end on a B or I tag
because it will result in a span that doesn't end with an E. In
our constrained decoding we handle this by having a set of illegal
transition from tags to the EOS symbol. In our pytorch CRF the
transition to EOS is calculated inside. In tf we use the built in
CRF which doesn't include transitions to EOS inside the CRF. We
fix that here by inserting EOS tokens explicitly into the emission
scores.

When I implemented warnigs from the iobes chucking code for illegal tags at the end of a sequence I noticed TF had a lot of these warnings while pytorch had none. I dug in and found that this is because there is no transition to EOS considered for the tf tagger.

This change adds the EOS tags into the tensorflow input so that we don't have these illegal moves anymore. I run a lot of taggers for 1 epoch (for speed reasons) comparing the feature/v2 version and this one and after one epoch this version had an average F1 of 88.1 while the old version had 87.9. I haven't run extensive tests on the differences of models trained to convergence.

I also plan to test how this effects speed before we merge but this is only happens at test time so it might not be a big deal if it slows things down.