### PR TITLE
fix: use an output delimiter when the input is None

### DIFF
--- a/layers/eight_mile/utils.py
+++ b/layers/eight_mile/utils.py
@@ -1029,6 +1029,7 @@ def convert_conll_file(ifile, ofile, convert, fields=[-1], delim=None):
     :param fields: `List[int]` The columns to convert.
     :param delim: `str` The symbol that separates the columns.
     """
+    output_delim = ' ' if delim is None else delim
     conll_length = sniff_conll_file(ifile, delim)
     fields = set(normalize_indices(fields, conll_length))
     for lines, md in read_conll_sentences_md(ifile, delim=delim):
@@ -1037,7 +1038,7 @@ def convert_conll_file(ifile, ofile, convert, fields=[-1], delim=None):
         if md:
             ofile.write("\n".join(md) + "\n")
         # Write out the lines
-        ofile.write("\n".join(delim.join(l).rstrip() for l in lines) + "\n\n")
+        ofile.write("\n".join(output_delim.join(l).rstrip() for l in lines) + "\n\n")
 
 
 @export

--- a/tests/test_conll.py
+++ b/tests/test_conll.py
@@ -1,5 +1,6 @@
 import os
 import random
+import textwrap
 from io import StringIO
 import pytest
 from eight_mile.utils import (
@@ -9,6 +10,7 @@ from eight_mile.utils import (
     read_conll_docs_md,
     read_conll_sentences,
     read_conll_sentences_md,
+    convert_conll_file,
 )
 
 
@@ -169,3 +171,18 @@ def test_sniff_reset():
     _ = sniff_conll_file(files)
     res = files.readline().rstrip()
     assert res == gold
+
+
+def test_read_write_with_delim_none():
+    data = textwrap.dedent("""
+        a 1 2
+        b 1 2
+
+        c 1 2
+        d 1 2
+    """.lstrip("\n"))
+    in_ = StringIO(data)
+    out_ = StringIO()
+    convert_conll_file(in_, out_, lambda x: x, delim=None)
+    out_.seek(0)
+    assert out_.read().strip("\n") == data.strip("\n")


### PR DESCRIPTION
When you read a conll file you can use None to properly parse both tab delimited and space delimited file but when
the delimiter is None the writing fails. This code adds a guard so that if you have a None delimiter coming in it
will use a space as the output delimiter. If you pass in a delimiter it will use that as the output one

This was a fix that made it into master but never got ported over to `feature/v2`