### PR TITLE
fix recursion bug, more friendly checkpoint reload

### DIFF
--- a/layers/eight_mile/tf/layers.py
+++ b/layers/eight_mile/tf/layers.py
@@ -1731,7 +1731,7 @@ class EmbeddingsStack(tf.keras.layers.Layer):
 
     @property
     def requires_length(self) -> bool:
-        return self.requires_length
+        return self._requires_length
 
     @property
     def output_dim(self) -> bool:
@@ -2883,6 +2883,8 @@ def reload_checkpoint(sess: tf.compat.v1.Session, checkpoint: str, blocks_to_ski
     if not blocks_to_skip:
         blocks_to_skip = ['OptimizeLoss', 'output/']
     latest = tf.train.latest_checkpoint(checkpoint)
+    if not latest:
+        latest = checkpoint
     LOGGER.info("Reloading %s", latest)
     model_vars = set([t[0] for t in tf.train.list_variables(latest)])
     g = tf.compat.v1.get_collection_ref(tf.compat.v1.GraphKeys.GLOBAL_VARIABLES)


### PR DESCRIPTION
The checkpoint function used to fail if it was not
given a checkpoint that TF can recognize, becase
tf.train.latest_checkpoint returned None.  Now,
if that happens, assume they already gave us the
full checkpoint and just try using it