### PR TITLE
feat: a safe way to infer tensor lengths

### DIFF
--- a/layers/eight_mile/tf/layers.py
+++ b/layers/eight_mile/tf/layers.py
@@ -51,6 +51,21 @@ def TRAIN_FLAG():
     return BASELINE_TF_TRAIN_FLAG
 
 
+def infer_lengths(tensor, axis=1):
+    """Infer the lengths of an input based on the idea the Offsets.PAD was used as the padding token.
+
+    :param tensor: The data to infer the length of, should be either [B, T] or [T, B]
+    :param axis: The dimension which contains the sequential signal
+
+    :returns: A Tensor of shape `[B]` that has the lengths for example item in the batch
+    """
+    if len(tensor.get_shape()) != 2:
+        raise ValueError(f"infer_lengths only works with tensors with two dims right now, got {len(tensor.get_shape())}")
+    offsets = tf.expand_dims(tf.range(1, tf.shape(tensor)[axis] + 1, dtype=tensor.dtype), 1 - axis)
+    non_pad_loc = tf.cast(tf.not_equal(tensor, Offsets.PAD), tensor.dtype)
+    return tf.argmax(non_pad_loc * offsets, axis=axis) + 1
+
+
 # Mapped
 def tensor_and_lengths(inputs):
     if isinstance(inputs, (list, tuple)):

--- a/tests/test_layers_tf1.py
+++ b/tests/test_layers_tf1.py
@@ -1,0 +1,64 @@
+import pytest
+import numpy as np
+from eight_mile.utils import get_version
+tf = pytest.importorskip('tensorflow')
+pytestmark = pytest.mark.skipif(get_version(tf) >= 2, reason="TF2.X")
+from eight_mile.utils import Offsets
+from eight_mile.tf.layers import infer_lengths
+
+B = 10
+T = 15
+TRIALS = 100
+
+@pytest.fixture
+def lengths():
+    lengths = np.random.randint(1, T, size=(B,)).astype(np.int32)
+    return lengths
+
+
+def generate_data_with_zeros(lengths):
+    data = np.random.randint(1, 100, (len(lengths), np.max(lengths))).astype(np.int32)
+    for i, length in enumerate(lengths):
+        data[i, length:] = 0
+        if length // 2 > 0:
+            extra_zeros = np.random.randint(0, length.item() - 1, size=((length // 2).item(),))
+            data[i, extra_zeros] = 0
+    return data
+
+
+def test_infer_lengths(lengths):
+    def test():
+        tf.compat.v1.reset_default_graph()
+        with tf.compat.v1.Session() as sess:
+            data = generate_data_with_zeros(lengths)
+            data = tf.constant(data)
+            infered = infer_lengths(data, axis=1)
+            infered = sess.run(infered)
+        np.testing.assert_allclose(infered, lengths)
+
+    for _ in range(TRIALS):
+        test()
+
+
+def test_infer_lengths_t_first(lengths):
+    def test():
+        tf.compat.v1.reset_default_graph()
+        with tf.compat.v1.Session() as sess:
+            data = generate_data_with_zeros(lengths)
+            print(data)
+            data = tf.constant(data)
+            data = tf.transpose(data)
+            print(data)
+            infered = infer_lengths(data, axis=0)
+            infered = sess.run(infered)
+            print(infered)
+        np.testing.assert_allclose(infered, lengths)
+
+    for _ in range(TRIALS):
+        test()
+
+
+def test_infer_lengths_multi_dim():
+    data = tf.random.uniform((10, 11, 12))
+    with pytest.raises(ValueError):
+        infer_lengths(data, axis=1)

--- a/tests/test_layers_tf2.py
+++ b/tests/test_layers_tf2.py
@@ -1,0 +1,55 @@
+import pytest
+import numpy as np
+from eight_mile.utils import get_version
+tf = pytest.importorskip('tensorflow')
+pytestmark = pytest.mark.skipif(get_version(tf) < 2, reason="TF1.X")
+from eight_mile.utils import Offsets
+from eight_mile.tf.layers import infer_lengths
+
+B = 10
+T = 15
+TRIALS = 100
+
+@pytest.fixture
+def lengths():
+    lengths = np.random.randint(1, T, size=(B,)).astype(np.int32)
+    return lengths
+
+
+def generate_data_with_zeros(lengths):
+    data = np.random.randint(1, 100, (len(lengths), np.max(lengths))).astype(np.int32)
+    for i, length in enumerate(lengths):
+        data[i, length:] = 0
+        if length // 2 > 0:
+            extra_zeros = np.random.randint(0, length.item() - 1, size=((length // 2).item(),))
+            data[i, extra_zeros] = 0
+    return data
+
+
+def test_infer_lengths(lengths):
+    def test():
+        data = generate_data_with_zeros(lengths)
+        data = tf.convert_to_tensor(data)
+        infered = infer_lengths(data, axis=1)
+        np.testing.assert_allclose(infered.numpy(), lengths)
+
+    for _ in range(TRIALS):
+        test()
+
+
+def test_infer_lengths_t_first(lengths):
+    def test():
+        data = generate_data_with_zeros(lengths)
+        data = tf.convert_to_tensor(data)
+        data = tf.transpose(data)
+        infered = infer_lengths(data, axis=0)
+        np.testing.assert_allclose(infered.numpy(), lengths)
+
+    for _ in range(TRIALS):
+        test()
+
+
+def test_infer_lengths_multi_dim():
+    data = tf.random.uniform((10, 11, 12))
+    with pytest.raises(ValueError):
+        infer_lengths(data, axis=1)


### PR DESCRIPTION
Based on the comment here https://github.com/dpressel/mead-baseline/blob/509453992838a524f6442d4e0f07a034390ae1f7/layers/eight_mile/pytorch/layers.py#L70

This adds functions that infer the length of an example but they are some what safer than just summing the number of non `<PAD>` elements because they find the last non padded element and us that +1 as the length

I didn't actually make the change to always return the lengths tho because I didn't know what repercussions that would have