### PR TITLE
Feature/ft relative attention

### DIFF
--- a/addons/embed_tlm_pytorch.py
+++ b/addons/embed_tlm_pytorch.py
@@ -7,7 +7,7 @@ from collections import Counter
 from eight_mile.utils import read_json
 from eight_mile.pytorch.layers import TransformerEncoderStack, subsequent_mask
 from eight_mile.pytorch.embeddings import PyTorchEmbeddings, PositionalLookupTableEmbeddings, LearnedPositionalLookupTableEmbeddings
-from baseline.embeddings import register_embeddings
+from baseline.embeddings import register_embeddings, create_embeddings
 from baseline.pytorch.embeddings import PyTorchEmbeddingsModel
 from baseline.vectorizers import register_vectorizer, AbstractVectorizer, BPEVectorizer1D
 from baseline.pytorch.torchy import *
@@ -126,15 +126,13 @@ class TransformerLMEmbeddings(PyTorchEmbeddings):
         self.d_model = int(kwargs.get('dsz', kwargs.get('d_model', 410)))
         d_ff = int(kwargs.get('d_ff', 2100))
         d_k = kwargs.get('d_k')
-        rpr_k = kwargs.get('rpr_k')
         embed_type = kwargs.get('word_embed_type', 'positional')
-        if embed_type == 'positional':
-            x_embedding = PositionalLookupTableEmbeddings(vsz=self.vsz, dsz=self.d_model)
-        elif embed_type == 'learned-positional':
-            x_embedding = LearnedPositionalLookupTableEmbeddings(vsz=self.vsz, dsz=self.d_model)
+        rpr_k = kwargs.get('rpr_k')
+        x_embedding = create_embeddings(vsz=self.vsz, dsz=self.d_model, embed_type=embed_type)
         self.dsz = self.init_embed({'x': x_embedding})
         self.proj_to_dsz = pytorch_linear(self.dsz, self.d_model) if self.dsz != self.d_model else _identity
-        self.transformer = TransformerEncoderStack(num_heads, d_model=self.d_model, pdrop=pdrop, scale=True, layers=layers, d_ff=d_ff, rpr_k=rpr_k, d_k=d_k)
+        self.transformer = TransformerEncoderStack(num_heads, d_model=self.d_model, pdrop=pdrop, scale=True,
+                                                   layers=layers, d_ff=d_ff, rpr_k=rpr_k, d_k=d_k)
         self.mlm = kwargs.get('mlm', False)
         self.finetune = kwargs.get('finetune', True)
 

--- a/addons/embed_tlm_tf.py
+++ b/addons/embed_tlm_tf.py
@@ -4,7 +4,7 @@ import tensorflow as tf
 from eight_mile.tf.serialize import load_tlm_npz
 from eight_mile.tf.layers import TransformerEncoderStack
 from eight_mile.tf.layers import EmbeddingsStack, subsequent_mask
-from baseline.embeddings import register_embeddings
+from baseline.embeddings import register_embeddings, create_embeddings
 from eight_mile.utils import Offsets, read_json
 from baseline.vectorizers import register_vectorizer, BPEVectorizer1D
 from eight_mile.tf.embeddings import TensorFlowEmbeddings, PositionalLookupTableEmbeddings, LearnedPositionalLookupTableEmbeddings
@@ -53,15 +53,14 @@ class TransformerLMEmbeddings(TensorFlowEmbeddings):
         pdrop = kwargs.get('dropout', 0.1)
         self.d_model = int(kwargs.get('dsz', kwargs.get('d_model', 410)))
         d_ff = int(kwargs.get('d_ff', 2100))
-        word_embed_type = kwargs.get('word_embed_type', 'positional')
-        if word_embed_type == 'positional':
-            x_embedding = PositionalLookupTableEmbeddings(name=self._name, vsz=self.vsz, dsz=self.d_model)
-        elif word_embed_type == 'learned-positional':
-            x_embedding = LearnedPositionalLookupTableEmbeddings(name=self._name, vsz=self.vsz, dsz=self.d_model)
+        d_k = kwargs.get('d_k')
+        embed_type = kwargs.get('word_embed_type', 'positional')
+        rpr_k = kwargs.get('rpr_k')
+        x_embedding = create_embeddings(vsz=self.vsz, dsz=self.d_model, embed_type=embed_type, name='word_embed')
         self.dsz = self.init_embed({'x': x_embedding})
         self.proj_to_dsz = tf.keras.layers.Dense(self.d_model) if self.dsz != self.d_model else _identity
         self.transformer = TransformerEncoderStack(layers=layers, d_model=self.d_model, pdrop=pdrop,
-                                                   num_heads=num_heads, d_ff=d_ff)
+                                                   num_heads=num_heads, d_ff=d_ff, d_k=d_k, rpr_k=rpr_k)
         self.mlm = kwargs.get('mlm', False)
 
     def embed(self, input):

--- a/layers/eight_mile/tf/serialize.py
+++ b/layers/eight_mile/tf/serialize.py
@@ -29,17 +29,22 @@ def from_ffn_array(tf_ffn: FFN, d: Dict, name: str):
     from_weight_array(tf_ffn.squeeze, d, f"{name}/squeeze")
 
 
-def from_mha_array(tf_mha: MultiHeadedAttention, d: Dict, name: str):
-    """Restore a `MultiHeadedAttention` module from a set of keys
+def from_attn_array(tf_attn: tf.keras.layers.Layer, d: Dict, name: str):
+    """Restore a self-attention module from a set of keys
 
-    :param tf_mha: A `MultiHeadedAttention` module for Transformers
+    :param tf_attn: A self-attention module for Transformers, could be MultiHeadedAttention or
+    MultiHeadedRelativeAttention
     :param d: A Dict of arrays by key
     :param name: The name of the layer
     """
-    from_weight_array(tf_mha.w_Q, d, f"{name}/w_Q")
-    from_weight_array(tf_mha.w_K, d, f"{name}/w_K")
-    from_weight_array(tf_mha.w_V, d, f"{name}/w_V")
-    from_weight_array(tf_mha.w_O, d, f"{name}/w_O")
+    from_weight_array(tf_attn.w_Q, d, f"{name}/w_Q")
+    from_weight_array(tf_attn.w_K, d, f"{name}/w_K")
+    from_weight_array(tf_attn.w_V, d, f"{name}/w_V")
+    from_weight_array(tf_attn.w_O, d, f"{name}/w_O")
+
+    if hasattr(tf_attn, 'rpr_key'):
+        tf_attn.rpr_key.set_weights([d[f"{name}/rpr_key"]])
+        tf_attn.rpr_value.set_weights([d[f"{name}/rpr_value"]])
 
 
 def from_encoder_array(tf_encoder: TransformerEncoder, d: Dict, name: str):
@@ -52,7 +57,7 @@ def from_encoder_array(tf_encoder: TransformerEncoder, d: Dict, name: str):
     """
     from_weight_array(tf_encoder.ln1, d, f"{name}/ln1")
     from_weight_array(tf_encoder.ln2, d, f"{name}/ln2")
-    from_mha_array(tf_encoder.self_attn, d, f"{name}/mha")
+    from_attn_array(tf_encoder.self_attn, d, f"{name}/attn")
     from_ffn_array(tf_encoder.ffn, d, f"{name}/ffn")
 
 

--- a/tests/test_tlm_serialization.py
+++ b/tests/test_tlm_serialization.py
@@ -35,7 +35,7 @@ def _call_model(m, inputs):
     return m.transformer((x, mask))
 
 
-def _round_trip(embed_type):
+def _round_trip(embed_type, rpr_k=None):
     test_file = os.path.join(file_loc, "test_data", "blah.npz")
     d_model = 40
     vocab_x = {'a':1, 'aardvark':100, 'beandip':42, 'cheerio':86, 'dumdum':129, 'eoyre':3}
@@ -53,6 +53,7 @@ def _round_trip(embed_type):
                                                 gpu=False,
                                                 num_heads=4,
                                                 layers=2,
+                                                rpr_k=rpr_k,
                                                 src_keys=['x'], tgt_key='x')
 
     save_tlm_npz(src_model, test_file)
@@ -68,6 +69,7 @@ def _round_trip(embed_type):
                                                 gpu=False,
                                                 num_heads=4,
                                                 layers=2,
+                                                rpr_k=rpr_k,
                                                 src_keys=['x'], tgt_key='x')
     load_tlm_npz(dst_model, test_file)
 
@@ -83,3 +85,4 @@ def _round_trip(embed_type):
 def test_round_trip():
     assert _round_trip('positional')
     assert _round_trip('learned-positional')
+    assert _round_trip('default', rpr_k=[3, 5])


### PR DESCRIPTION
This PR add support to relative attention in saving/loading npz checkpoint; and fine-tuning in TF. It is tested with LookupTableEmbeddings + rpr_k, and the TF module output the same as pytorch one with random input. 

Note: need to re-run `ckpt2npz.py` to old ckpts after this is merged. 