### PR TITLE
fix: labels dont normally have pad

### DIFF
--- a/baseline/reader.py
+++ b/baseline/reader.py
@@ -316,7 +316,7 @@ class SeqPredictReader(object):
 
         vocabs = _filter_vocab(vocabs, kwargs.get('min_f', {}))
         base_offset = len(self.label2index)
-        labels.pop(Offsets.VALUES[Offsets.PAD])
+        labels.pop(Offsets.VALUES[Offsets.PAD], None)
         for i, k in enumerate(labels.keys()):
             self.label2index[k] = i + base_offset
         if pre_vocabs:


### PR DESCRIPTION
I think this pop was introduced for the bpe tagger where a special label vectorizer will output pad labels for the tokens that are not the start of a bpe word. The problem is that for normal sequence tagging tasks the pad symbol isn't normally in the label space so this pop causes and error. This should fix it

I tested this training a normal tagger but have been able to test with a bpe tagger because we don't have a config for running one