### PR TITLE
fix: Nan from the log in the log of manual cross entropy

### DIFF
--- a/python/eight_mile/tf/layers.py
+++ b/python/eight_mile/tf/layers.py
@@ -1423,15 +1423,13 @@ class TaggerGreedyDecoder(tf.keras.layers.Layer):
         return self.A
 
     def neg_log_loss(self, unary, tags, lengths):
-        # Cross entropy loss
-        # This should be replaced with a SequenceLoss layer like in pytorch
         mask = tf.sequence_mask(lengths, tf.shape(unary)[1])
-        cross_entropy = tf.one_hot(tags, self.num_tags, axis=-1) * tf.math.log(tf.nn.softmax(unary))
-        cross_entropy = -tf.reduce_sum(cross_entropy, axis=2)
+        cross_entropy = tf.nn.sparse_softmax_cross_entropy_with_logits(
+            labels=tags, logits=unary
+        )
         cross_entropy *= tf.cast(mask, tf.float32)
         cross_entropy = tf.reduce_sum(cross_entropy, axis=1)
-        all_loss = tf.reduce_mean(cross_entropy, name="loss")
-        return all_loss
+        return tf.reduce_mean(cross_entropy, name="loss")
 
     def call(self, inputs, training=False, mask=None):
 


### PR DESCRIPTION
This PR fixes a `NaN` found in training by a user. The `NaN` was being introduced via the `tf.math.log` in the manual cross entropy calculation. The location was found via adding `tf.debugging.check_numerics` to the code and training with the same config/data the user had.

This fix was tested by training the same config on the new branch. Training finished without any `NaN`s using this branch.