### PR TITLE
chore: add tooling to go back to IOB if need be

### DIFF
--- a/api-examples/tag-text.py
+++ b/api-examples/tag-text.py
@@ -21,6 +21,7 @@ parser.add_argument('--export_mapping', help='mapping between features and the f
                                                          'request, eg: token:word ner:ner. This should match with the '
                                                          '`exporter_field` definition in the mead config',
                     default=[], nargs='+')
+parser.add_argument("--batchsz", default=64)
 args = parser.parse_args()
 
 
@@ -60,7 +61,9 @@ else:
 
 m = bl.TaggerService.load(args.model, backend=args.backend, remote=args.remote,
                           name=args.name, preproc=args.preproc, device=args.device)
-for sen in m.predict(texts, export_mapping=create_export_mapping(args.export_mapping)):
-    for word_tag in sen:
-        print("{} {}".format(word_tag['text'], word_tag['label']))
-    print()
+batched = [texts[i:i+args.batchsz] for i in range(0, len(texts), args.batchsz)]
+for texts in batched:
+    for sen in m.predict(texts, export_mapping=create_export_mapping(args.export_mapping)):
+        for word_tag in sen:
+            print("{} {}".format(word_tag['text'], word_tag['label']))
+        print()

--- a/python/tests/test_iobes.py
+++ b/python/tests/test_iobes.py
@@ -4,8 +4,11 @@ from baseline.utils import (
     to_chunks,
     to_chunks_iobes,
     convert_iob_to_bio,
-    convert_iobes_to_bio,
+    convert_iob_to_iobes,
+    convert_bio_to_iob,
     convert_bio_to_iobes,
+    convert_iobes_to_bio,
+    convert_iobes_to_iob,
 )
 
 # Most of these tests follow this general format. A random sequence of entity spans are generated,
@@ -96,6 +99,14 @@ def test_iob_bio():
     for _ in range(100):
         test()
 
+def test_bio_iob():
+    def test():
+        spans = generate_spans()
+        bio = generate_bio(spans)
+        gold_iob = generate_iob()
+        iob = convert_bio_to_iob(bio)
+        assert iob == gold_iob
+
 
 def test_bio_iobes():
     def test():
@@ -121,6 +132,37 @@ def test_iobes_bio():
         test()
 
 
+def test_iobes_iob():
+    def test():
+        spans = generate_spans()
+        iobes = generate_iobes(spans)
+        gold_iob = generate_iob(spans)
+        iob = convert_iobes_to_iob(iobes)
+        assert iob == gold_iob
+
+
+def test_iob_bio_cycle():
+    def test():
+        spans = generate_spans()
+        gold_iob = generate_iob(spans)
+        res = convert_bio_to_iob(convert_iob_to_bio(gold_iob))
+        assert res == gold_iob
+
+    for _ in range(100):
+        test()
+
+
+def test_bio_iob_cycle():
+    def test():
+        spans = generate_spans()
+        gold_bio = generate_bio(spans)
+        res = convert_iob_to_bio(convert_bio_to_iob(gold_bio))
+        assert res == gold_bio
+
+    for _ in range(100):
+        test()
+
+
 def test_iobes_bio_cycle():
     def test():
         spans = generate_spans()
@@ -138,6 +180,28 @@ def test_bio_iobes_cycle():
         gold_bio = generate_bio(spans)
         res = convert_iobes_to_bio(convert_bio_to_iobes(gold_bio))
         assert res == gold_bio
+
+    for _ in range(100):
+        test()
+
+
+def test_iobes_iob_cycle():
+    def test():
+        spans = generate_spans()
+        gold_iobes = generate_iobes(spans)
+        res = convert_iob_to_iobes(convert_iobes_to_iob(gold_iobes))
+        assert res == gold_iobes
+
+    for _ in range(100):
+        test()
+
+
+def test_iob_iobes_cycle():
+    def test():
+        spans = generate_spans()
+        gold_iob = generate_iob(spans)
+        res = convert_iobes_to_iob(convert_iob_to_iobes(gold_iob))
+        assert res == gold_iob
 
     for _ in range(100):
         test()
@@ -235,6 +299,20 @@ def test_iob_bio_i_after_o():
     in_ = ['O', 'I-X', 'O']
     gold = ['O', 'B-X', 'O']
     res = convert_iob_to_bio(in_)
+    assert res == gold
+
+
+def test_bio_iob_b_after_diff():
+    in_ = ['O', 'B-X', 'B-Y', 'O']
+    gold = ['O', 'I-X', 'I-Y', 'O']
+    res = convert_bio_to_iob(in_)
+    assert res == gold
+
+
+def test_bio_iob_b_after_same():
+    in_ = ['O', 'B-X', 'B-X', 'O']
+    gold = ['O', 'I-X', 'B-X', 'O']
+    res = convert_bio_to_iob(in_)
     assert res == gold
 
 


### PR DESCRIPTION
This PR adds the ability to go from iobes to iob (as well as bio to iob) for completeness sake.

It also makes it possible to run tag text with batches to allow for processing large datasets withit.

It also adds some `@exporter`s so we can call some of these functions with

```python
import baseline as bl
bl.read_label_first_data(...)
```

instead of having to import it from `baseline.utils`