### PR TITLE
Adds class name cascading inside the tagger

### DIFF
--- a/layers/eight_mile/tf/embeddings.py
+++ b/layers/eight_mile/tf/embeddings.py
@@ -22,7 +22,7 @@ class TensorFlowEmbeddings(tf.keras.layers.Layer):
         # to be passed into it. These are not documented and you need to look into the
         # code to find this. For now just don't pass in out kwargs
         super().__init__(trainable, name, dtype)
-        self._name = name
+        #self._name = name
         self.W = None
 
     def get_dsz(self):

--- a/layers/eight_mile/tf/layers.py
+++ b/layers/eight_mile/tf/layers.py
@@ -2695,9 +2695,10 @@ class TagSequenceModel(tf.keras.Model):
         path, self.path_scores = self.decoder_model((transduced, lengths))
         return path
 
-    def call(self, inputs, training=None):
+    def call(self, inputs, return_probs=False):
         transduced = self.transduce(inputs)
-        return self.decode(transduced, inputs.get("lengths"))
+        decoded = self.decode(transduced, inputs.get("lengths"))
+        return (transduced, decoded) if return_probs else decoded
 
     def neg_log_loss(self, unary, tags, lengths):
         return self.decoder_model.neg_log_loss(unary, tags, lengths)


### PR DESCRIPTION
Previously, when we called the tagger, we were calling
`.transduce()` followed by `.decode()` so that we could grab
the probabilities from `.transduce().`  This meant that we
werent actually calling the `.call()` method, which caused
us not to scope the name of the models as we do in the
classifier.  This change makes the underlying `.call()` function
take an boolean to support returning the LSTM layer output
optionally, which means that we can now use the proper method
so that Keras/TF can figure out how to properly name our sub-objs

Previous behavior:
```
<tf.Variable 'embeddings_stack/word/word/LUT/Weight:0' shape=(7534, 200) dtype=float32>

```
New behavior:
```
<tf.Variable 'rnn_tagger_model/tag_sequence_model/embeddings_stack/word/word/LUT/Weight:0' shape=(7534, 200) dtype=float32>


```