### PR TITLE
Stop writing out the meta-graph, as not needed

### DIFF
--- a/addons/create_servable_embeddings.py
+++ b/addons/create_servable_embeddings.py
@@ -200,7 +200,7 @@ class ServableTensorFlowEmbeddingsModel(ServableEmbeddingsModel):
             e.save_md('{}-{}-md.json'.format(basename, k))
 
     def save_values(self, basename):
-        self.saver.save(self.sess, basename)
+        self.saver.save(self.sess, basename, write_meta_graph=False)
 
 
 @register_exporter(task='servable_embeddings', name='default')

--- a/api-examples/classify-text.py
+++ b/api-examples/classify-text.py
@@ -1,6 +1,7 @@
 import baseline as bl
 import argparse
 import os
+from baseline.utils import str2bool
 
 parser = argparse.ArgumentParser(description='Classify text with a model')
 parser.add_argument('--model', help='The path to either the .zip file created by training or to the client bundle '
@@ -16,7 +17,13 @@ parser.add_argument('--preproc', help='(optional) where to perform preprocessing
 parser.add_argument('--batchsz', help='batch size when --text is a file', default=100, type=int)
 parser.add_argument('--model_type', type=str, default='default')
 parser.add_argument('--modules', default=[])
+parser.add_argument('--prefer_eager', help="If running in TensorFlow, should we prefer eager model", type=str2bool)
+
 args = parser.parse_args()
+
+if args.backend == 'tf':
+    from eight_mile.tf.layers import set_tf_eager_mode
+    set_tf_eager_mode(args.prefer_eager)
 
 for mod_name in args.modules:
     bl.import_user_module(mod_name)

--- a/api-examples/ed-text.py
+++ b/api-examples/ed-text.py
@@ -2,6 +2,8 @@ from __future__ import print_function
 import baseline as bl
 import argparse
 import os
+from baseline.utils import str2bool
+
 parser = argparse.ArgumentParser(description='Encoder-Decoder execution')
 parser.add_argument('--model', help='An encoder-decoder model', required=True, type=str)
 parser.add_argument('--text', help='raw value or a file', type=str)
@@ -14,8 +16,13 @@ parser.add_argument('--batchsz', help='Size of a batch to pass at once', default
 parser.add_argument('--device', help='device')
 parser.add_argument('--alpha', type=float, help='If set use in the gnmt length penalty.')
 parser.add_argument('--beam', type=int, default=30, help='The size of beam to use.')
+parser.add_argument('--prefer_eager', help="If running in TensorFlow, should we prefer eager model", type=str2bool)
 
 args = parser.parse_known_args()[0]
+
+if args.backend == 'tf':
+    from eight_mile.tf.layers import set_tf_eager_mode
+    set_tf_eager_mode(args.prefer_eager)
 
 batches = []
 if os.path.exists(args.text) and os.path.isfile(args.text):

--- a/api-examples/lm-text.py
+++ b/api-examples/lm-text.py
@@ -1,13 +1,19 @@
 import baseline as bl
 import argparse
 import os
+from baseline.utils import str2bool
 parser = argparse.ArgumentParser(description='Classify text with a model')
 parser.add_argument('--model', help='A classifier model', required=True, type=str)
 parser.add_argument('--text', help='raw value', type=str)
 parser.add_argument('--device', help='device')
+parser.add_argument('--prefer_eager', help="If running in TensorFlow, should we prefer eager model", type=str2bool)
 
 
 args = parser.parse_known_args()[0]
+
+if args.backend == 'tf':
+    from eight_mile.tf.layers import set_tf_eager_mode
+    set_tf_eager_mode(args.prefer_eager)
 
 if os.path.exists(args.text) and os.path.isfile(args.text):
     texts = []

--- a/api-examples/tag-text.py
+++ b/api-examples/tag-text.py
@@ -21,7 +21,13 @@ parser.add_argument('--export_mapping', help='mapping between features and the f
                                                          'request, eg: token:word ner:ner. This should match with the '
                                                          '`exporter_field` definition in the mead config',
                     default=[], nargs='+')
+parser.add_argument('--prefer_eager', help="If running in TensorFlow, should we prefer eager model", type=str2bool)
+
 args = parser.parse_args()
+
+if args.backend == 'tf':
+    from eight_mile.tf.layers import set_tf_eager_mode
+    set_tf_eager_mode(args.prefer_eager)
 
 
 def create_export_mapping(feature_map_strings):

--- a/baseline/tf/classify/model.py
+++ b/baseline/tf/classify/model.py
@@ -59,7 +59,7 @@ class ClassifierModelBase(tf.keras.Model, ClassifierModel):
         :return:
         """
         if not tf.executing_eagerly():
-            self.saver.save(self.sess, basename)
+            self.saver.save(self.sess, basename, write_meta_graph=False)
         else:
             self.save_weights(f"{basename}.wgt")
 

--- a/baseline/tf/classify/training/utils.py
+++ b/baseline/tf/classify/training/utils.py
@@ -240,7 +240,10 @@ class ClassifyTrainerTf(EpochReportingTrainer):
         :return: None
         """
         checkpoint_dir = '{}-{}'.format("./tf-classify", os.getpid())
-        self.model.saver.save(self.sess, os.path.join(checkpoint_dir, 'classify'), global_step=self.global_step)
+        self.model.saver.save(self.sess,
+                              os.path.join(checkpoint_dir, 'classify'),
+                              global_step=self.global_step,
+                              write_meta_graph=False)
 
     def recover_last_checkpoint(self):
         """Recover the last saved checkpoint

--- a/baseline/tf/lm/model.py
+++ b/baseline/tf/lm/model.py
@@ -34,7 +34,7 @@ class LanguageModelBase(tf.keras.Model, LanguageModel):
         :return:
         """
         if not tf.executing_eagerly():
-            self.saver.save(self.sess, basename)
+            self.saver.save(self.sess, basename, write_meta_graph=False)
         else:
             self.save_weights(f"{basename}.wgt")
 

--- a/baseline/tf/lm/training/utils.py
+++ b/baseline/tf/lm/training/utils.py
@@ -113,7 +113,10 @@ class LanguageModelTrainerTf(Trainer):
         :return: None
         """
         checkpoint_dir = '{}-{}'.format("./tf-lm", os.getpid())
-        self.model.saver.save(self.sess, os.path.join(checkpoint_dir, 'lm'), global_step=self.global_step)
+        self.model.saver.save(self.sess,
+                              os.path.join(checkpoint_dir, 'lm'),
+                              global_step=self.global_step,
+                              write_meta_graph=False)
 
     def recover_last_checkpoint(self):
         """Recover the last saved checkpoint

--- a/baseline/tf/seq2seq/model.py
+++ b/baseline/tf/seq2seq/model.py
@@ -199,7 +199,7 @@ if not tf.executing_eagerly():
 
         def save(self, model_base):
             self.save_md(model_base)
-            self.saver.save(self.sess, model_base)
+            self.saver.save(self.sess, model_base, write_meta_graph=False)
 
         def predict(self, batch_dict, **kwargs):
             feed_dict = self.make_input(batch_dict)

--- a/baseline/tf/seq2seq/training/utils.py
+++ b/baseline/tf/seq2seq/training/utils.py
@@ -115,7 +115,10 @@ class Seq2SeqTrainerTf(Trainer):
         :return: None
         """
         checkpoint_dir = '{}-{}'.format("./tf-seq2seq", os.getpid())
-        self.model.saver.save(self.sess, os.path.join(checkpoint_dir, 'seq2seq'), global_step=self.global_step)
+        self.model.saver.save(self.sess,
+                              os.path.join(checkpoint_dir, 'seq2seq'),
+                              global_step=self.global_step,
+                              write_meta_graph=False)
 
     def recover_last_checkpoint(self):
         """Recover the last saved checkpoint

--- a/baseline/tf/tagger/model.py
+++ b/baseline/tf/tagger/model.py
@@ -51,7 +51,7 @@ class TaggerModelBase(tf.keras.Model, TaggerModel):
         :return:
         """
         if not tf.executing_eagerly():
-            self.saver.save(self.sess, basename)
+            self.saver.save(self.sess, basename, write_meta_graph=False)
         else:
             self.save_weights(f"{basename}.wgt")
 

--- a/baseline/tf/tagger/training/utils.py
+++ b/baseline/tf/tagger/training/utils.py
@@ -212,7 +212,9 @@ class TaggerTrainerTf(EpochReportingTrainer):
         :return: None
         """
         checkpoint_dir = '{}-{}'.format("./tf-tagger", os.getpid())
-        self.model.saver.save(self.sess, os.path.join(checkpoint_dir, 'tagger'), global_step=self.global_step)
+        self.model.saver.save(self.sess, os.path.join(checkpoint_dir, 'tagger'),
+                              global_step=self.global_step,
+                              write_meta_graph=False)
 
     def recover_last_checkpoint(self):
         """Recover the last saved checkpoint

--- a/layers/eight_mile/tf/layers.py
+++ b/layers/eight_mile/tf/layers.py
@@ -10,6 +10,15 @@ BASELINE_TF_TRAIN_FLAG = None
 LOGGER = logging.getLogger('mead.layers')
 
 
+def set_tf_eager_mode(prefer_eager: bool = False):
+    tf_version = get_version(tf)
+    if prefer_eager and tf_version < 2:
+        LOGGER.info('user requesting eager on 1.x')
+        tf.compat.v1.enable_eager_execution()
+    elif not prefer_eager and tf_version >= 2:
+        LOGGER.info('User requesting eager disabled on 2.x')
+        tf.compat.v1.disable_eager_execution()
+
 def set_tf_log_level(ll):
     # 0     | DEBUG            | [Default] Print all messages
     # 1     | INFO             | Filter out INFO messages

--- a/mead/tasks.py
+++ b/mead/tasks.py
@@ -68,16 +68,8 @@ class Backend(object):
     def load(self, task_name=None):
         if self.name == 'tf':
             prefer_eager = self.params.get('prefer_eager', False)
-
-            import tensorflow as tf
-            tf_version = get_version(tf)
-            if prefer_eager and tf_version < 2:
-                logger.info('user requesting eager on 1.x')
-                tf.compat.v1.enable_eager_execution()
-            elif not prefer_eager and tf_version >= 2:
-                logger.info('User requesting eager disabled on 2.x')
-                tf.compat.v1.disable_eager_execution()
-            from eight_mile.tf.layers import set_tf_log_level
+            from eight_mile.tf.layers import set_tf_eager_mode, set_tf_log_level
+            set_tf_eager_mode(prefer_eager)
             set_tf_log_level(os.getenv("MEAD_TF_LOG_LEVEL", "ERROR"))
 
         base_pkg_name = 'baseline.{}'.format(self.name)


### PR DESCRIPTION
The meta-graph takes up space on disk and there
can be issues when the graph is greater than 2GB.
We never use this because we construct the graph
via code, so it can be removed.

Additionally, this fix adds the ability to enable
or disable eager mode in TF for API examples