### PR TITLE
use pytorch data loader to train

### DIFF
--- a/baseline/pytorch/classify/model.py
+++ b/baseline/pytorch/classify/model.py
@@ -118,10 +118,10 @@ class ClassifierModelBase(nn.Module, ClassifierModel):
 
     def predict_batch(self, batch_dict, **kwargs):
         numpy_to_tensor = bool(kwargs.get('numpy_to_tensor', True))
-        examples, prem_idx = self.make_input(batch_dict, perm=True, numpy_to_tensor=numpy_to_tensor)
+        examples, perm_idx = self.make_input(batch_dict, perm=True, numpy_to_tensor=numpy_to_tensor)
         with torch.no_grad():
             probs = self(examples).exp()
-            probs = unsort_batch(probs, prem_idx)
+            probs = unsort_batch(probs, perm_idx)
         return probs
 
     def predict(self, batch_dict, raw=False, dense=False, **kwargs):

--- a/baseline/pytorch/classify/model.py
+++ b/baseline/pytorch/classify/model.py
@@ -54,54 +54,76 @@ class ClassifierModelBase(nn.Module, ClassifierModel):
     def create_loss(self):
         return nn.NLLLoss()
 
-    def make_input(self, batch_dict, numpy_to_tensor=False):
+    def make_input(self, batch_dict, perm=False, numpy_to_tensor=False):
         """Transform a `batch_dict` into something usable in this model
 
         :param batch_dict: (``dict``) A dictionary containing all inputs to the embeddings for this model
         :return:
         """
         example_dict = dict({})
-        for key in self.embeddings.keys():
-            if numpy_to_tensor:
-                example_dict[key] = torch.from_numpy(batch_dict[key])
-            else:
-                example_dict[key] = batch_dict[key]
-            if self.gpu:
-                example_dict[key] = example_dict[key].cuda()
+        perm_idx = None
 
         # Allow us to track a length, which is needed for BLSTMs
         if self.lengths_key is not None:
+            lengths = batch_dict[self.lengths_key]
+
             if numpy_to_tensor:
-                example_dict['lengths'] = torch.from_numpy(batch_dict[self.lengths_key])
-            else:
-                example_dict['lengths'] = batch_dict[self.lengths_key]
+                lengths = torch.from_numpy(lengths)
+                lengths, perm_idx = lengths.sort(0, descending=True)
+                if self.gpu:
+                    lengths = lengths.cuda()
+                example_dict['lengths'] = lengths
+
+        for key in self.embeddings.keys():
+            tensor = torch.from_numpy(batch_dict[key])
+            if numpy_to_tensor:
+
+                tensor = torch.from_numpy(tensor)
+            if perm_idx is not None:
+                tensor = tensor[perm_idx]
             if self.gpu:
-                example_dict['lengths'] = example_dict['lengths'].cuda()
+                tensor = tensor.cuda()
+            example_dict[key] = tensor
 
         y = batch_dict.get('y')
         if y is not None:
             if numpy_to_tensor:
                 y = torch.from_numpy(y)
+            if perm_idx is not None:
+                y = y[perm_idx]
             if self.gpu:
                 y = y.cuda()
             example_dict['y'] = y
+
+        if perm:
+            return example_dict, perm_idx
 
         return example_dict
 
     def forward(self, input: Dict[str, torch.Tensor]):
         return self.layers(input)
 
-    def predict(self, batch_dict, **kwargs):
+    def predict_batch(self, batch_dict, **kwargs):
         numpy_to_tensor = bool(kwargs.get('numpy_to_tensor', True))
-        examples = self.make_input(batch_dict, numpy_to_tensor=numpy_to_tensor)
-
+        examples, prem_idx = self.make_input(batch_dict, perm=True, numpy_to_tensor=numpy_to_tensor)
         with torch.no_grad():
             probs = self(examples).exp()
-            results = []
-            batchsz = probs.size(0)
-            for b in range(batchsz):
-                outcomes = [(self.labels[id_i], prob_i) for id_i, prob_i in enumerate(probs[b])]
-                results.append(outcomes)
+        probs = unsort_batch(probs, prem_idx)
+        return probs
+
+    def predict(self, batch_dict, raw=False, dense=False, **kwargs):
+        probs = self.predict_batch(batch_dict, **kwargs)
+        if raw and not dense:
+            logger.warning(
+                "Warning: `raw` parameter is deprecated pass `dense=True` to get back values as a single tensor")
+            dense = True
+        if dense:
+            return probs
+        results = []
+        batchsz = probs.size(0)
+        for b in range(batchsz):
+            outcomes = [(self.labels[id_i], prob_i) for id_i, prob_i in enumerate(probs[b])]
+            results.append(outcomes)
         return results
 
     def get_labels(self):

--- a/baseline/pytorch/classify/model.py
+++ b/baseline/pytorch/classify/model.py
@@ -69,10 +69,10 @@ class ClassifierModelBase(nn.Module, ClassifierModel):
 
             if numpy_to_tensor:
                 lengths = torch.from_numpy(lengths)
-                lengths, perm_idx = lengths.sort(0, descending=True)
-                if self.gpu:
-                    lengths = lengths.cuda()
-                example_dict['lengths'] = lengths
+            lengths, perm_idx = lengths.sort(0, descending=True)
+            if self.gpu:
+                lengths = lengths.cuda()
+            example_dict['lengths'] = lengths
 
         for key in self.embeddings.keys():
             tensor = torch.from_numpy(batch_dict[key])

--- a/baseline/pytorch/seq2seq/train.py
+++ b/baseline/pytorch/seq2seq/train.py
@@ -9,6 +9,7 @@ from baseline.train import Trainer, create_trainer, register_trainer, register_t
 from eight_mile.pytorch.optz import OptimizerManager
 from eight_mile.bleu import bleu
 from baseline.model import create_model_for
+from torch.utils.data import DataLoader
 
 logger = logging.getLogger('baseline')
 
@@ -17,7 +18,7 @@ logger = logging.getLogger('baseline')
 class Seq2SeqTrainerPyTorch(Trainer):
 
     def __init__(self, model, **kwargs):
-        super(Seq2SeqTrainerPyTorch, self).__init__()
+        super().__init__()
         if type(model) is dict:
             model = create_model_for('seq2seq', **model)
 
@@ -43,7 +44,7 @@ class Seq2SeqTrainerPyTorch(Trainer):
 
     @staticmethod
     def _num_toks(tgt_lens):
-        return np.sum(tgt_lens)
+        return float(torch.sum(tgt_lens))
 
     def save(self, model_file):
         self._get_pytorch_model().save(model_file)
@@ -99,7 +100,7 @@ class Seq2SeqTrainerPyTorch(Trainer):
         for batch_dict in pg(es):
             tgt = batch_dict['tgt']
             tgt_lens = batch_dict['tgt_lengths']
-            pred = [p[0] for p in self._predict(batch_dict, **kwargs)]
+            pred = [p[0] for p in self._predict(batch_dict, numpy_to_tensor=False, **kwargs)]
             preds.extend(convert_seq2seq_preds(pred, self.tgt_rlut))
             golds.extend(convert_seq2seq_golds(tgt, tgt_lens, self.tgt_rlut))
         metrics = {'bleu': bleu(preds, golds)[0]}
@@ -158,6 +159,13 @@ def fit(model_params, ts, vs, es=None, **kwargs):
     do_early_stopping = bool(kwargs.get('do_early_stopping', True))
     epochs = int(kwargs.get('epochs', 20))
     model_file = get_model_file('seq2seq', 'pytorch', kwargs.get('basedir'))
+
+
+    num_loader_workers = int(kwargs.get('num_loader_workers', 0))
+    pin_memory = bool(kwargs.get('pin_memory', True))
+    ts = DataLoader(ts, num_workers=num_loader_workers, batch_size=None, pin_memory=pin_memory)
+    vs = DataLoader(vs, batch_size=None, pin_memory=pin_memory)
+    es = DataLoader(es, batch_size=None, pin_memory=pin_memory) if es is not None else None
 
     best_metric = 0
     if do_early_stopping:

--- a/baseline/pytorch/seq2seq/train.py
+++ b/baseline/pytorch/seq2seq/train.py
@@ -44,7 +44,7 @@ class Seq2SeqTrainerPyTorch(Trainer):
 
     @staticmethod
     def _num_toks(tgt_lens):
-        return float(torch.sum(tgt_lens))
+        return torch.sum(tgt_lens).item()
 
     def save(self, model_file):
         self._get_pytorch_model().save(model_file)

--- a/baseline/pytorch/tagger/train.py
+++ b/baseline/pytorch/tagger/train.py
@@ -8,6 +8,7 @@ from baseline.pytorch.torchy import *
 from eight_mile.pytorch.optz import OptimizerManager
 from eight_mile.utils import span_f1, per_entity_f1, conlleval_output
 from baseline.model import create_model_for
+from torch.utils.data import DataLoader
 
 logger = logging.getLogger('baseline')
 
@@ -169,6 +170,13 @@ def fit(model_params, ts, vs, es, **kwargs):
     model_file = get_model_file('tagger', 'pytorch', kwargs.get('basedir'))
     conll_output = kwargs.get('conll_output', None)
     txts = kwargs.get('txts', None)
+
+
+    num_loader_workers = int(kwargs.get('num_loader_workers', 0))
+    pin_memory = bool(kwargs.get('pin_memory', True))
+    ts = DataLoader(ts, num_workers=num_loader_workers, batch_size=None, pin_memory=pin_memory)
+    vs = DataLoader(vs, batch_size=None, pin_memory=pin_memory)
+    es = DataLoader(es, batch_size=None, pin_memory=pin_memory) if es is not None else None
 
     best_metric = 0
     if do_early_stopping:

--- a/baseline/pytorch/torchy.py
+++ b/baseline/pytorch/torchy.py
@@ -108,3 +108,4 @@ def long_tensor_alloc(dims, dtype=None):
     if type(dims) == int or len(dims) == 1:
         return torch.LongTensor(dims)
     return torch.LongTensor(*dims)
+


### PR DESCRIPTION
Use PyTorch's built-in `DataLoader` to traverse the MEAD-generated map-style dataset.
This is a pre-cursor for doing larger-scale processing in the future with access to multiple workers.

Analysis of the timing logs shows that the impact is negligable, and the model performance is not impacted.

One change that is required is to not assume that `make_input` should be accessing numpy arrays,
I added a `numpy_to_tensor` boolean to the argument list and to the sub-methods it calls for each task, and default this to false, so that for all training we do not have it on.

I also made the predict methods support `kwargs` and default to `numpy_to_tensor` on.