### PR TITLE
chore: refactor remote model handling

### DIFF
--- a/python/baseline/services.py
+++ b/python/baseline/services.py
@@ -168,8 +168,8 @@ class Service(object):
         return_labels = bool(assets['metadata']['return_labels'])
         version = kwargs.get('version')
 
-        if backend not in {'tf', 'pytorch'}:
-            raise ValueError("only Tensorflow and Pytorch are currently supported for remote Services")
+        if backend not in {'tf'}:
+            raise ValueError("only Tensorflow is currently supported for remote Services")
         import_user_module('baseline.{}.remote'.format(backend))
         exp_type = kwargs.get('remote_type')
         if exp_type is None:

--- a/python/baseline/services.py
+++ b/python/baseline/services.py
@@ -245,7 +245,7 @@ class ClassifierService(Service):
 class EmbeddingsService(Service):
     @classmethod
     def task_name(cls):
-        return 'servable_embeddings'
+        return 'servable-embeddings'
 
     @classmethod
     def signature_name(cls):

--- a/python/baseline/tf/remote.py
+++ b/python/baseline/tf/remote.py
@@ -1,9 +1,20 @@
 import numpy as np
-from baseline.remote import RemoteModelREST, RemoteModelGRPC, register_remote
+from baseline.remote import (
+    RemoteModelREST,
+    RemoteModelGRPC,
+    register_remote,
+    RemoteRESTClassifier,
+    RemoteRESTTagger,
+    RemoteRESTSeq2Seq,
+    RemoteRESTEmbeddings,
+    RemoteGRPCClassifier,
+    RemoteGRPCTagger,
+    RemoteGRPCSeq2Seq,
+    RemoteGRPCEmbeddings,
+)
 
 
-@register_remote('http')
-class RemoteModelRESTTensorFlow(RemoteModelREST):
+class RemoteRESTTensorFlowMixin(RemoteModelREST):
 
     def create_request(self, examples):
         inputs = {}
@@ -16,13 +27,37 @@ class RemoteModelRESTTensorFlow(RemoteModelREST):
         request = {'signature_name': self.signature, 'inputs': inputs}
         return request
 
+@register_remote('http-classify')
+class RemoteRESTTensorFlowClassifier(RemoteRESTTensorFlowMixin, RemoteRESTClassifier): pass
+
+@register_remote('http-tagger')
+class RemoteRESTTensorFlowTagger(RemoteRESTTensorFlowMixin, RemoteRESTTagger): pass
+
+@register_remote('http-seq2seq')
+class RemoteRESTTensorFlowSeq2Seq(RemoteRESTTensorFlowMixin, RemoteRESTSeq2Seq): pass
+
+@register_remote('http-embeddings')
+class RemoteRESTTensorFlowEmbeddings(RemoteRESTTensorFlowMixin, RemoteRESTEmbeddings): pass
+
 
 @register_remote('grpc')
-class RemoteModelGRPCTensorFlow(RemoteModelGRPC): pass
+class RemoteGRPCTensorFlowMixin(RemoteModelGRPC): pass
+
+@register_remote('grpc-classify')
+class RemoteGRPCTensorFlowClassifier(RemoteGRPCTensorFlowMixin, RemoteGRPCClassifier): pass
+
+@register_remote('grpc-tagger')
+class RemoteGRPCTensorFlowTagger(RemoteGRPCTensorFlowMixin, RemoteGRPCTagger): pass
+
+@register_remote('grpc-seq2seq')
+class RemoteGRPCTensorFlowSeq2Seq(RemoteGRPCTensorFlowMixin, RemoteGRPCSeq2Seq): pass
+
+@register_remote('grpc-embeddings')
+class RemoteGRPCTensorFlowEmbeddings(RemoteGRPCTensorFlowMixin, RemoteGRPCEmbeddings): pass
 
 
 @register_remote('grpc-preproc')
-class RemoteModelGRPCTensorFlowPreproc(RemoteModelGRPCTensorFlow):
+class RemoteGRPCTensorFlowPreprocMixin(RemoteModelGRPC):
 
     def create_request(self, examples):
         # TODO: Remove TF dependency client side
@@ -47,9 +82,21 @@ class RemoteModelGRPCTensorFlowPreproc(RemoteModelGRPCTensorFlow):
                 )
         return request
 
+@register_remote('grpc-preproc-classify')
+class RemoteGRPCTensorFlowPreprocClassifier(RemoteGRPCTensorFlowPreprocMixin, RemoteGRPCClassifier): pass
+
+@register_remote('grpc-preproc-tagger')
+class RemoteGRPCTensorFlowPreprocTagger(RemoteGRPCTensorFlowPreprocMixin, RemoteGRPCTagger): pass
+
+@register_remote('grpc-preproc-seq2seq')
+class RemoteGRPCTensorFlowPreprocSeq2Seq(RemoteGRPCTensorFlowPreprocMixin, RemoteGRPCSeq2Seq): pass
+
+@register_remote('grpc-preproc-embeddings')
+class RemoteGRPCTensorFlowPreprocEmbeddings(RemoteGRPCTensorFlowPreprocMixin, RemoteGRPCEmbeddings): pass
+
 
 @register_remote('http-preproc')
-class RemoteModelRESTTensorFlowPreproc(RemoteModelRESTTensorFlow):
+class RemoteRESTTensorFlowPreprocMixin(RemoteModelREST):
 
     def create_request(self, examples):
         inputs = {}
@@ -64,3 +111,15 @@ class RemoteModelRESTTensorFlowPreproc(RemoteModelRESTTensorFlow):
                 else:
                     inputs[feature] = examples[feature]
         return {'signature_name': self.signature, 'inputs': inputs}
+
+@register_remote('http-preproc-classify')
+class RemoteRESTTensorFlowPreprocClassifier(RemoteRESTTensorFlowPreprocMixin, RemoteRESTClassifier): pass
+
+@register_remote('http-preproc-tagger')
+class RemoteRESTTensorFlowPreprocTagger(RemoteRESTTensorFlowPreprocMixin, RemoteRESTTagger): pass
+
+@register_remote('http-preproc-seq2seq')
+class RemoteRESTTensorFlowPreprocSeq2Seq(RemoteRESTTensorFlowPreprocMixin, RemoteRESTSeq2Seq): pass
+
+@register_remote('http-preproc-embeddings')
+class RemoteRESTTensorFlowPreprocEmbeddings(RemoteRESTTensorFlowPreprocMixin, RemoteRESTEmbeddings): pass

--- a/python/baseline/tf/remote.py
+++ b/python/baseline/tf/remote.py
@@ -36,7 +36,7 @@ class RemoteRESTTensorFlowTagger(RemoteRESTTensorFlowMixin, RemoteRESTTagger): p
 @register_remote('http-seq2seq')
 class RemoteRESTTensorFlowSeq2Seq(RemoteRESTTensorFlowMixin, RemoteRESTSeq2Seq): pass
 
-@register_remote('http-embeddings')
+@register_remote('http-servable-embeddings')
 class RemoteRESTTensorFlowEmbeddings(RemoteRESTTensorFlowMixin, RemoteRESTEmbeddings): pass
 
 
@@ -52,7 +52,7 @@ class RemoteGRPCTensorFlowTagger(RemoteGRPCTensorFlowMixin, RemoteGRPCTagger): p
 @register_remote('grpc-seq2seq')
 class RemoteGRPCTensorFlowSeq2Seq(RemoteGRPCTensorFlowMixin, RemoteGRPCSeq2Seq): pass
 
-@register_remote('grpc-embeddings')
+@register_remote('grpc-servable-embeddings')
 class RemoteGRPCTensorFlowEmbeddings(RemoteGRPCTensorFlowMixin, RemoteGRPCEmbeddings): pass
 
 
@@ -91,7 +91,7 @@ class RemoteGRPCTensorFlowPreprocTagger(RemoteGRPCTensorFlowPreprocMixin, Remote
 @register_remote('grpc-preproc-seq2seq')
 class RemoteGRPCTensorFlowPreprocSeq2Seq(RemoteGRPCTensorFlowPreprocMixin, RemoteGRPCSeq2Seq): pass
 
-@register_remote('grpc-preproc-embeddings')
+@register_remote('grpc-preproc-servable-embeddings')
 class RemoteGRPCTensorFlowPreprocEmbeddings(RemoteGRPCTensorFlowPreprocMixin, RemoteGRPCEmbeddings): pass
 
 
@@ -121,5 +121,5 @@ class RemoteRESTTensorFlowPreprocTagger(RemoteRESTTensorFlowPreprocMixin, Remote
 @register_remote('http-preproc-seq2seq')
 class RemoteRESTTensorFlowPreprocSeq2Seq(RemoteRESTTensorFlowPreprocMixin, RemoteRESTSeq2Seq): pass
 
-@register_remote('http-preproc-embeddings')
+@register_remote('http-preproc-servable-embeddings')
 class RemoteRESTTensorFlowPreprocEmbeddings(RemoteRESTTensorFlowPreprocMixin, RemoteRESTEmbeddings): pass


### PR DESCRIPTION
This refactor creates multiple remote model object for different tasks. This lets us subclass the remote model which would let you change how the response from the remote model is handled via registration.

fixes https://github.com/dpressel/mead-baseline/issues/419