### PR TITLE
Feature: add transformer masked LM

### DIFF
--- a/python/baseline/pytorch/lm/model.py
+++ b/python/baseline/pytorch/lm/model.py
@@ -174,3 +174,13 @@ class TransformerLanguageModel(LanguageModelBase):
         T = bth.shape[1]
         mask = subsequent_mask(T).type_as(bth)
         return self.transformer(bth, mask), None
+
+
+@register_model(task='lm', name='transformer-mlm')
+class TransformerMaskedLanguageModel(TransformerLanguageModel):
+    def decode(self, bth, hidden):
+        import numpy as np
+        bth = self.proj_to_dsz(bth)
+        T = bth.shape[1]
+        mask = torch.from_numpy(np.ones((1, 1, T, T)).astype('uint8')).type_as(bth)
+        return self.transformer(bth, mask), None

--- a/python/baseline/tf/lm/model.py
+++ b/python/baseline/tf/lm/model.py
@@ -366,3 +366,18 @@ class TransformerLanguageModel(LanguageModelBase):
             x = tf.layers.dense(x, self.hsz)
         x = transformer_encoder_stack(x, mask, num_heads, self.pdrop_value, scale, layers, activation_type, d_ff=d_ff)
         return tf.reshape(x, [-1, self.hsz])
+
+
+@register_model(task='lm', name='transformer-mlm')
+class TransformerMaskedLanguageModel(LanguageModelBase):
+    def __init__(self):
+        super(TransformerMaskedLanguageModel, self).__init__()
+
+    def decode(self, x, num_heads=4, layers=1, scale=True, activation_type='relu', scope='TransformerEncoder', d_ff=None, **kwargs):
+        T = get_shape_as_list(x)[1]
+        dsz = get_shape_as_list(x)[-1]
+        mask = tf.ones([1, 1, T, T])
+        if dsz != self.hsz:
+            x = tf.layers.dense(x, self.hsz)
+        x = transformer_encoder_stack(x, mask, num_heads, self.pdrop_value, scale, layers, activation_type, d_ff=d_ff)
+        return tf.reshape(x, [-1, self.hsz])


### PR DESCRIPTION
The PR adds transformer masked LM by just replacing the `subsequent_mask` by a matrix with all 1s. Also some small changes were made to `pretrain-transformer-lm.py` to ensure `mlm` option works properly. 