### PR TITLE
chore: add hook for the output layer of EmbedPoolStackModel

### DIFF
--- a/baseline/pytorch/classify/model.py
+++ b/baseline/pytorch/classify/model.py
@@ -43,7 +43,8 @@ class ClassifierModelBase(nn.Module, ClassifierModel):
         model.labels = labels
         pool_model = model.init_pool(embed_model.dsz, **kwargs)
         stack_model = model.init_stacked(pool_model.output_dim, **kwargs)
-        model.layers = EmbedPoolStackModel(len(labels), embed_model, pool_model, stack_model)
+        output_model = model.init_output(stack_model.output_dim if stack_model else pool_model.output_dim, len(labels), **kwargs)
+        model.layers = EmbedPoolStackModel(len(labels), embed_model, pool_model, stack_model, output_model)
         logger.info(model)
         return model
 
@@ -157,6 +158,11 @@ class ClassifierModelBase(nn.Module, ClassifierModel):
         if len(hszs) == 0:
             return None
         return DenseStack(input_dim, hszs)
+
+    def init_output(self, input_dim, output_dim, **kwargs):
+        if input_dim is None:
+            return None
+        return Dense(input_dim, output_dim, activation=kwargs.get('output_activation', 'log_softmax'))
 
 
 @register_model(task='classify', name='default')

--- a/layers/eight_mile/pytorch/layers.py
+++ b/layers/eight_mile/pytorch/layers.py
@@ -1793,10 +1793,9 @@ class EmbedPoolStackModel(nn.Module):
         super().__init__()
         self.embed_model = embeddings
         self.pool_model = pool_model
-        output_dim = self.pool_model.output_dim if stack_model is None else stack_model.output_dim
-        self.output_layer = Dense(output_dim, nc, activation="log_softmax")
         self.stack_model = stack_model if stack_model else nn.Identity()
-        self.output_layer = Dense(output_dim, nc, activation="log_softmax") if output_model is None else output_model
+        output_dim = self.pool_model.output_dim if stack_model is None else stack_model.output_dim
+        self.output_model = Dense(output_dim, nc, activation="log_softmax") if output_model is None else output_model
 
     def forward(self, inputs: Dict[str, torch.Tensor]):
         lengths = inputs["lengths"]
@@ -1804,7 +1803,7 @@ class EmbedPoolStackModel(nn.Module):
         embedded = (embedded, lengths)
         pooled = self.pool_model(embedded)
         stacked = self.stack_model(pooled)
-        return self.output_layer(stacked)
+        return self.output_model(stacked)
 
 
 class PassThru(nn.Module):

--- a/layers/eight_mile/pytorch/layers.py
+++ b/layers/eight_mile/pytorch/layers.py
@@ -1795,7 +1795,7 @@ class EmbedPoolStackModel(nn.Module):
         self.pool_model = pool_model
         self.stack_model = stack_model if stack_model else nn.Identity()
         output_dim = self.pool_model.output_dim if stack_model is None else stack_model.output_dim
-        self.output_model = Dense(output_dim, nc, activation="log_softmax") if output_model is None else output_model
+        self.output_layer = Dense(output_dim, nc, activation="log_softmax") if output_model is None else output_model
 
     def forward(self, inputs: Dict[str, torch.Tensor]):
         lengths = inputs["lengths"]
@@ -1803,7 +1803,7 @@ class EmbedPoolStackModel(nn.Module):
         embedded = (embedded, lengths)
         pooled = self.pool_model(embedded)
         stacked = self.stack_model(pooled)
-        return self.output_model(stacked)
+        return self.output_layer(stacked)
 
 
 class PassThru(nn.Module):

--- a/layers/eight_mile/tf/layers.py
+++ b/layers/eight_mile/tf/layers.py
@@ -2749,7 +2749,7 @@ class EmbedPoolStackModel(tf.keras.Model):
         self.pool_requires_length = getattr(pool_model, "requires_length", False)
         self.pool_model = pool_model
         self.stack_model = stack_model
-        self.output_model = tf.keras.layers.Dense(nc) if output_model is None else output_model
+        self.output_layer = tf.keras.layers.Dense(nc) if output_model is None else output_model
 
     def call(self, inputs):
         lengths = inputs.get("lengths")
@@ -2758,7 +2758,7 @@ class EmbedPoolStackModel(tf.keras.Model):
             embedded = (embedded, lengths)
         pooled = self.pool_model(embedded)
         stacked = self.stack_model(pooled) if self.stack_model is not None else pooled
-        return self.output_model(stacked)
+        return self.output_layer(stacked)
 
 
 class FineTuneModel(tf.keras.Model):

--- a/layers/eight_mile/tf/layers.py
+++ b/layers/eight_mile/tf/layers.py
@@ -2746,23 +2746,19 @@ class EmbedPoolStackModel(tf.keras.Model):
     ):
         super().__init__(name=name)
         self.embed_model = embeddings
-        self.pool_requires_length = False
-        if hasattr(pool_model, "requires_length"):
-            self.pool_requires_length = pool_model.requires_length
+        self.pool_requires_length = getattr(pool_model, "requires_length", False)
         self.pool_model = pool_model
         self.stack_model = stack_model
-        self.output_layer = tf.keras.layers.Dense(nc) if output_model is None else output_model
+        self.output_model = tf.keras.layers.Dense(nc) if output_model is None else output_model
 
     def call(self, inputs):
         lengths = inputs.get("lengths")
-
         embedded = self.embed_model(inputs)
-
         if self.pool_requires_length:
             embedded = (embedded, lengths)
         pooled = self.pool_model(embedded)
         stacked = self.stack_model(pooled) if self.stack_model is not None else pooled
-        return self.output_layer(stacked)
+        return self.output_model(stacked)
 
 
 class FineTuneModel(tf.keras.Model):


### PR DESCRIPTION
In the shuffle of deciding if we should move eight_mile into it's own repo the changes that let you override the output hook in the pytorch classifier model got lost. This PR changes them back. It also updates the name if the output from `output_layer` to `output_model` to be consistent with the naming of the other parts of the model (`pool_model`, etc) 