### PR TITLE
fix: use if not elif

### DIFF
--- a/layers/eight_mile/tf/optz.py
+++ b/layers/eight_mile/tf/optz.py
@@ -463,7 +463,7 @@ def _optimize_loss(
             if "learning_rate" in summaries:
                 tf.compat.v1.summary.scalar("learning_rate", lr)
 
-        elif isinstance(optimizer, type) and issubclass(optimizer, tf.compat.v1.train.Optimizer):
+        if isinstance(optimizer, type) and issubclass(optimizer, tf.compat.v1.train.Optimizer):
             if lr is None:
                 raise ValueError(
                     "Learning rate is None, but should be specified if " "optimizer is class (%s)." % optimizer


### PR DESCRIPTION
In the _optimize_loss function we have an if statement that checks if
there is a learning rate decay function. If there is we initialize it
with the learning rate and then call that function the lr so that if we
pass it into an optimizer it will be used which training. The problem
was that the first if statement in the block of `elif`s that dealt with
creating the optimizer object. Being an `elif` it wouldn't execute if we
hit the block about the learning rate decay so the `opt` would never
actually be created. I fixed this by switching it to an `if`. The two
sets of conditionals are doing different things so they shouldn't have
been one large block of `if` and `elif`s