### PR TITLE
feat: add a test for the all loss

### DIFF
--- a/api-examples/pretrain-seq2seq.py
+++ b/api-examples/pretrain-seq2seq.py
@@ -293,11 +293,11 @@ class TensorWordDatasetReader(TensorDatasetReaderBase):
         self.use_subword = use_subword
 
         if self.use_subword == 'bpe':
-            vectorizer = BPEVectorizer1D(model_file=model_file, vocab_file=vocab_file)
+            vectorizer = BPEVectorizer1D(model_file=model_file, vocab_file=vocab_file, mxlen=nctx)
         elif self.use_subword == 'wordpiece':
-            vectorizer = WordPieceVectorizer1D(embed_file=model_file)
+            vectorizer = WordPieceVectorizer1D(embed_file=model_file, mxlen=nctx)
         else:
-            vectorizer = Token1DVectorizer(transform_fn=baseline.lowercase)
+            vectorizer = Token1DVectorizer(transform_fn=baseline.lowercase, mxlen=nctx)
         super().__init__(nctx, vectorizer)
 
     def build_vocab(self, files):


### PR DESCRIPTION
This PR adds some tests to make sure the all loss is calculated correctly. It re-implements the loss in both log space and normal space with explicit loops over the batch of xs and the batch of ys in numpy. The results are within normal tolerances (`1e-6`).

```
$ pytest pretrain-paired.py 
============================================================================================================ test session starts =============================================================================================================
platform linux -- Python 3.6.7, pytest-5.2.1, py-1.8.0, pluggy-0.13.0
rootdir: /home/blester/dev/work/baseline
plugins: forked-1.1.1
collected 1 item                                                                                                                                                                                                                             

pretrain-paired.py .                                                                                                                                                                                                                   [100%]

============================================================================================================= 1 passed in 5.72s ==============================================================================================================
```

I also added some comments on how the loss worked and the how the batched implementation works. There is also some changes to the vectorizer that I have been using locally but never made their way upstream