### PR TITLE
feat: Added tools and models for calibration

### DIFF
--- a/api-examples/analyze_calibration.py
+++ b/api-examples/analyze_calibration.py
@@ -1,0 +1,102 @@
+"""Calculate and plot metrics on calibration like in https://arxiv.org/abs/1706.04599
+
+While not needed having matplotlib installed gives nicer results.
+"""
+
+import os
+import re
+import pickle
+import argparse
+import numpy as np
+import baseline as bl
+from eight_mile.calibration import (
+    expected_calibration_error,
+    maximum_calibration_error,
+    multiclass_calibration_bins,
+    binary_calibration_bins,
+    average_confidence,
+)
+
+
+parser = argparse.ArgumentParser(description="Analyze the calibration of a classifier")
+parser.add_argument('--model', help='The path to either the .zip file created by training or to the client bundle created by exporting', required=True, type=str)
+parser.add_argument('--backend', help='The deep learning backend your model was trained with', choices={'tf', 'pytorch'}, default='tf')
+parser.add_argument('--device', help='The device to run your model on')
+parser.add_argument('--batchsz', help='The number of examples to run at once', default=100, type=int)
+parser.add_argument('--data', help="The data to test calibration on in the label first format", required=True)
+parser.add_argument('--bins', help="The number of bins to use in calibration", default=10, type=int)
+parser.add_argument('--hist-bins', '--hist_bins', help="The number of bins to use when creating the confidence histogram", default=100, type=int)
+parser.add_argument('--output', help="The name of the output pickle that holds calibration stats")
+args = parser.parse_args()
+
+# Read in the dataset
+labels, texts = bl.read_label_first_data(args.data)
+
+# Batch the dataset and the labels
+batched = [texts[i : i + args.batchsz] for i in range(0, len(texts), args.batchsz)]
+batched_labels = [labels[i : i + args.batchsz] for i in range(0, len(labels), args.batchsz)]
+
+# Load the model
+m = bl.ClassifierService.load(args.model, backend=args.backend, device=args.device)
+# Extract the label vocab from the model: Note this is p messy and we should have a better story about handling label vocabs
+label_vocab = {l: i for i, l in enumerate(m.get_labels())}
+
+# Process batches to collect the probabilities and gold labels for each example
+probs = []
+labels = []
+for texts, labs in zip(batched, batched_labels):
+    prob = m.predict(texts, dense=True)
+    probs.append(prob)
+    labels.extend(label_vocab[l] for l in labs)
+
+probs = np.concatenate(probs, axis=0)
+labels = np.array(labels)
+
+# Binning
+bins = multiclass_calibration_bins(labels, probs, bins=args.bins)
+hist_bins = multiclass_calibration_bins(labels, probs, bins=args.hist_bins)
+binary_bins = binary_calibration_bins(labels, probs[:, 1], bins=args.bins) if len(label_vocab) == 2 else None
+acc = np.mean(labels == np.argmax(probs, axis=1))
+conf = average_confidence(probs)
+
+# Metrics
+print(f"ECE: {expected_calibration_error(bins.accs, bins.confs, bins.counts)}")
+print(f"MCE: {maximum_calibration_error(bins.accs, bins.confs, bins.counts)}")
+
+# Save the needed data to a pickle so we can recreate the graphs if we need to
+args.output = f"{re.sub(r'.pkl$', '', args.output)}.pkl" if args.output is not None else f"{args.model}-calibration-stats.pkl"
+with open(args.output, "wb") as wf:
+    pickle.dump({
+        "multiclass": bins,
+        "histogram": hist_bins,
+        "binary": binary_bins,
+        "acc": acc,
+        "conf": conf,
+        "num_classes": len(label_vocab)
+    }, wf)
+
+try:
+    # If they have matplotlib installed plot the reliability graphs and the confidence histograms
+    import matplotlib.pyplot as plt
+    from eight_mile.calibration import reliability_diagram, reliability_curve, confidence_histogram
+    reliability_diagram(
+        bins.accs,
+        bins.confs,
+        bins.edges,
+        num_classes=len(label_vocab),
+        title=f"Reliability Diagram\n{args.model}"
+    )
+    confidence_histogram(
+        hist_bins.edges,
+        hist_bins.counts,
+        acc=acc,
+        avg_conf=conf,
+        x_ticks=np.arange(0, 1.01, 0.2),
+        title=f"Confidence Histogram\n{args.model}"
+    )
+    # If we using a binary classifier look at the reliability curve a la sklearn
+    if binary_bins:
+        reliability_curve(binary_bins.accs, binary_bins.confs, title=f"Reliability Curve\n{args.model}")
+    plt.show()
+except ImportError:
+    pass

--- a/baseline/model.py
+++ b/baseline/model.py
@@ -172,7 +172,7 @@ class ClassifierModel:
     """
     task_name = 'classify'
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
         super().__init__()
 
     def save(self, basename):

--- a/baseline/tf/classify/training/datasets.py
+++ b/baseline/tf/classify/training/datasets.py
@@ -94,7 +94,7 @@ def fit_datasets(model_params, ts, vs, es=None, **kwargs):
     features, y = iter.get_next()
     # Add features to the model params
     model_params.update(features)
-    model_params['y'] = tf.one_hot(tf.reshape(y, [-1, 1]), len(model_params['labels']))
+    model_params['y'] = tf.one_hot(tf.reshape(y, [-1]), len(model_params['labels']))
     # create the initialisation operations
     train_init_op = iter.make_initializer(train_dataset)
     valid_init_op = iter.make_initializer(valid_dataset)

--- a/baseline/tf/classify/training/utils.py
+++ b/baseline/tf/classify/training/utils.py
@@ -129,10 +129,6 @@ class ClassifyTrainerTf(EpochReportingTrainer):
             skip_blocks = kwargs.get('blocks_to_skip', ['OptimizeLoss'])
             reload_checkpoint(self.model.sess, checkpoint, skip_blocks)
 
-    @staticmethod
-    def _get_batchsz(batch_dict):
-        return len(batch_dict['y'])
-
     def _train(self, loader, dataset=True, **kwargs):
         """Train an epoch of data using either the input loader or using `tf.dataset`
 
@@ -216,13 +212,11 @@ class ClassifyTrainerTf(EpochReportingTrainer):
             y = batch_dict['y']
             if use_dataset:
                 guess, lossv = self.sess.run([self.model.best, self.test_loss])
-                batchsz = len(guess)
             else:
                 feed_dict = self.model.make_input(batch_dict, False)
                 guess, lossv = self.sess.run([self.model.best, self.test_loss], feed_dict=feed_dict)
 
-                batchsz = self._get_batchsz(batch_dict)
-                assert len(guess) == batchsz
+            batchsz = len(guess)
             total_loss += lossv * batchsz
             total_norm += batchsz
             cm.add_batch(y, guess)

--- a/layers/eight_mile/calibration/__init__.py
+++ b/layers/eight_mile/calibration/__init__.py
@@ -1,0 +1,6 @@
+from eight_mile.calibration.calibration import *
+from eight_mile.calibration.metrics import *
+try:
+    from eight_mile.calibration.plot import *
+except ImportError:
+    pass

--- a/layers/eight_mile/calibration/calibration.py
+++ b/layers/eight_mile/calibration/calibration.py
@@ -11,7 +11,7 @@ Bins = namedtuple("Bins", "accs confs counts edges")
 def multiclass_calibration_bins(truth: np.ndarray, probs: np.ndarray, bins: int, class_weights: Optional[np.ndarray] = None) -> Bins:
     """Calculate the binned confidence and accuracy for a multiclass problem.
 
-    :param true: A 1D array of the true labels for some examples.
+    :param truth: A 1D array of the true labels for some examples.
     :param probs: A 1D array of the probabilities from a model. Each row represents an example in the dataset.
         and each column represents the probably assigned by the model to each class for that example.
     :param bins: The number of bins to use when aggregating.
@@ -54,11 +54,11 @@ def binary_calibration_bins(credit: np.ndarray, probs: np.ndarray, bins: int) ->
     bin_acc_sum = np.bincount(bin_idx, weights=credit, minlength=len(bins))
     bin_counts = np.bincount(bin_idx, minlength=len(bins))
 
-    mask = bin_counts != 0
-    denom = np.where(mask, bin_counts, 1)
+    mask = bin_counts == 0
+    denom = bin_counts + mask
 
-    bin_mean_conf = (bin_conf_sum / denom) * mask
-    bin_mean_acc = (bin_acc_sum / denom) * mask
+    bin_mean_conf = bin_conf_sum / denom
+    bin_mean_acc = bin_acc_sum / denom
 
     return Bins(bin_mean_acc[:-1], bin_mean_conf[:-1], bin_counts[:-1], bins[:-1])
 

--- a/layers/eight_mile/calibration/calibration.py
+++ b/layers/eight_mile/calibration/calibration.py
@@ -1,0 +1,74 @@
+from typing import Optional
+from collections import namedtuple
+import numpy as np
+
+__all__ = ["calibration_bins", "multiclass_calibration_bins", "binary_calibration_bins", "average_confidence", "Bins"]
+
+
+Bins = namedtuple("Bins", "accs confs counts edges")
+
+
+def multiclass_calibration_bins(truth: np.ndarray, probs: np.ndarray, bins: int, class_weights: Optional[np.ndarray] = None) -> Bins:
+    """Calculate the binned confidence and accuracy for a multiclass problem.
+
+    :param true: A 1D array of the true labels for some examples.
+    :param probs: A 1D array of the probabilities from a model. Each row represents an example in the dataset.
+        and each column represents the probably assigned by the model to each class for that example.
+    :param bins: The number of bins to use when aggregating.
+    :param class_weights: A 1D array of scores that can add extra weight to examples of specific classes.
+
+    :returns: The metrics aggregated by bins
+    """
+    preds = np.argmax(probs, axis=1)
+    pred_probs = np.max(probs, axis=1)
+    credit = truth == preds
+    if class_weights is not None:
+        weighted_labels = class_weights[truth]
+        credit = credit * weighted_labels
+    return binary_calibration_bins(credit, pred_probs, bins=bins)
+
+
+calibration_bins = multiclass_calibration_bins
+
+
+def binary_calibration_bins(credit: np.ndarray, probs: np.ndarray, bins: int) -> Bins:
+    """Calculate the accuracy and confidence inside bins. This is similar to the sklearn function.
+
+    Note:
+        This is different than the multiclass function. This will look at the scores for a specific
+        class even if it is below the 1/num_classes threshold that will cause the multiclass
+        version to not select this class.
+
+    :param credit: How much credit the model gets for this example. If it is wrong the value will be zero
+        If it is right one. You can also give different classes different weights by passing real values.
+    :param probs: The probabilities assigned to the positive class by the model.
+    :param bins: The number of bins to use when aggregating.
+
+    :returns: The metrics aggregated by bins
+    """
+    bins = np.linspace(0.0, 1.0, num=bins + 1, endpoint=True)
+
+    bin_idx = np.digitize(probs, bins) - 1
+
+    bin_conf_sum = np.bincount(bin_idx, weights=probs, minlength=len(bins))
+    bin_acc_sum = np.bincount(bin_idx, weights=credit, minlength=len(bins))
+    bin_counts = np.bincount(bin_idx, minlength=len(bins))
+
+    mask = bin_counts != 0
+    denom = np.where(mask, bin_counts, 1)
+
+    bin_mean_conf = (bin_conf_sum / denom) * mask
+    bin_mean_acc = (bin_acc_sum / denom) * mask
+
+    return Bins(bin_mean_acc[:-1], bin_mean_conf[:-1], bin_counts[:-1], bins[:-1])
+
+
+def average_confidence(probs: np.ndarray) -> float:
+    """Calculate the average (maximum) confidence for a collection of predictions
+
+    :param probs: `[B, C]` A matrix of probabilities, each row is an example and
+        each column is a class.
+    """
+    if probs.ndim == 1:
+        probs = np.expand_dims(probs, axis=-1)
+    return np.mean(np.max(probs, axis=1))

--- a/layers/eight_mile/calibration/metrics/__init__.py
+++ b/layers/eight_mile/calibration/metrics/__init__.py
@@ -1,0 +1,1 @@
+from eight_mile.calibration.metrics.calibration_error import expected_calibration_error, maximum_calibration_error

--- a/layers/eight_mile/calibration/metrics/calibration_error.py
+++ b/layers/eight_mile/calibration/metrics/calibration_error.py
@@ -15,7 +15,7 @@ def expected_calibration_error(
         from https://arxiv.org/abs/1706.04599
 
     This is the absolute difference between the confidence and accuracy of each
-    bin weighted but the number of samples in each bin.
+    bin weighted by the number of samples in each bin.
 
     :param bin_mean_acc: `[B]` an array with the accuracy of each bin as elements
     :param bin_meanc_conf: `[B]` an array with the mean confidence of each bin as elements

--- a/layers/eight_mile/calibration/metrics/calibration_error.py
+++ b/layers/eight_mile/calibration/metrics/calibration_error.py
@@ -1,0 +1,54 @@
+import numpy as np
+
+
+__all__ = ["expected_calibration_error", "maximum_calibration_error"]
+
+
+def expected_calibration_error(
+    bin_mean_acc: np.ndarray,
+    bin_mean_conf: np.ndarray,
+    bin_counts: np.ndarray,
+) -> float:
+    """The difference in expectation between the confidence and the accuracy.
+
+    This is an approximation of eq (2) as described in eq (5)
+        from https://arxiv.org/abs/1706.04599
+
+    This is the absolute difference between the confidence and accuracy of each
+    bin weighted but the number of samples in each bin.
+
+    :param bin_mean_acc: `[B]` an array with the accuracy of each bin as elements
+    :param bin_meanc_conf: `[B]` an array with the mean confidence of each bin as elements
+    :param bin_counts: `[B]` an array with the number of samples in each bin
+
+    :returns: The ECE between the accuracy and confidence distributions via binning.
+    """
+    abs_differences = np.abs(bin_mean_acc - bin_mean_conf)
+    coeff = bin_counts / np.sum(bin_counts)
+    return np.sum(coeff * abs_differences)
+
+
+def maximum_calibration_error(
+    bin_mean_acc: np.ndarray,
+    bin_mean_conf: np.ndarray,
+    bin_counts: np.ndarray,
+) -> float:
+    """The worst case deviation between confidence and accuracy.
+
+    This is an approximation of eq (4) as described in eq (5)
+        from https://arxiv.org/abs/1706.04599
+
+    This is the maximum absolute difference between the confidence and accuracy
+    of each bin. The bin_counts are used to filter out bins that have no samples
+    in them. This seems like it is very dependent on the number of bins you have
+    and should therefore be kept constant when comparing models.
+
+    :param bin_mean_acc:
+    :param bin_mean_conf:
+    :param bin_counts:
+
+    :returns: The MCE between the accuracy and confidence distributions via binning.
+    """
+    abs_differences = np.abs(bin_mean_acc - bin_mean_conf)
+    filtered = abs_differences[bin_counts != 0]
+    return np.max(filtered)

--- a/layers/eight_mile/calibration/plot/__init__.py
+++ b/layers/eight_mile/calibration/plot/__init__.py
@@ -1,0 +1,2 @@
+from eight_mile.calibration.plot.confidence_histogram import confidence_histogram
+from eight_mile.calibration.plot.reliability_diagram import reliability_diagram, reliability_curve

--- a/layers/eight_mile/calibration/plot/confidence_histogram.py
+++ b/layers/eight_mile/calibration/plot/confidence_histogram.py
@@ -1,0 +1,121 @@
+from typing import Optional, Tuple
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
+
+
+__all__ = ["confidence_histogram"]
+
+
+def confidence_histogram(
+    left_bins: np.array,
+    bin_counts: np.array,
+    acc: Optional[float] = None,
+    avg_conf: Optional[float] = None,
+    x_ticks: Optional[np.array] = None,
+    y_ticks: Optional[np.array] = None,
+    title: Optional[str] = "Confidence Distribution",
+    y_label: Optional[str] = "% of Samples",
+    x_label: Optional[str] = "Confidence",
+    conf_label: Optional[str] = "Avg. Confidence",
+    acc_label: Optional[str] = "Accuracy",
+    label_y: float = 0.4,
+    conf_spacer: float = 0.015,
+    acc_spacer: float = -0.07,
+    edge: str = "k",
+    color: str = "b",
+    fig_size: int = 3,
+    ax: Optional[Axes] = None,
+    fig: Optional[Figure] = None,
+) -> Tuple[Figure, Axes]:
+    """Plot a reliability graph a la https://arxiv.org/abs/1706.04599
+
+    :param left_bins: The bins that define the groups, they should specify the left
+        edge of the bin
+    :param accs: The average accuracy for examples in that bin
+    :param x_ticks: Where to show the ticks along the x axis. If not provided it
+        will display every other tick, pass an empty list to skip adding ticks
+    :param y_ticks: Where to show the ticks along the y axis. If not provided it
+        uses default matplotlib ticks, padd an empty list to skip adding ticks
+    :param title: The title for the axes, pass None to skip adding a title to the axes
+    :param y_label: A label for the y axes, pass None to skip adding a label
+    :param x_label: A label for the x axes, pass None to skip adding a label
+    :param conf_label: A label to put on the line representing the average confidence
+    :param acc_label: A label to put on the line representing the accuract
+    :param label_y: Where to start the above labels alon the y axis, 0 is the bottom, 1 is the top
+    :param conf_spacer: How far off the line to put the confidence label, use positive to move
+        right of the line and negative to move to the left
+    :param acc_spacer: How far off the line to put the accuracy label, use positive to move right
+        of the line and negative to move to the left
+    :param edge: The color to use for the edges of the output bins
+    :param color: The color to use for the main section of the output bins
+    :param fig_size: The figure size, only used if creating the figure/axis from scratch
+    :param ax: An Axes object that we can create the graph in, if None it will be created
+    :param fig: A figure that holds the axes object
+
+    :returns: `Tuple(fig, ax)` If the figure and ax are passed in they are returned, if they
+        were not passed in the created ones are returned. The don't use the figure at all but
+        because we want to return both in case we created them.
+    """
+    # If niether a figure non-axes are passed in we create them.
+    if ax is None and fig is None:
+        fig, ax = plt.subplots(1, 1, figsize=(fig_size, fig_size))
+    # If the axes was not passed in but the figure was we get the current active
+    # axes for the figure.
+    if ax is None and fig is not None:
+        ax = fig.gca()
+    # If the axes is provided but the figure we look up the figure on the axes
+    if ax is not None and fig is None:
+        fig = ax.figure
+    widths = np.diff(left_bins, append=1)
+    ax.bar(
+        left_bins,
+        bin_counts / np.sum(bin_counts),
+        align='edge',
+        width=widths,
+        edgecolor=edge,
+        color=color
+    )
+    trans = ax.get_xaxis_transform()
+    if avg_conf is not None:
+        ax.axvline(avg_conf, ls='--', c='.3')
+        if conf_label is not None:
+            ax.text(avg_conf + conf_spacer, label_y, conf_label, rotation=90, transform=trans)
+    if acc is not None:
+        ax.axvline(acc, ls='--', c='.3')
+        if acc_label is not None:
+            ax.text(acc + acc_spacer, label_y, acc_label, rotation=90, transform=trans)
+    ax.set_xlim(0, 1)
+    ax.set_ylim(0, 1)
+    ax.set_aspect("equal", "box")
+    ax.set_title(title)
+    ax.set_ylabel(y_label)
+    ax.set_xlabel(x_label)
+    if x_ticks is None:
+        x_ticks = [y for i, y in enumerate(left_bins) if i % 2 == 0] + [1.0]
+    ax.set_xticks(x_ticks)
+    if y_ticks is not None:
+        ax.set_yticks(y_ticks)
+    return fig, ax
+
+
+def _demo():
+    small_bins = np.arange(0, 1, step=0.05)
+    counts = np.zeros_like(small_bins)
+    prev = 0
+    for i in range(len(small_bins)):
+        add = np.random.randint(10, 15 * (i + 1))
+        counts[i] = prev + add
+        prev = counts[i]
+    counts[-1] += np.random.randint(50, 1000)
+    x_ticks = np.arange(0, 1.1, step=0.2)
+    ACC = 0.72
+    CONF = 0.84
+
+    f, a = confidence_histogram(small_bins, counts, x_ticks=x_ticks, acc=ACC, avg_conf=CONF)
+    plt.show()
+
+
+if __name__ == "__main__":
+    _demo()

--- a/layers/eight_mile/calibration/plot/reliability_diagram.py
+++ b/layers/eight_mile/calibration/plot/reliability_diagram.py
@@ -1,0 +1,229 @@
+from typing import Optional, Tuple
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
+
+
+__all__ = ["reliability_diagram", "reliability_curve"]
+
+
+def reliability_diagram(
+    accs: np.array,
+    confs: np.array,
+    left_bins: np.array,
+    num_classes: Optional[int] = None,
+    x_ticks: Optional[np.array] = None,
+    y_ticks: Optional[np.array] = None,
+    title: Optional[str] = "Reliability Graph",
+    y_label: Optional[str] = "Accuracy",
+    x_label: Optional[str] = "Confidence",
+    gap_label: Optional[str] = "Gap",
+    output_label: Optional[str] = "Outputs",
+    gap_edge: str = "r",
+    gap_color: str = "r",
+    gap_alpha: float = 0.25,
+    gap_hatch: str = "/",
+    output_edge: str = "k",
+    output_color: str = "b",
+    fig_size: int = 3,
+    ax: Optional[Axes] = None,
+    fig: Optional[Figure] = None,
+) -> Tuple[Figure, Axes]:
+    """Plot a reliability graph a la https://arxiv.org/abs/1706.04599
+
+    :param accs: The average accuracy for examples in that bin
+    :param congs: The average confidence for examples in that bin
+    :param left_bins: The bins that define the groups, they should specify the left
+        edge of the bin
+    :param x_ticks: Where to show the ticks along the x axis. If not provided it
+        will display every other tick, pass an empty list to skip adding ticks
+    :param y_ticks: Where to show the ticks along the y axis. If not provided it
+        uses default matplotlib ticks, padd an empty list to skip adding ticks
+    :param title: The title for the axes, pass None to skip adding a title to the axes
+    :param y_label: A label for the y axes, pass None to skip adding a label
+    :param x_label: A label for the x axes, pass None to skip adding a label
+    :param gap_label: A label for the gap bins, pass None to skip adding a label
+    :param output_label: A label for the output bins, pass None to skip adding a label
+    :param gap_edge: The color to use for the edges of the gap bins
+    :param gap_color: The color to use for the main section of the gap bins
+    :param gap_hatch: The hatching pattern for the gap, useful when a bin a under confident
+    :param output_edge: The color to use for the edges of the output bins
+    :param output_color: The color to use for the main section of the output bins
+    :param fig_size: The figure size, only used if creating the figure/axis from scratch
+    :param ax: An Axes object that we can create the graph in, if None it will be created
+    :param fig: A figure that holds the axes object
+
+    :returns: `Tuple(fig, ax)` If the figure and ax are passed in they are returned, if they
+        were not passed in the created ones are returned. The don't use the figure at all but
+        because we want to return both in case we created them.
+    """
+    # If neither a figure non-axes are passed in we create them.
+    if ax is None and fig is None:
+        fig, ax = plt.subplots(1, 1, figsize=(fig_size, fig_size))
+    # If the axes was not passed in but the figure was we get the current active
+    # axes for the figure.
+    if ax is None and fig is not None:
+        ax = fig.gca()
+    # If the axes is provided but the figure we look up the figure on the axes
+    if ax is not None and fig is None:
+        fig = ax.figure
+    widths = np.diff(left_bins, append=1)
+    expected = left_bins + (widths / 2)
+    expected = np.where(confs != 0, confs, expected)
+    if num_classes is not None:
+        # This is the minimum possible confidence. This is maximum entropy. If your confidence is
+        # lower than this and something else has to have a larger confidence
+        min_conf = 1.0 / num_classes
+        # These bins are lowest confidence allowed in the bin so the highest confidence is the left edge
+        # of the bin above it. So if we do a compare to the bins we will see that the first bin will always
+        # be false. But we can use a np.roll and force the last bin to be true to simulate as if we compared
+        # to the right bin
+        possible_mask = np.roll(left_bins > min_conf, shift=-1)
+        possible_mask[-1] = True
+        # Mask out the expected values for bins that we can't put values in. Otherwise we will see all these
+        # red bars we can't do anything about.
+        expected *= possible_mask
+    ax.bar(
+        left_bins,
+        accs,
+        align='edge',
+        width=widths,
+        label=output_label,
+        edgecolor=output_edge,
+        color=output_color
+    )
+    ax.bar(
+        left_bins,
+        expected - accs,
+        bottom=accs,
+        align='edge',
+        width=widths,
+        label=gap_label,
+        edgecolor=gap_edge,
+        color=gap_color,
+        alpha=gap_alpha,
+        hatch=gap_hatch,
+    )
+    ax.set_xlim(0, 1)
+    ax.set_ylim(0, 1)
+    ax.plot(ax.get_xlim(), ax.get_ylim(), ls="--", c=".3")
+    ax.set_aspect("equal", "box")
+    ax.set_title(title)
+    ax.set_ylabel(y_label)
+    ax.set_xlabel(x_label)
+    if x_ticks is None:
+        x_ticks = [y for i, y in enumerate(left_bins) if i % 2 == 0] + [1.0]
+    ax.set_xticks(x_ticks)
+    if y_ticks is not None:
+        ax.set_yticks(y_ticks)
+    if not (gap_label is None and output_label is None):
+        ax.legend()
+    return fig, ax
+
+
+def reliability_curve(
+    accs: np.array,
+    confs: np.array,
+    num_classes: Optional[int] = None,
+    x_ticks: Optional[np.array] = None,
+    y_ticks: Optional[np.array] = None,
+    title: Optional[str] = "Reliability Curve",
+    y_label: Optional[str] = "Accuracy",
+    x_label: Optional[str] = "Confidence",
+    label: Optional[str] = None,
+    color: str = "tab:orange",
+    line_style: str = "o-",
+    fig_size: int = 3,
+    ax: Optional[Axes] = None,
+    fig: Optional[Figure] = None,
+) -> Tuple[Figure, Axes]:
+    """Plot a reliability curve a la https://scikit-learn.org/stable/modules/calibration.html#calibration
+
+    Note:
+        When there is a bin that had no samples in it the average confidence will be zero
+        and the average accuracy will be zero too. If this is the case we skip plotting
+        that point.
+
+    :param confs: The average confidence in a bin
+    :param accs: The average accuracy for examples in that bin
+    :param x_ticks: Where to show the ticks along the x axis. If not provided it
+        will display every other tick, pass an empty list to skip adding ticks
+    :param y_ticks: Where to show the ticks along the y axis. If not provided it
+        uses default matplotlib ticks, padd an empty list to skip adding ticks
+    :param title: The title for the axes, pass None to skip adding a title to the axes
+    :param y_label: A label for the y axes, pass None to skip adding a label
+    :param x_label: A label for the x axes, pass None to skip adding a label
+    :param label: A label for the plot we are making.
+    :param color: A color for the line we are making.
+    :param line_style: The stle of line to draw.
+    :param fig_size: The figure size, only used if creating the figure/axis from scratch
+    :param ax: An Axes object that we can create the graph in, if None it will be created
+    :param fig: A figure that holds the axes object
+
+    :returns: `Tuple(fig, ax)` If the figure and ax are passed in they are returned, if they
+        were not passed in the created ones are returned. The don't use the figure at all but
+        because we want to return both in case we created them.
+    """
+    # If neither a figure non-axes are passed in we create them.
+    if ax is None and fig is None:
+        fig, ax = plt.subplots(1, 1, figsize=(fig_size, fig_size))
+    # If the axes was not passed in but the figure was we get the current active
+    # axes for the figure.
+    if ax is None and fig is not None:
+        ax = fig.gca()
+    # If the axes is provided but the figure we look up the figure on the axes
+    if ax is not None and fig is None:
+        fig = ax.figure
+    valid = (confs != 0) | (accs != 0)
+    ax.plot(
+        confs[valid], accs[valid], line_style, color=color, label=label
+    )
+    ax.set_xlim(0, 1)
+    ax.set_ylim(0, 1)
+    ax.plot(ax.get_xlim(), ax.get_ylim(), ls="--", c=".3")
+    ax.set_aspect("equal", "box")
+    ax.set_title(title)
+    ax.set_ylabel(y_label)
+    ax.set_xlabel(x_label)
+    if x_ticks is None:
+        x_ticks = [y for i, y in enumerate(np.arange(0, 1 + 1e-8, 1. / len(confs))) if i % 2 == 0]
+    ax.set_xticks(x_ticks)
+    if y_ticks is not None:
+        ax.set_yticks(y_ticks)
+    if label is not None:
+        ax.legend()
+    return fig, ax
+
+
+def _demo():
+    f, axs = plt.subplots(2, 2, figsize=(4, 4))
+    data = np.array([0, 0, .15, .25, .28, .40, .38, .42, .56, .84])
+    x = np.arange(0, 1, 1 / len(data))
+    reliability_diagram(data, x + 0.05, x, num_classes=10, ax=axs[0][0], title="Reliability Diagram (10 classes)")
+    data[5] = 0
+    reliability_diagram(data, x + 0.05, x, num_classes=100, ax=axs[0][1], title="Reliability Diagram (100 classes)")
+    conf = np.array([
+        0.07167232, 0.16942227, 0.26184   , 0.35503329, 0.44979852,
+        0.55041263, 0.64713617, 0.73971958, 0.83297067, 0.92842073
+    ])
+    acc = np.array([
+        0.        , 0.00589623, 0.00789084, 0.03013831, 0.18707902,
+        0.64843534, 0.92417131, 0.98329403, 0.98977505, 1.
+    ])
+    reliability_curve(acc, conf, label="SVC", ax=axs[1][0])
+    conf = np.array([
+        0.07167232, 0.16942227, 0.26184   , 0.35503329, 0.44979852,
+        0.55041263, 0.64713617, 0, 0.83297067, 0.92842073
+    ])
+    acc = np.array([
+        0.        , 0.00589623, 0.00789084, 0.03013831, 0.18707902,
+        0.64843534, 0.92417131, 0, 0.98977505, 1.
+    ])
+    reliability_curve(acc * 0.5, conf, label="NB", ax=axs[1][1], color="b")
+    reliability_curve(acc, conf, label="SVC", ax=axs[1][1], title="Reliability Curve, Missing bins")
+    plt.show()
+
+
+if __name__ == "__main__":
+    _demo()

--- a/layers/eight_mile/tf/optz.py
+++ b/layers/eight_mile/tf/optz.py
@@ -626,6 +626,7 @@ def optimizer(loss_fn, **kwargs):
             clip_gradients=clip,
             learning_rate_decay_fn=lr_scheduler,
             increment_global_step=True,
+            variables=kwargs.get('variables')
         ),
     )
 

--- a/layers/setup.py
+++ b/layers/setup.py
@@ -42,6 +42,7 @@ def main():
             "test": ["pytest", "mock", "contextdecorator", "pytest-forked"],
             "yaml": ["pyyaml"],
             "tf2": ["tensorflow_addons"],
+            "plot": ["matplotlib"],
         },
         entry_points={"console_scripts": ["bleu = eight_mile.bleu:main" "conlleval = eight_mile.conlleval:main"]},
         classifiers={

--- a/scripts/compare_calibrations.py
+++ b/scripts/compare_calibrations.py
@@ -1,0 +1,152 @@
+"""Plot and compare the metrics from various calibrated models.
+
+This script creates the following:
+
+    * A csv file with columns for the Model Type (the label), and the various calibration metrics
+    * A grid of graphs, the first row is confidence histograms for each model, the second row is
+      the reliability diagram for that model.
+    * If the problem as binary it creates calibration curves for each model all plotted on the same graph.
+
+Matplotlib is required to use this script. The `tabulate` package is recommended but not required.
+
+The input of this script is pickle files created by `$MEAD-BASELINE/api-examples/analyze_calibration.py`
+"""
+
+import csv
+import pickle
+import argparse
+from collections import Counter
+from eight_mile.calibration import (
+    expected_calibration_error,
+    maximum_calibration_error,
+    reliability_diagram,
+    reliability_curve,
+    confidence_histogram,
+    Bins,
+)
+import matplotlib.pyplot as plt
+
+
+parser = argparse.ArgumentParser(description="Compare calibrated models by grouping visualizations and creating a table.")
+parser.add_argument("--stats", nargs="+", default=[], required=True, help="A list of pickles created by the analyze_calibration.py script to compare.")
+parser.add_argument("--labels", nargs="+", default=[], required=True, help="A list of labels to assign to each pickle, should have the same number of arguments as --stats")
+parser.add_argument("--metrics-output", "--metrics_output", default="table.csv", help="Filename to save the resulting metrics into as a csv")
+parser.add_argument("--curve-output", "--curve_output", default="curve.png", help="Filename to save the reliability curves graph to.")
+parser.add_argument("--diagram-output", "--diagram_output", default="diagram.png", help="Filename to save the reliability diagrams and confidence histograms too.")
+parser.add_argument("--figsize", default=10, type=int, help="The size of the figure, controls how tall the figure is.")
+args = parser.parse_args()
+
+# Make sure the labels and stats are aligned
+if len(args.stats) != len(args.labels):
+    raise ValueError(f"You need a label for each calibration stat you load. Got {len(args.stats)} stats and {len(args.labels)} labels")
+
+# Make sure the labels are unique
+counts = Counter(args.labels)
+if any(v != 1 for v in counts.values()):
+    raise ValueError(f"All labels must be unique, found duplicates of {[k for k, v in counts.items() if v != 1]}")
+
+# Load the calibration stats
+stats = []
+for file_name in args.stats:
+    with open(file_name, "rb") as f:
+        stats.append(pickle.load(f))
+
+# Make sure there is the same number of bins for each model
+for field in stats[0]:
+    if not isinstance(stats[0][field], Bins):
+        continue
+    lengths = []
+    for stat in stats:
+        if stat[field] is None:
+            continue
+        lengths.append(len(stat[field].accs))
+    if len(set(lengths)) != 1:
+        raise ValueError(f"It is meaningless to compare calibrations with different numbers of bins: Mismatch was found for {field}")
+
+
+def get_metrics(data, model_type):
+    return {
+        "Model Type": model_type,
+        "ECE": expected_calibration_error(data.accs, data.confs, data.counts) * 100,
+        "MCE": maximum_calibration_error(data.accs, data.confs, data.counts) * 100,
+    }
+
+# Calculate the metrics based on the multiclass calibration bins
+metrics = [get_metrics(stat['multiclass'], label) for stat, label in zip(stats, args.labels)]
+
+# Print the metrics
+try:
+    # If you have tabulate installed it prints a nice postgres style table
+    from tabulate import tabulate
+    print(tabulate(metrics, headers="keys", floatfmt=".3f", tablefmt="psql"))
+except ImportError:
+    for metric in metrics:
+        for k, v in metric.items():
+            if isinstance(v, float):
+                print(f"{k}: {v:.3f}")
+            else:
+                print(f"{k}: {v}")
+
+# Write the metrics to a csv to look at later
+with open(args.metrics_output, "w", newline="") as csvfile:
+    writer = csv.DictWriter(csvfile, fieldnames=list(metrics[0].keys()), quoting=csv.QUOTE_MINIMAL, delimiter=",", dialect="unix")
+    writer.writeheader()
+    writer.writerows(metrics)
+
+# Plot the histograms and graphs for each model
+f, ax = plt.subplots(2, len(metrics), figsize=(args.figsize * len(metrics) // 2, args.figsize), sharey=True, sharex=True)
+for i, (stat, label) in enumerate(zip(stats, args.labels)):
+    # If you are the first model you get y_labels, everyone else just uses yours
+    if i == 0:
+        confidence_histogram(
+            stat['histogram'].edges,
+            stat['histogram'].counts,
+            acc=stat['acc'],
+            avg_conf=stat['conf'],
+            title=f"{label}\nConfidence Distribution",
+            x_label=None,
+            ax=ax[0][i],
+        )
+        reliability_diagram(
+            stat['multiclass'].accs,
+            stat['multiclass'].confs,
+            stat['multiclass'].edges,
+            num_classes=stat['num_classes'],
+            ax=ax[1][i]
+        )
+    else:
+        confidence_histogram(
+            stat['histogram'].edges,
+            stat['histogram'].counts,
+            acc=stat['acc'],
+            avg_conf=stat['conf'],
+            title=f"{label}\nConfidence Distribution",
+            y_label=None,
+            x_label=None,
+            ax=ax[0][i],
+        )
+        reliability_diagram(
+            stat['multiclass'].accs,
+            stat['multiclass'].confs,
+            stat['multiclass'].edges,
+            num_classes=stat['num_classes'],
+            y_label=None,
+            ax=ax[1][i]
+        )
+
+f.savefig(args.diagram_output)
+plt.show()
+
+# Plot reliability curves for binary classification models
+if stats[0]['num_classes'] == 2:
+    f, ax = plt.subplots(1, 1, figsize=(args.figsize, args.figsize))
+    for stat, label, color in zip(stats, args.labels, plt.rcParams['axes.prop_cycle'].by_key()['color']):
+        reliability_curve(
+            stat['binary'].accs,
+            stat['binary'].confs,
+            color=color,
+            label=label,
+            ax=ax
+        )
+    f.savefig(args.curve_output)
+    plt.show()


### PR DESCRIPTION
Calibration is an important tool for trustworthy models. When you have a
classifier it often outputs scores for each class that people
interpret as probabilities for each class. The problem is these are
often not well calibrated. This means that when you have 100 examples
that all have a score of 0.8 we would expected that about 80 of those
100 examples would be correctly labeled by the model, however; with
neural networks this is often not the case. When a model says that
examples have a probability of 0.8 the proportion of examples that are
correct will be much less than than the expected 80/100. These models
are over confident in their answers.

This PR adds metrics, models, and training for calibration as discussed
in [On Calibration of Modern Neural Networks](https://arxiv.org/abs/1706.04599).
It adds metrics and visualization as an `eight_mile.calibration`
package, adds various post-hoc methods for calibration as addons, adds
and api-example to collect metrics on calibrations, and adds a script
that can combine the various graphs that describe calibration into a
single figure.

The way this models are trained is with a checkpoint. First you train a
model as normal with `mead-train` and then you use a second config that
specifies the same model but set the model type to one of the new
calibrations methods and pass the checkpoint of the old model in. You
need to make sure the model is specified the same as the old model or
else weights won't get read into the checkpoint.

The final thing this PR does it that it updates the classify trainer to
only update the `.trainable_variables` of a model. This means that by
controlling this value in the post-hoc calibration models we can in
effect freeze the rest of the network weights by ignoring them in the
optimization.