### PR TITLE
fix: make the EmbeddingsStack have a .keys() like a dict

### DIFF
--- a/layers/eight_mile/pytorch/layers.py
+++ b/layers/eight_mile/pytorch/layers.py
@@ -935,7 +935,7 @@ class EmbeddingsStack(nn.Module):
         return self.dropout(word_embeddings)
 
     def keys(self):
-        return self._keys()
+        return self._keys
 
 
 class DenseStack(nn.Module):


### PR DESCRIPTION
Fix, you can't call a list