### PR TITLE
fix: make pytorch classifier models work again

### DIFF
--- a/baseline/pytorch/classify/model.py
+++ b/baseline/pytorch/classify/model.py
@@ -67,7 +67,6 @@ class ClassifierModelBase(nn.Module, ClassifierModel):
         # Allow us to track a length, which is needed for BLSTMs
         if self.lengths_key is not None:
             lengths = batch_dict[self.lengths_key]
-
             if numpy_to_tensor:
                 lengths = torch.from_numpy(lengths)
             lengths, perm_idx = lengths.sort(0, descending=True)
@@ -76,27 +75,14 @@ class ClassifierModelBase(nn.Module, ClassifierModel):
             example_dict['lengths'] = lengths
 
         for key in self.embeddings.keys():
-            tensor = torch.from_numpy(batch_dict[key])
+            tensor = batch_dict[key]
             if numpy_to_tensor:
-
                 tensor = torch.from_numpy(tensor)
             if perm_idx is not None:
                 tensor = tensor[perm_idx]
-
             if self.gpu:
                 tensor = tensor.cuda()
             example_dict[key] = tensor
-
-        if perm_idx is None:
-            for key in self.embeddings.keys():
-                example_dict[key] = torch.from_numpy(batch_dict[key])
-                if self.gpu:
-                    example_dict[key] = example_dict[key].cuda()
-        else:
-            for key in self.embeddings.keys():
-                example_dict[key] = torch.from_numpy(batch_dict[key])[perm_idx]
-                if self.gpu:
-                    example_dict[key] = example_dict[key].cuda()
 
         y = batch_dict.get('y')
         if y is not None:

--- a/baseline/pytorch/classify/train.py
+++ b/baseline/pytorch/classify/train.py
@@ -59,8 +59,8 @@ class ClassifyTrainerPyTorch(EpochReportingTrainer):
     def save(self, model_file):
         self._get_pytorch_model().save(model_file)
 
-    def _make_input(self, batch_dict):
-        return self._get_pytorch_model().make_input(batch_dict)
+    def _make_input(self, batch_dict, **kwargs):
+        return self._get_pytorch_model().make_input(batch_dict, **kwargs)
 
     @staticmethod
     def _get_batchsz(batch_dict):
@@ -80,7 +80,7 @@ class ClassifyTrainerPyTorch(EpochReportingTrainer):
         line_number = 0
         if output is not None and txts is not None:
             handle = open(output, "w")
-        
+
         for batch_dict in pg(loader):
             example = self._make_input(batch_dict)
             ys = example.pop('y')
@@ -192,8 +192,6 @@ def fit(model_params, ts, vs, es, **kwargs):
     trainer = create_trainer(model_params, **kwargs)
 
     last_improved = 0
-
-
 
     for epoch in range(epochs):
         trainer.train(ts, reporting_fns)


### PR DESCRIPTION
In the change to allowing for using the Pytorch DataLoaders the `make_input` function for the pytorch classifiers were broken. This fixes that problem