### PR TITLE
Update layers to be more consistent with shapes, add shape tests

### DIFF
--- a/baseline/reader.py
+++ b/baseline/reader.py
@@ -316,7 +316,7 @@ class SeqPredictReader(object):
 
         vocabs = _filter_vocab(vocabs, kwargs.get('min_f', {}))
         base_offset = len(self.label2index)
-        labels.pop(Offsets.VALUES[Offsets.PAD])
+        labels.pop(Offsets.VALUES[Offsets.PAD], None)
         for i, k in enumerate(labels.keys()):
             self.label2index[k] = i + base_offset
         if pre_vocabs:

--- a/baseline/tf/seq2seq/encoders/v1.py
+++ b/baseline/tf/seq2seq/encoders/v1.py
@@ -34,7 +34,7 @@ class RNNEncoder(EncoderBase):
 
     def __init__(self, name='encoder', pdrop=0.1, hsz=650, rnntype='blstm', layers=1, vdrop=False, scope='RNNEncoder', residual=False, create_src_mask=True, **kwargs):
         super().__init__(name=name)
-        Encoder = BiLSTMEncoderAll if rnntype == 'blstm' else LSTMEncoderALL
+        Encoder = BiLSTMEncoderAllLegacy if rnntype == 'blstm' else LSTMEncoderAllLegacy
         self.rnn = Encoder(None, hsz, layers, pdrop, vdrop, name=scope)
         self.residual = residual
         self.src_mask_fn = _make_src_mask if create_src_mask is True else lambda x, y: None

--- a/layers/eight_mile/tf/layers.py
+++ b/layers/eight_mile/tf/layers.py
@@ -923,11 +923,6 @@ class LSTMEncoderWithState1(LSTMEncoder1):
         return self.rnn.zero_state(batchsz, tf.float32)
 
     def call(self, inputs):
-        """
-
-        :param inputs: The input at this timestep and the previous hidden unit or `None`
-        :return: Raw TensorFlow output
-        """
         inputs, hidden = inputs
         rnnout, hidden = tf.nn.dynamic_rnn(self.rnn, inputs, initial_state=hidden, dtype=tf.float32)
         return rnnout, hidden  # (hidden[-1].h, hidden[-1].c)

--- a/layers/eight_mile/tf/layers.py
+++ b/layers/eight_mile/tf/layers.py
@@ -922,13 +922,13 @@ class LSTMEncoderWithState1(LSTMEncoder1):
         """
         return self.rnn.zero_state(batchsz, tf.float32)
 
-    def call(self, input_and_prev_h):
+    def call(self, inputs):
         """
 
-        :param input_and_prev_h: The input at this timestep and the previous hidden unit or `None`
+        :param inputs: The input at this timestep and the previous hidden unit or `None`
         :return: Raw TensorFlow output
         """
-        inputs, hidden = input_and_prev_h
+        inputs, hidden = inputs
         rnnout, hidden = tf.nn.dynamic_rnn(self.rnn, inputs, initial_state=hidden, dtype=tf.float32)
         return rnnout, hidden  # (hidden[-1].h, hidden[-1].c)
 

--- a/layers/eight_mile/tf/layers.py
+++ b/layers/eight_mile/tf/layers.py
@@ -2569,13 +2569,16 @@ class CRF(tf.keras.layers.Layer):
     def neg_log_loss(self, unary, tags, lengths):
         """Neg Log Loss with a Batched CRF.
 
-        :param unary: torch.FloatTensor: [T, B, N] or [B, T, N]
-        :param tags: torch.LongTensor: [T, B] or [B, T]
-        :param lengths: torch.LongTensor: [B]
+        :param unary: unary outputs of length `[B, S, N]`
+        :param tags: tag truth values `[B, T]`
+        :param lengths: tensor of shape `[B]`
 
-        :return: torch.FloatTensor: [B]
+        :return: Tensor of shape `[B]`
         """
-        fwd_score = self((unary, tf.cast(lengths, tf.int32)), training=True)
+        lengths = tf.cast(lengths, tf.int32)
+        max_length = tf.reduce_max(lengths)
+        fwd_score = self((unary, lengths), training=True)
+        tags = tags[:, :max_length]
         gold_score = self.score_sentence(unary, tags, lengths)
         log_likelihood = gold_score - fwd_score
         return -tf.reduce_mean(log_likelihood)

--- a/layers/eight_mile/tf/optz.py
+++ b/layers/eight_mile/tf/optz.py
@@ -269,7 +269,7 @@ class AdamWOptimizer(tf.compat.v1.train.Optimizer):
 
     def __init__(self, learning_rate, weight_decay=0.0, beta_1=0.9, beta_2=0.999, epsilon=1e-6, name="AdamWOptimizer"):
         """Constructs a AdamWOptimizer."""
-        super(AdamWOptimizer, self).__init__(False, name)
+        super().__init__(False, name)
 
         self.learning_rate = learning_rate
         self.weight_decay = weight_decay
@@ -294,19 +294,19 @@ class AdamWOptimizer(tf.compat.v1.train.Optimizer):
 
             param_name = self._get_variable_name(param.name)
 
-            m = tf.get_variable(
+            m = tf.compat.v1.get_variable(
                 name=param_name + "/adam_m",
                 shape=param.shape.as_list(),
                 dtype=tf.float32,
                 trainable=False,
-                initializer=tf.zeros_initializer(),
+                initializer=tf.compat.v1.zeros_initializer(),
             )
-            v = tf.get_variable(
+            v = tf.compat.v1.get_variable(
                 name=param_name + "/adam_v",
                 shape=param.shape.as_list(),
                 dtype=tf.float32,
                 trainable=False,
-                initializer=tf.zeros_initializer(),
+                initializer=tf.compat.v1.zeros_initializer(),
             )
 
             # Standard Adam update.

--- a/mead/tasks.py
+++ b/mead/tasks.py
@@ -744,8 +744,9 @@ class EncoderDecoderTask(Task):
 
     def _reorganize_params(self):
         train_params = self.config_params['train']
-        train_params['batchsz'] = self.config_params['batchsz']
-        train_params['test_batchsz'] = self.config_params.get('test_batchsz', 1)
+        train_params['batchsz'] = train_params.get('batchsz', self.config_params.get('batchsz'))
+        train_params['test_batchsz'] = train_params.get('test_batchsz',
+                                                        self.config_params.get('test_batchsz', 1))
 
         self.config_params['model']["unif"] = self.config_params["unif"]
         model = self.config_params['model']

--- a/tests/test_pytorch_layers.py
+++ b/tests/test_pytorch_layers.py
@@ -7,19 +7,19 @@ from eight_mile.pytorch.layers import *
 
 C = 10
 B = 50
-S = 20
+T = 20
 H = 8
 L = 2
 
 @pytest.fixture
 def lengths():
-    lengths = torch.randint(1, S, size=(B,)).long()
+    lengths = torch.randint(1, T, size=(B,)).long()
     return lengths
 
 
 @pytest.fixture
 def logits(lengths):
-    logits = torch.rand(B, S, C)
+    logits = torch.rand(B, T, C)
     for i, l in enumerate(lengths):
         logits[i, l:, :] = 0
     return logits
@@ -27,14 +27,14 @@ def logits(lengths):
 
 @pytest.fixture
 def labels(lengths):
-    lab = torch.randint(1, C, size=(B, S)).long()
+    lab = torch.randint(1, C, size=(B, T)).long()
     for i, l in enumerate(lengths):
         lab[i, l:] = 0
     return lab
 
 @pytest.fixture
-def rnn_input(lengths):
-    hidden = torch.rand(B, S, C)
+def encoder_input(lengths):
+    hidden = torch.rand(B, T, C)
     lengths, perm_idx = lengths.sort(0, descending=True)
     return hidden[perm_idx], lengths
 
@@ -64,95 +64,114 @@ def test_token_sequence_loss(logits, labels, lengths):
     np.testing.assert_allclose(res.numpy(), gold.numpy(), rtol=1e-6)
 
 
-def test_gru_sequence_shapes(rnn_input):
+def test_gru_sequence_shapes(encoder_input):
 
     z = GRUEncoderSequence(C, H, L, batch_first=True)
-    out = z(rnn_input)
-    seq_len = torch.max(rnn_input[1]).item()
+    out = z(encoder_input)
+    seq_len = torch.max(encoder_input[1]).item()
     np.testing.assert_equal(out.shape, (B, seq_len, H))
 
     z = BiGRUEncoderSequence(C, H, L, batch_first=True)
-    out = z(rnn_input)
+    out = z(encoder_input)
     np.testing.assert_equal(out.shape, (B, seq_len, H))
 
 
 
-def test_gru_hidden_shapes(rnn_input):
+def test_gru_hidden_shapes(encoder_input):
 
     z = GRUEncoderHidden(C, H, L, batch_first=True)
-    out = z(rnn_input)
+    out = z(encoder_input)
     np.testing.assert_equal(out.shape, (B, H))
 
     z = BiGRUEncoderHidden(C, H, L, batch_first=True)
-    out = z(rnn_input)
+    out = z(encoder_input)
     np.testing.assert_equal(out.shape, (B, H))
 
 
-def test_gru_all_shapes(rnn_input):
+def test_gru_all_shapes(encoder_input):
 
-    seq_len = torch.max(rnn_input[1]).item()
+    seq_len = torch.max(encoder_input[1]).item()
     z = GRUEncoderAll(C, H, L, batch_first=True)
-    seq, s = z(rnn_input)
+    seq, s = z(encoder_input)
     np.testing.assert_equal(seq.shape, (B, seq_len, H))
     np.testing.assert_equal(s.shape, (L, B, H))
 
     z = BiGRUEncoderAll(C, H, L, batch_first=True)
-    seq, s = z(rnn_input)
+    seq, s = z(encoder_input)
     np.testing.assert_equal(seq.shape, (B, seq_len, H))
     np.testing.assert_equal(s.shape, (L, B, H))
 
 
-def test_lstm_sequence_shapes(rnn_input):
+def test_lstm_sequence_shapes(encoder_input):
 
     z = LSTMEncoderSequence(C, H, L, batch_first=True)
-    out = z(rnn_input)
-    seq_len = torch.max(rnn_input[1]).item()
+    out = z(encoder_input)
+    seq_len = torch.max(encoder_input[1]).item()
     np.testing.assert_equal(out.shape, (B, seq_len, H))
 
     z = BiLSTMEncoderSequence(C, H, L, batch_first=True)
-    out = z(rnn_input)
+    out = z(encoder_input)
     np.testing.assert_equal(out.shape, (B, seq_len, H))
 
 
-def test_lstm_hidden_shapes(rnn_input):
+def test_lstm_hidden_shapes(encoder_input):
 
     z = LSTMEncoderHidden(C, H, L, batch_first=True)
-    out = z(rnn_input)
+    out = z(encoder_input)
     np.testing.assert_equal(out.shape, (B, H))
 
     z = BiLSTMEncoderHidden(C, H, L, batch_first=True)
-    out = z(rnn_input)
+    out = z(encoder_input)
     np.testing.assert_equal(out.shape, (B, H))
 
 
 
-def test_lstm_shc_shapes(rnn_input):
+def test_lstm_shc_shapes(encoder_input):
 
-    seq_len = torch.max(rnn_input[1]).item()
+    seq_len = torch.max(encoder_input[1]).item()
     z = LSTMEncoderSequenceHiddenContext(C, H, L, batch_first=True)
-    seq, (s1, s2) = z(rnn_input)
+    seq, (s1, s2) = z(encoder_input)
     np.testing.assert_equal(seq.shape, (B, seq_len, H))
     np.testing.assert_equal(s1.shape, (B, H))
     np.testing.assert_equal(s2.shape, (B, H))
 
     z = BiLSTMEncoderSequenceHiddenContext(C, H, L, batch_first=True)
-    seq, (s1, s2) = z(rnn_input)
+    seq, (s1, s2) = z(encoder_input)
     np.testing.assert_equal(seq.shape, (B, seq_len, H))
     np.testing.assert_equal(s1.shape, (B, H))
     np.testing.assert_equal(s2.shape, (B, H))
 
 
-def test_lstm_all_shapes(rnn_input):
+def test_lstm_all_shapes(encoder_input):
 
-    seq_len = torch.max(rnn_input[1]).item()
+    seq_len = torch.max(encoder_input[1]).item()
     z = LSTMEncoderAll(C, H, L, batch_first=True)
-    seq, (s1, s2) = z(rnn_input)
+    seq, (s1, s2) = z(encoder_input)
     np.testing.assert_equal(seq.shape, (B, seq_len, H))
     np.testing.assert_equal(s1.shape, (L, B, H))
     np.testing.assert_equal(s2.shape, (L, B, H))
 
     z = BiLSTMEncoderAll(C, H, L, batch_first=True)
-    seq, (s1, s2) = z(rnn_input)
+    seq, (s1, s2) = z(encoder_input)
     np.testing.assert_equal(seq.shape, (B, seq_len, H))
     np.testing.assert_equal(s1.shape, (L, B, H))
     np.testing.assert_equal(s2.shape, (L, B, H))
+
+
+def test_conv_shapes(encoder_input):
+
+    z = WithoutLength(ConvEncoder(C, H, 4))
+    seq = z(encoder_input)
+    np.testing.assert_equal(seq.shape, (B, T, H))
+
+    z = WithoutLength(ConvEncoder(C, H, 3))
+    seq = z(encoder_input)
+    np.testing.assert_equal(seq.shape, (B, T, H))
+
+    z = WithoutLength(ConvEncoderStack(C, H, 3, nlayers=3))
+    seq = z(encoder_input)
+    np.testing.assert_equal(seq.shape, (B, T, H))
+
+    z = WithoutLength(ConvEncoderStack(C, H, 4, nlayers=3))
+    seq = z(encoder_input)
+    np.testing.assert_equal(seq.shape, (B, T, H))

--- a/tests/test_pytorch_layers.py
+++ b/tests/test_pytorch_layers.py
@@ -3,12 +3,13 @@ import numpy as np
 
 torch = pytest.importorskip("torch")
 from eight_mile.utils import Offsets
-from eight_mile.pytorch.layers import SequenceLoss
+from eight_mile.pytorch.layers import *
 
 C = 10
 B = 50
 S = 20
-
+H = 8
+L = 2
 
 @pytest.fixture
 def lengths():
@@ -31,6 +32,11 @@ def labels(lengths):
         lab[i, l:] = 0
     return lab
 
+@pytest.fixture
+def rnn_input(lengths):
+    hidden = torch.rand(B, S, C)
+    lengths, perm_idx = lengths.sort(0, descending=True)
+    return hidden[perm_idx], lengths
 
 def raw_loss(logits, labels, loss):
     B, T, H = logits.size()
@@ -56,3 +62,97 @@ def test_token_sequence_loss(logits, labels, lengths):
     crit = SequenceLoss(LossFn=loss, avg="token")
     res = crit(logits, labels)
     np.testing.assert_allclose(res.numpy(), gold.numpy(), rtol=1e-6)
+
+
+def test_gru_sequence_shapes(rnn_input):
+
+    z = GRUEncoderSequence(C, H, L, batch_first=True)
+    out = z(rnn_input)
+    seq_len = torch.max(rnn_input[1]).item()
+    np.testing.assert_equal(out.shape, (B, seq_len, H))
+
+    z = BiGRUEncoderSequence(C, H, L, batch_first=True)
+    out = z(rnn_input)
+    np.testing.assert_equal(out.shape, (B, seq_len, H))
+
+
+
+def test_gru_hidden_shapes(rnn_input):
+
+    z = GRUEncoderHidden(C, H, L, batch_first=True)
+    out = z(rnn_input)
+    np.testing.assert_equal(out.shape, (B, H))
+
+    z = BiGRUEncoderHidden(C, H, L, batch_first=True)
+    out = z(rnn_input)
+    np.testing.assert_equal(out.shape, (B, H))
+
+
+def test_gru_all_shapes(rnn_input):
+
+    seq_len = torch.max(rnn_input[1]).item()
+    z = GRUEncoderAll(C, H, L, batch_first=True)
+    seq, s = z(rnn_input)
+    np.testing.assert_equal(seq.shape, (B, seq_len, H))
+    np.testing.assert_equal(s.shape, (L, B, H))
+
+    z = BiGRUEncoderAll(C, H, L, batch_first=True)
+    seq, s = z(rnn_input)
+    np.testing.assert_equal(seq.shape, (B, seq_len, H))
+    np.testing.assert_equal(s.shape, (L, B, H))
+
+
+def test_lstm_sequence_shapes(rnn_input):
+
+    z = LSTMEncoderSequence(C, H, L, batch_first=True)
+    out = z(rnn_input)
+    seq_len = torch.max(rnn_input[1]).item()
+    np.testing.assert_equal(out.shape, (B, seq_len, H))
+
+    z = BiLSTMEncoderSequence(C, H, L, batch_first=True)
+    out = z(rnn_input)
+    np.testing.assert_equal(out.shape, (B, seq_len, H))
+
+
+def test_lstm_hidden_shapes(rnn_input):
+
+    z = LSTMEncoderHidden(C, H, L, batch_first=True)
+    out = z(rnn_input)
+    np.testing.assert_equal(out.shape, (B, H))
+
+    z = BiLSTMEncoderHidden(C, H, L, batch_first=True)
+    out = z(rnn_input)
+    np.testing.assert_equal(out.shape, (B, H))
+
+
+
+def test_lstm_shc_shapes(rnn_input):
+
+    seq_len = torch.max(rnn_input[1]).item()
+    z = LSTMEncoderSequenceHiddenContext(C, H, L, batch_first=True)
+    seq, (s1, s2) = z(rnn_input)
+    np.testing.assert_equal(seq.shape, (B, seq_len, H))
+    np.testing.assert_equal(s1.shape, (B, H))
+    np.testing.assert_equal(s2.shape, (B, H))
+
+    z = BiLSTMEncoderSequenceHiddenContext(C, H, L, batch_first=True)
+    seq, (s1, s2) = z(rnn_input)
+    np.testing.assert_equal(seq.shape, (B, seq_len, H))
+    np.testing.assert_equal(s1.shape, (B, H))
+    np.testing.assert_equal(s2.shape, (B, H))
+
+
+def test_lstm_all_shapes(rnn_input):
+
+    seq_len = torch.max(rnn_input[1]).item()
+    z = LSTMEncoderAll(C, H, L, batch_first=True)
+    seq, (s1, s2) = z(rnn_input)
+    np.testing.assert_equal(seq.shape, (B, seq_len, H))
+    np.testing.assert_equal(s1.shape, (L, B, H))
+    np.testing.assert_equal(s2.shape, (L, B, H))
+
+    z = BiLSTMEncoderAll(C, H, L, batch_first=True)
+    seq, (s1, s2) = z(rnn_input)
+    np.testing.assert_equal(seq.shape, (B, seq_len, H))
+    np.testing.assert_equal(s1.shape, (L, B, H))
+    np.testing.assert_equal(s2.shape, (L, B, H))


### PR DESCRIPTION
First, I added GRUs but only using Keras layers on the TF side. 
These arent that commonly used and just implementing it one way shouldnt really be a compatibility concern.

The PyTorch and TF were different in their output shapes.  PyTorch's RNN output is limited to the max length found in the batch, which may not always be the actual tensor width.

Using Keras LSTM/GRU this was failing because we could generate a sequence mask that was shorter than the tensor width.  In TF 1.x the output would always be the size of the input.

I added some shape/layer tests for common encoders.  This helped find inconsistencies in API.

Also, I found a mismatch in the TF All in 1.x vs Keras.
The legacy was not packaging the hidden layers consistently with the other versions.
This is all right in theory, as we can just use whatever and pass it downstream, but in practice, we were looking for drop in replacement and so this caused things like shape tests to fail.

During discussions on proper behavior for RNNs, we decided to make them consistent with PyTorch,
which means that we now have to trim the inputs according to the max sequence length for all
TF versions.

We also decided that it would be nice to make the conv layers guaranteed to not exceed the temporal length of the input tensor.  This is accounted for by replacing the `padding=kernel_size//2` with a `Conv1DSame` which expands the tensor to the normal pad on the front and  1 px less on the backend of the tensor when its an even kernel.  This makes the output shape guaranteed to match the input size.  Constant zero padding is applied.

The conv encoder stack number of layers param was different from the RNNs and was ordered on the other side of `pdrop` so I changed those to be consistent with the ordering of the RNN stacks.

I also made the default conv encoders `[B, T, H]` with an option `hidden_last=True`.  The encoder stacks only do this on input and output to keep a stack of layers internally consistent as `[B, H, T]` for convolution efficiency.