### PR TITLE
fix: update the undo of the log_softmax activation

### DIFF
--- a/python/baseline/pytorch/classify/model.py
+++ b/python/baseline/pytorch/classify/model.py
@@ -89,7 +89,6 @@ class ClassifierModelBase(nn.Module, ClassifierModel):
 
         with torch.no_grad():
             probs = self(examples).exp()
-            probs.div_(torch.sum(probs))
             results = []
             batchsz = probs.size(0)
             for b in range(batchsz):


### PR DESCRIPTION
I'm not sure what was happened here but the way the pytorch classifier was undoing the `log_softmax` to get softmax scores looked wrong. To turn `log_softmax` into `softmax` you only need to do the `.exp` you don't need to re-normalize the scores. Also the way these scores are normalized seems wrong, it might be a hold over from the dev/test data is only ever batch size of `1` but this sum is summing the whole tensor not over a batch. This should be division by `torch.sum(probs, dim=1)` to properly renormalize. Regardless the normalization is not needed because all you actually need is the `.exp`