### PR TITLE
Fix pretrain transformer lm

### DIFF
--- a/api-examples/pretrain-transformer-lm.py
+++ b/api-examples/pretrain-transformer-lm.py
@@ -266,7 +266,7 @@ class TensorDatasetReaderBase(object):
         self.num_words = {}
 
     def build_vocab(self, files):
-        vocabs = {k: Counter() for k in self.vectorizers.keys()}
+        vocabs = {k: Counter({'[CLS]': 1}) for k in self.vectorizers.keys()}
 
         for file in files:
             if file is None:
@@ -396,16 +396,24 @@ def load_embed_and_vocab(token_type, reader, dataset, dataset_key, d_model, cach
         logger.info("Loading cached preprocessing info [%s]", preproc_cache)
         preproc_data = torch.load(preproc_cache)
         vectorizers_mxlen = preproc_data['vectorizers_mxlen']
-        for k, vectorizer in reader.vectorizers.items():
-            vectorizer.max_seen = vectorizers_mxlen[k]
-
+        if token_type == 'chars':
+            char_vectorizer = reader.vectorizers['x']
+            tok_vectorizer = reader.vectorizers['y']
+            char_vectorizer.max_seen_tok, char_vectorizer.max_seen_char = vectorizers_mxlen['x']
+            tok_vectorizer.max_seen = vectorizers_mxlen['y']
+        else:
+            reader.vectorizers['x'].max_seen = vectorizers_mxlen['x']
     else:
         vocab_sources = [dataset['train_file'], dataset['valid_file']]
         vocabs = reader.build_vocab(vocab_sources)
         valid_num_words = reader.num_words[dataset['valid_file']]
-        vectorizers_maxlen = {}
-        for k, vectorizer in reader.vectorizers.items():
-            vectorizers_maxlen[k] = vectorizer.max_seen
+        vectorizers_mxlen = {}
+        if token_type == 'chars':
+            vectorizers_mxlen['x'] = (reader.vectorizers['x'].max_seen_tok, reader.vectorizers['x'].max_seen_char)
+            vectorizers_mxlen['y'] = reader.vectorizers['y'].max_seen
+        else:
+            vectorizers_mxlen['x'] = reader.vectorizers['x'].max_seen
+
         logger.info("Read vocabulary")
         embeddings = {}
 
@@ -431,7 +439,7 @@ def load_embed_and_vocab(token_type, reader, dataset, dataset_key, d_model, cach
             embeddings['x'] = x_embedding['embeddings']
 
         preproc_data = {'vocabs': vocabs, 'embeddings': embeddings, 'valid_num_words': valid_num_words,
-                        'tgt_key': tgt_key, 'vectorizers_mxlen': vectorizers_maxlen}
+                        'tgt_key': tgt_key, 'vectorizers_mxlen': vectorizers_mxlen}
         logger.info("Saving preprocessing info [%s]", preproc_cache)
         torch.save(preproc_data, preproc_cache)
     return preproc_data

--- a/api-examples/pretrain-transformer-lm.py
+++ b/api-examples/pretrain-transformer-lm.py
@@ -204,7 +204,7 @@ class WordPieceVectorizer1D(AbstractVectorizer):
         handle = kwargs.get('embed_file')
         custom_vocab = kwargs.get('vocab_file')
         if custom_vocab is None:
-            self.tokenizer = BertTokenizer.from_pretrained(handle, do_lower_case=False)
+            self.tokenizer = BertTokenizer.from_pretrained(handle, do_lower_case=True)
         else:
             special_tokens = kwargs.get('special_tokens')
             never_split = ('[UNK]', '[SEP]', '[PAD]', '[CLS]', '[MASK]') + special_tokens

--- a/python/addons/embed_tlm_pytorch.py
+++ b/python/addons/embed_tlm_pytorch.py
@@ -12,6 +12,7 @@ from baseline.pytorch.embeddings import PyTorchEmbeddings
 from baseline.vectorizers import register_vectorizer, AbstractVectorizer, Token1DVectorizer, Char2DVectorizer
 from baseline.pytorch.torchy import *
 
+
 @register_vectorizer(name='tlm-token1d')
 class Token1DVectorizerCLS(Token1DVectorizer):
     """Override token1d vectorizer to generate [CLS] for pooling"""
@@ -70,10 +71,10 @@ class Char2DVectorizerCLS(Char2DVectorizer):
                 continue
             if i == self.mxlen:
                 i -= 1
-                for j in range(self.mxwlen):
-                    vec2d[i, j] = 0
-                vec2d[i, 0] = CLS
+                vec2d[i, :] = CLS  # fill last word with all CLS to avoid smearing by max pool
                 break
+            elif atom == CLS:
+                vec2d[i, :] = CLS  # fill that word with all CLS to avoid smearing by max pool
             if atom == EOW:
                 i += 1
                 j = 0
@@ -88,6 +89,7 @@ class Char2DVectorizerCLS(Char2DVectorizer):
                 j += 1
         valid_length = i
         return vec2d, valid_length
+
 
 @register_vectorizer(name='tlm-wordpiece')
 class WordPieceVectorizer1D(AbstractVectorizer):
@@ -266,7 +268,8 @@ class TransformerLMEmbeddings(PyTorchEmbeddings):
         self.d_model = int(kwargs.get('dsz', kwargs.get('d_model', 410)))
         d_ff = int(kwargs.get('d_ff', 2100))
         x_embedding = PositionalLookupTableEmbeddings('pos', vsz=self.vsz, dsz=self.d_model)
-        self.init_embed({'x': x_embedding})
+        self.dsz = self.init_embed({'x': x_embedding})
+        self.proj_to_dsz = pytorch_linear(self.dsz, self.d_model) if self.dsz != self.d_model else _identity
         self.transformer = TransformerEncoderStack(num_heads, d_model=self.d_model, pdrop=pdrop, scale=True, layers=layers, d_ff=d_ff)
         self.mlm = kwargs.get('mlm', False)
 
@@ -305,11 +308,13 @@ class TransformerLMEmbeddings(PyTorchEmbeddings):
             return subsequent_mask(nctx)
 
     def forward(self, x):
-        # the following line masks out the attention to padding tokens
+        # the following line masks out the attention to padding tokens: Bx1x1xT
         input_mask = torch.zeros(x.shape, device=x.device, dtype=torch.long).masked_fill(x != 0, 1).unsqueeze(1).unsqueeze(1)
-        # the following line builds mask depending on whether it is a causal lm or masked lm
-        input_mask = input_mask & self._model_mask(x.shape[1]).type_as(input_mask)
+        # the following line builds mask depending on whether it is a causal lm or masked lm: 1x1xTxT
+        model_mask = self._model_mask(x.shape[1]).type_as(input_mask)
+        input_mask = input_mask & model_mask  # Bx1XTxT
         embedding = self.embed(x)
+        embedding = self.proj_to_dsz(embedding)
         transformer_output = self.transformer(embedding, mask=input_mask)
         return self.get_output(x, transformer_output)
 
@@ -331,6 +336,7 @@ class TransformerLMEmbeddings(PyTorchEmbeddings):
         unmatch = c.load_state_dict(torch.load(embeddings), strict=False)
         if unmatch.missing_keys or len(unmatch.unexpected_keys) > 2:
             print("Warning: Embedding doesn't match with the checkpoint being loaded.")
+            print(f"missing keys: {unmatch.missing_keys}\n unexpected keys: {unmatch.unexpected_keys}")
         return c
 
 
@@ -340,6 +346,10 @@ def _mean_pool(_, embeddings):
 
 def _max_pool(_, embeddings):
     return torch.max(embeddings, 1, False)[0]
+
+
+def _identity(x):
+    return x
 
 
 @register_embeddings(name='tlm-words-embed-pooled')
@@ -362,3 +372,72 @@ class TransformerLMPooledEmbeddings(TransformerLMEmbeddings):
 
     def get_output(self, inputs, z):
         return self.pooling_op(inputs, z)
+
+
+@register_embeddings(name='tlm-chars-embed-pooled')
+class TransformerLMCharEmbeddings(TransformerLMEmbeddings):
+    """Use PositionalCharConvEmbeddings instead of PositionalLookupTableEmbeddings as an LM using chars"""
+
+    def __init__(self, name, **kwargs):
+        from baseline.pytorch.embeddings import PositionalCharConvEmbeddings
+        X_CHAR_EMBEDDINGS = {
+            "dsz": 16,
+            "wsz": 128,
+            "embed_type": "positional-char-conv",
+            "keep_unused": True,
+            "cfiltsz": [
+                [1, 32],
+                [2, 32],
+                [3, 64],
+                [4, 128],
+                [5, 256],
+                [6, 512],
+                [7, 1024]
+            ],
+            "gating": "highway",
+            "num_gates": 2,
+            "projsz": 512
+        }
+        super(TransformerLMEmbeddings, self).__init__(name)
+        self.vocab = read_json(kwargs.get('vocab_file'), strict=True)
+        self.cls_index = self.vocab['[CLS]']
+        self.vsz = len(self.vocab)
+        layers = int(kwargs.get('layers', 18))
+        num_heads = int(kwargs.get('num_heads', 10))
+        pdrop = kwargs.get('dropout', 0.1)
+        self.d_model = int(kwargs.get('dsz', kwargs.get('d_model', 410)))
+        d_ff = int(kwargs.get('d_ff', 2100))
+        x_embedding = PositionalCharConvEmbeddings('pcc', vsz=self.vsz, **X_CHAR_EMBEDDINGS)
+        self.dsz = self.init_embed({'x': x_embedding})
+        self.proj_to_dsz = pytorch_linear(self.dsz, self.d_model) if self.dsz != self.d_model else _identity
+        self.init_embed({'x': x_embedding})
+        self.transformer = TransformerEncoderStack(num_heads, d_model=self.d_model, pdrop=pdrop, scale=True, layers=layers, d_ff=d_ff)
+        self.mlm = kwargs.get('mlm', False)
+
+        pooling = kwargs.get('pooling', 'cls')
+        if pooling == 'max':
+            self.pooling_op = _max_pool
+        elif pooling == 'mean':
+            self.pooling_op = _mean_pool
+        else:
+            self.pooling_op = self._cls_pool
+
+    def _cls_pool(self, inputs, tensor):
+        # here the inputs is BxTxW, the tensor (transformer output) is BxTxH
+        pooled = tensor[inputs[:, :, 0] == self.cls_index]
+        return pooled
+
+    def get_output(self, inputs, z):
+        return self.pooling_op(inputs, z)
+
+    def forward(self, x):
+        # for char x has dim: Bx1x1xTxW
+        input_mask = torch.zeros(x.shape, device=x.device, dtype=torch.long).masked_fill(x != 0, 1).unsqueeze(1).unsqueeze(1)
+        # Bx1x1xTxW -> Bx1x1xT. mask only need to work on T dimension
+        input_mask = input_mask[:, :, :, :, 0]
+        model_mask = self._model_mask(x.shape[1]).type_as(input_mask)  # 1x1xTxT
+        input_mask = input_mask & model_mask  # Bx1XTxT
+        embedding = self.embed(x)
+        embedding = self.proj_to_dsz(embedding)
+        transformer_output = self.transformer(embedding, mask=input_mask)
+        return self.get_output(x, transformer_output)

--- a/python/addons/embed_tlm_pytorch.py
+++ b/python/addons/embed_tlm_pytorch.py
@@ -183,7 +183,7 @@ class TransformerLMEmbeddings(PyTorchEmbeddings):
     """
     def __init__(self, name, **kwargs):
         super(TransformerLMEmbeddings, self).__init__(name)
-        self.vocab = read_json(kwargs.get('vocab_file'))
+        self.vocab = read_json(kwargs.get('vocab_file'), strict=True)
         self.cls_index = self.vocab['[CLS]']
         self.vsz = len(self.vocab)
         layers = int(kwargs.get('layers', 18))

--- a/python/baseline/pytorch/embeddings.py
+++ b/python/baseline/pytorch/embeddings.py
@@ -148,7 +148,7 @@ class PositionalCharConvEmbeddings(CharConvEmbeddings):
     def forward(self, xch):
         """Add a positional encoding to the embedding, followed by dropout
 
-        :param x: The temporal signal in, to which the positional embeddings are applied
+        :param xch: The temporal signal in, to which the positional embeddings are applied
         :return: Embedded output
         """
         xch = super(PositionalCharConvEmbeddings, self).forward(xch) * math.sqrt(self.get_dsz())

--- a/python/baseline/pytorch/lm/model.py
+++ b/python/baseline/pytorch/lm/model.py
@@ -170,12 +170,12 @@ class TransformerLanguageModel(LanguageModelBase):
         self.apply(self.init_layer_weights)
 
     def create_mask(self, bth):
-        bth = self.proj_to_dsz(bth)
         T = bth.shape[1]
         mask = subsequent_mask(T).type_as(bth)
         return mask
 
     def decode(self, bth, hidden):
+        bth = self.proj_to_dsz(bth)
         mask = self.create_mask(bth)
         return self.transformer(bth, mask), None
 
@@ -184,7 +184,6 @@ class TransformerLanguageModel(LanguageModelBase):
 class TransformerMaskedLanguageModel(TransformerLanguageModel):
 
     def create_mask(self, bth):
-        bth = self.proj_to_dsz(bth)
         T = bth.shape[1]
         mask = torch.ones((1, 1, T, T)).type_as(bth)
         return mask


### PR DESCRIPTION
This PR made the following changes:
- fix the `proj_to_dsz` bug: in `TransformerLanguageModel`, when the embedding dim is different from the self-attention dim, the model does a projection between them. I put this projection in `create_mask` by mistake in a previous PR. This PR fixes it, and adds this projection in fine-tuning code as well. 
- add `[CLS]` to the vocab when pretraining using `word` or `chars`, and override corresponding vectorizers in the addon to generate `[CLS]` token. 
- add new subclass so that we can fine-tune model pretrained with `chars`. 