### PR TITLE
fix: load addons from files directly to allow for same names as baseline addons

### DIFF
--- a/python/baseline/utils.py
+++ b/python/baseline/utils.py
@@ -614,8 +614,12 @@ def import_user_module(module_name):
     addon_path = os.path.dirname(os.path.realpath(addons.__file__))
     _idempotent_append(addon_path, sys.path)
     if module_name.endswith(".py"):
-        module_name, module_dir = _parse_module_as_path(module_name)
-        _idempotent_append(module_dir, sys.path)
+        module_path = module_name
+        module_name, _ = _parse_module_as_path(module_path)
+        spec = importlib.util.spec_from_file_location(module_name, module_path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
     mod = importlib.import_module(module_name)
     return mod
 


### PR DESCRIPTION
Right now the way we load addons from files is we take the path and generate the directory and the file name (without .py) to turn it into a module. We then add the dir to the `sys.path` so we can import the module by name. The problem is that is you have a file that has the same name as an addon that baseline already defines it will load the baseline addon rather than yours (because the addons directory is added to the sys.path before your file's path is added).

This PR updates the mechanism used to import files as addons, it instead uses the actual import lib functions to read and load the file itself instead of our hack.

Tested by loading the demolib module from file i copied outside of the addons dir instead of from addons.