### PR TITLE
fix: move to tensor scatter update nd for onnx

### DIFF
--- a/python/eight_mile/pytorch/embeddings.py
+++ b/python/eight_mile/pytorch/embeddings.py
@@ -45,7 +45,7 @@ class LookupTableEmbeddings(PyTorchEmbeddings):
         self.finetune = kwargs.get('finetune', True)
         weights = kwargs.get('weights')
         if weights is None:
-            self.embeddings = nn.Embedding(self.vsz, self.dsz, padding_idx=0)
+            self.embeddings = nn.Embedding(self.vsz, self.dsz, padding_idx=Offsets.PAD)
         else:
             self.embeddings = pytorch_embedding(weights, self.finetune)
             # This makes sure that if you init with a weight and not vsz it will still be available

--- a/python/eight_mile/pytorch/embeddings.py
+++ b/python/eight_mile/pytorch/embeddings.py
@@ -207,7 +207,7 @@ class LearnedPositionalMixin(PositionalMixin):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.mxlen = int(kwargs.get('mxlen', 512))
-        self.pos_embeddings = nn.Embedding(self.mxlen, self.get_dsz(), padding_idx=0)
+        self.pos_embeddings = nn.Embedding(self.mxlen, self.get_dsz())
 
     def positional(self, length):
         return self.pos_embeddings(

--- a/python/eight_mile/pytorch/layers.py
+++ b/python/eight_mile/pytorch/layers.py
@@ -1420,7 +1420,7 @@ class LangSequenceModel(nn.Module):
 
 
 def pytorch_embedding(weights, finetune=True):
-    lut = nn.Embedding(weights.shape[0], weights.shape[1], padding_idx=0)
+    lut = nn.Embedding(weights.shape[0], weights.shape[1], padding_idx=Offsets.PAD)
     del lut.weight
     lut.weight = nn.Parameter(torch.FloatTensor(weights),
                               requires_grad=finetune)

--- a/python/eight_mile/tf/embeddings.py
+++ b/python/eight_mile/tf/embeddings.py
@@ -124,9 +124,9 @@ class LookupTableEmbeddings(TensorFlowEmbeddings):
         :return: The sub-graph output
         """
         self.x = x
-        e0 = tf.compat.v1.scatter_update(
+        e0 = tf.tensor_scatter_nd_update(
             self.W,
-            tf.constant(0, dtype=tf.int32, shape=[1]),
+            tf.constant(0, dtype=tf.int32, shape=[1, 1]),
             tf.zeros(shape=[1, self.dsz])
         )
         with tf.control_dependencies([e0]):
@@ -337,9 +337,7 @@ class LearnedPositionalMixin(PositionalMixin):
         super().build(input_shape)
 
     def positional(self, length):
-        e0 = tf.compat.v1.scatter_update(self.pos, tf.constant(0, dtype=tf.int32, shape=[1]), tf.zeros(shape=[1, self.get_dsz()]))
-        with tf.control_dependencies([e0]):
-            return tf.expand_dims(tf.nn.embedding_lookup(self.pos, tf.range(length, dtype=tf.int32)), 0)
+        return tf.expand_dims(tf.nn.embedding_lookup(self.pos, tf.range(length, dtype=tf.int32)), 0)
 
 
 class PositionalLookupTableEmbeddings(SinusoidalPositionalMixin, LookupTableEmbeddings):

--- a/python/eight_mile/tf/embeddings.py
+++ b/python/eight_mile/tf/embeddings.py
@@ -126,7 +126,7 @@ class LookupTableEmbeddings(TensorFlowEmbeddings):
         self.x = x
         e0 = tf.tensor_scatter_nd_update(
             self.W,
-            tf.constant(0, dtype=tf.int32, shape=[1, 1]),
+            tf.constant(Offsets.PAD, dtype=tf.int32, shape=[1, 1]),
             tf.zeros(shape=[1, self.dsz])
         )
         with tf.control_dependencies([e0]):


### PR DESCRIPTION
When exporting to onnx you need to freeze the tensorflow graph before you give it to onnx. Among other things this results in the `tf.Variable`s getting converted to `tf.Constant`s. This causes problems with our call to `tf.scatter_update` because that only works on variables. This change uses `tf.tensor_scatter_update` so that it works on both tensors and variables. This should allow for training and exporting with onnx without having to do graph surgery during the onnx export.

Here we can see that the first index is force to zero like normal.

```
In [8]: weights = m2.model.sess.run('conv_model/embed_pool_stack_model/embeddings_stack/word/word/TensorScatterUpdate:
   ...: 0')                                                                                                           

In [9]: weights                                                                                                       
Out[9]: 
array([[ 0.        ,  0.        ,  0.        , ...,  0.        ,
         0.        ,  0.        ],
       [ 0.23561554,  0.0668358 ,  0.12596287, ..., -0.06482406,
         0.08465774, -0.15594955],
       [-0.07322488, -0.09636456,  0.18026018, ..., -0.04915399,
         0.05599565, -0.04521407],
       ...,
       [ 0.09450348,  0.0402012 , -0.02134273, ...,  0.15959035,
        -0.15341455, -0.09791269],
       [ 0.20427342,  0.05767576, -0.0052578 , ..., -0.10133192,
         0.2222662 ,  0.2168913 ],
       [-0.00085181,  0.050082  ,  0.16496918, ...,  0.06464937,
         0.24544643, -0.14694127]], dtype=float32)

```

I also trained sst2 models for both tf1 and tf2 and they have normal looking performance.

I also exported a model and compared scores between the local and remote ones, they match.

There is also a small change to the learned embeddings, basically it doesn't make sense to force the `0th` index to be all zeros because this is just the first position, it isn't a pad like it is for normal word embeddings.