### PR TITLE
fix: a couple of bugs in mlm

### DIFF
--- a/api-examples/pretrain-transformer-lm.py
+++ b/api-examples/pretrain-transformer-lm.py
@@ -675,11 +675,11 @@ def train():
                 labels[~masked_indices] = 0
                 # Of the masked items, mask 80% of them with [MASK]
                 indices_replaced = torch.bernoulli(torch.full(labels.shape, 0.8)).type(torch.bool) & masked_indices
-                inputs[indices_replaced] = mask_value
+                inputs['x'][indices_replaced] = mask_value
                 # Replace 10% of them with random words, rest preserved for auto-encoding
                 indices_random = torch.bernoulli(torch.full(labels.shape, 0.5)).type(torch.bool) & masked_indices & ~indices_replaced
                 random_words = torch.randint(vocab_size, labels.shape, dtype=torch.long, device=args.device)
-                inputs[indices_random] = random_words[indices_random]
+                inputs['x'][indices_random] = random_words[indices_random]
 
             labels = labels.transpose(0, 1).contiguous()
             logits = model(inputs, None)[0].transpose(0, 1).contiguous()
@@ -724,11 +724,11 @@ def train():
                     labels[~masked_indices] = 0
                     # Of the masked items, mask 80% of them with [MASK]
                     indices_replaced = torch.bernoulli(torch.full(labels.shape, 0.8)).type(torch.bool) & masked_indices
-                    inputs[indices_replaced] = mask_value
+                    inputs['x'][indices_replaced] = mask_value
                     # Replace 10% of them with random work
                     indices_random = torch.bernoulli(torch.full(labels.shape, 0.5)).type(torch.bool) & masked_indices & ~indices_replaced
                     random_words = torch.randint(vocab_size, labels.shape, dtype=torch.long, device=args.device)
-                    inputs[indices_random] = random_words[indices_random]
+                    inputs['x'][indices_random] = random_words[indices_random]
 
                 labels = labels.transpose(0, 1).contiguous()
                 logits = model(inputs, None)[0].transpose(0, 1).contiguous()

--- a/api-examples/pretrain-transformer-lm.py
+++ b/api-examples/pretrain-transformer-lm.py
@@ -608,8 +608,8 @@ def train():
                                                       dropout=args.dropout,
                                                       gpu=False,
                                                       num_heads=args.num_heads,
-                                                      layeres=args.num_layers,
-                                                      src_key=['x'], tgt_key=tgt_key)
+                                                      layers=args.num_layers,
+                                                      src_keys=['x'], tgt_key=tgt_key)
     else:
         model = TransformerLanguageModel.create(embeddings,
                                                 hsz=args.d_model,

--- a/api-examples/pretrain-transformer-lm.py
+++ b/api-examples/pretrain-transformer-lm.py
@@ -670,14 +670,14 @@ def train():
             labels = y.to(args.device)
             if args.mlm:
                 # Replace 15% of tokens
-                masked_indices = torch.bernoulli(torch.full(labels.shape, 0.15)).byte()
+                masked_indices = torch.bernoulli(torch.full(labels.shape, 0.15)).type(torch.bool)
                 # Anything not masked is 0 so no loss
                 labels[~masked_indices] = 0
                 # Of the masked items, mask 80% of them with [MASK]
-                indices_replaced = torch.bernoulli(torch.full(labels.shape, 0.8)).byte() & masked_indices
+                indices_replaced = torch.bernoulli(torch.full(labels.shape, 0.8)).type(torch.bool) & masked_indices
                 inputs[indices_replaced] = mask_value
                 # Replace 10% of them with random words, rest preserved for auto-encoding
-                indices_random = torch.bernoulli(torch.full(labels.shape, 0.5)).byte() & masked_indices & ~indices_replaced
+                indices_random = torch.bernoulli(torch.full(labels.shape, 0.5)).type(torch.bool) & masked_indices & ~indices_replaced
                 random_words = torch.randint(vocab_size, labels.shape, dtype=torch.long, device=args.device)
                 inputs[indices_random] = random_words[indices_random]
 
@@ -719,14 +719,14 @@ def train():
 
                 if args.mlm:
                     # Replace 15% of tokens
-                    masked_indices = torch.bernoulli(torch.full(labels.shape, 0.15)).byte()
+                    masked_indices = torch.bernoulli(torch.full(labels.shape, 0.15)).type(torch.bool)
                     # Anything not masked is 0 so no loss
                     labels[~masked_indices] = 0
                     # Of the masked items, mask 80% of them with [MASK]
-                    indices_replaced = torch.bernoulli(torch.full(labels.shape, 0.8)).byte() & masked_indices
+                    indices_replaced = torch.bernoulli(torch.full(labels.shape, 0.8)).type(torch.bool) & masked_indices
                     inputs[indices_replaced] = mask_value
                     # Replace 10% of them with random work
-                    indices_random = torch.bernoulli(torch.full(labels.shape, 0.5)).byte() & masked_indices & ~indices_replaced
+                    indices_random = torch.bernoulli(torch.full(labels.shape, 0.5)).type(torch.bool) & masked_indices & ~indices_replaced
                     random_words = torch.randint(vocab_size, labels.shape, dtype=torch.long, device=args.device)
                     inputs[indices_random] = random_words[indices_random]
 


### PR DESCRIPTION
When running `pretrain-transformer-lm.py` with `torch==1.2.0`, one gets hundreds of warnings like 
```UserWarning: indexing with dtype torch.uint8 is now deprecated, please use a dtype torch.bool instead.```
which overwhelm the job log. This PR fixes it.  