### PR TITLE
fix: import gzip library now that downloader is a baseline util

### DIFF
--- a/baseline/utils.py
+++ b/baseline/utils.py
@@ -3,6 +3,7 @@ import os
 import re
 import sys
 import json
+import gzip
 import pickle
 import hashlib
 import logging


### PR DESCRIPTION
When the data downloading code was moved into `baseline.utils` from `mead.downloader` some of the imports like `gzip` were not copied over