### PR TITLE
fix buf in no CRF tagger, reload_checkpoint

### DIFF
--- a/baseline/tf/classify/training/utils.py
+++ b/baseline/tf/classify/training/utils.py
@@ -6,6 +6,7 @@ import tensorflow as tf
 
 from eight_mile.confusion import ConfusionMatrix
 from eight_mile.utils import listify
+from eight_mile.tf.layers import reload_checkpoint
 from eight_mile.tf.optz import optimizer
 
 from baseline.progress import create_progress_bar
@@ -14,6 +15,7 @@ from baseline.tf.tfy import _add_ema, TRAIN_FLAG, SET_TRAIN_FLAG
 from baseline.train import EpochReportingTrainer, create_trainer, register_trainer, register_training_func
 from baseline.utils import verbose_output
 from baseline.model import create_model_for
+
 import numpy as np
 
 # Number of batches to prefetch if using tf.datasets
@@ -124,6 +126,10 @@ class ClassifyTrainerTf(EpochReportingTrainer):
         self.model.sess.run(tables)
         self.model.sess.run(tf.compat.v1.global_variables_initializer())
         self.model.set_saver(tf.compat.v1.train.Saver())
+        checkpoint = kwargs.get('checkpoint')
+        if checkpoint is not None:
+            skip_blocks = kwargs.get('blocks_to_skip', ['Optimize_Loss'])
+            reload_checkpoint(self.model.sess, checkpoint, skip_blocks)
 
     @staticmethod
     def _get_batchsz(batch_dict):

--- a/baseline/tf/lm/training/utils.py
+++ b/baseline/tf/lm/training/utils.py
@@ -2,6 +2,7 @@ import os
 import time
 import numpy as np
 import tensorflow as tf
+from eight_mile.tf.layers import reload_checkpoint
 from eight_mile.tf.optz import optimizer
 from baseline.tf.tfy import TRAIN_FLAG, SET_TRAIN_FLAG
 from baseline.train import Trainer, register_trainer
@@ -101,6 +102,10 @@ class LanguageModelTrainerTf(Trainer):
         self.model.sess.run(init)
         saver = tf.compat.v1.train.Saver()
         self.model.set_saver(saver)
+        checkpoint = kwargs.get('checkpoint')
+        if checkpoint is not None:
+            skip_blocks = kwargs.get('blocks_to_skip', ['Optimize_Loss'])
+            reload_checkpoint(self.model.sess, checkpoint, skip_blocks)
 
     def checkpoint(self):
         """This method saves a checkpoint

--- a/baseline/tf/seq2seq/training/utils.py
+++ b/baseline/tf/seq2seq/training/utils.py
@@ -2,7 +2,7 @@ import os
 import time
 import numpy as np
 import tensorflow as tf
-from eight_mile.tf.layers import create_session
+from eight_mile.tf.layers import create_session, reload_checkpoint
 from eight_mile.tf.optz import optimizer
 from baseline.progress import create_progress_bar
 from eight_mile.bleu import bleu
@@ -84,7 +84,7 @@ class Seq2SeqTrainerTf(Trainer):
           * *beam* (`int`) -- The beam size to use at prediction time, defaults to `10`
 
         """
-        super(Seq2SeqTrainerTf, self).__init__()
+        super().__init__()
         if type(model_params) is dict:
             self.model = create_model_for('seq2seq', **model_params)
         else:
@@ -104,6 +104,10 @@ class Seq2SeqTrainerTf(Trainer):
 
         init = tf.compat.v1.global_variables_initializer()
         self.model.sess.run(init)
+        checkpoint = kwargs.get('checkpoint')
+        if checkpoint is not None:
+            skip_blocks = kwargs.get('blocks_to_skip', ['Optimize_Loss'])
+            reload_checkpoint(self.model.sess, checkpoint, skip_blocks)
 
     def checkpoint(self):
         """This method saves a checkpoint

--- a/baseline/tf/tagger/model.py
+++ b/baseline/tf/tagger/model.py
@@ -21,7 +21,7 @@ class TaggerModelBase(tf.keras.Model, TaggerModel):
     def __init__(self):
         """Create a tagger, nothing marked as unserializable
         """
-        super(TaggerModelBase, self).__init__()
+        super().__init__()
         self._unserializable = []
         self._lengths_key = None
         self._dropin_value = None

--- a/baseline/tf/tagger/training/datasets.py
+++ b/baseline/tf/tagger/training/datasets.py
@@ -8,7 +8,7 @@ from eight_mile.utils import listify
 from baseline.train import create_trainer, register_training_func
 from baseline.tf.tfy import TRAIN_FLAG
 from baseline.utils import get_model_file, get_metric_cmp
-from baseline.tf.tfy import reload_lower_layers
+from baseline.tf.tfy import reload_checkpoint
 from baseline.tf.tagger.training.utils import to_tensors, TaggerEvaluatorTf
 
 # Number of batches to prefetch if using tf.datasets

--- a/baseline/tf/tagger/training/eager.py
+++ b/baseline/tf/tagger/training/eager.py
@@ -5,7 +5,7 @@ import numpy as np
 import tensorflow as tf
 import logging
 from eight_mile.utils import listify, revlut, to_spans, write_sentence_conll, per_entity_f1, span_f1, conlleval_output
-from eight_mile.tf.layers import TRAIN_FLAG, SET_TRAIN_FLAG, reload_lower_layers
+from eight_mile.tf.layers import TRAIN_FLAG, SET_TRAIN_FLAG, reload_checkpoint
 from eight_mile.tf.optz import EagerOptimizer
 from baseline.progress import create_progress_bar
 from baseline.model import create_model_for

--- a/baseline/tf/tagger/training/feed.py
+++ b/baseline/tf/tagger/training/feed.py
@@ -7,7 +7,7 @@ from eight_mile.utils import listify
 from baseline.train import create_trainer, register_training_func
 from baseline.tf.tfy import TRAIN_FLAG
 from baseline.utils import get_model_file, get_metric_cmp
-from baseline.tf.tfy import reload_lower_layers
+from baseline.tf.tfy import reload_checkpoint
 from baseline.tf.tagger.training.utils import TaggerEvaluatorTf
 
 logger = logging.getLogger('baseline')

--- a/baseline/tf/tagger/training/utils.py
+++ b/baseline/tf/tagger/training/utils.py
@@ -12,7 +12,7 @@ from baseline.train import EpochReportingTrainer, create_trainer, register_train
 from baseline.tf.tfy import TRAIN_FLAG
 from baseline.model import create_model_for
 from baseline.utils import get_model_file, get_metric_cmp
-from baseline.tf.tfy import reload_lower_layers
+from eight_mile.tf.layers import reload_checkpoint
 
 logger = logging.getLogger('baseline')
 
@@ -201,6 +201,10 @@ class TaggerTrainerTf(EpochReportingTrainer):
         self.model.sess.run(init)
         saver = tf.compat.v1.train.Saver()
         self.model.save_using(saver)
+        checkpoint = kwargs.get('checkpoint')
+        if checkpoint is not None:
+            skip_blocks = kwargs.get('blocks_to_skip', ['Optimize_Loss'])
+            reload_checkpoint(self.model.sess, checkpoint, skip_blocks)
 
     def checkpoint(self):
         """This method saves a checkpoint


### PR DESCRIPTION
- fix bug in tagger on TF with greedy decoder due to trimming
- fix non-eager to call `reload_checkpoint`
(previously known as `reload_lower_layers`)