### PR TITLE
Fix/tagger name cascading without sub-model

### DIFF
--- a/baseline/tf/tagger/model.py
+++ b/baseline/tf/tagger/model.py
@@ -162,8 +162,10 @@ class TaggerModelBase(tf.keras.Model, TaggerModel):
 
         return batch_for_model
 
-    def call(self, *args, **kwargs):
-        return self.impl(*args, **kwargs)
+    def call(self, inputs, **kwargs):
+        transduced = self.impl.transduce(inputs)
+        best = self.impl.decode(transduced, self.lengths)
+        return transduced, best
 
     @property
     def trainable_variables(self):
@@ -361,8 +363,7 @@ class TaggerModelBase(tf.keras.Model, TaggerModel):
 
         model.impl = TagSequenceModel(nc, embed_model, transduce_model, decode_model)
         if not tf.executing_eagerly():
-            model.probs = model.impl.transduce(inputs)
-            model.best = model.impl.decode(model.probs, model.lengths)
+            model.probs, model.best = model(inputs)
         return model
 
 

--- a/baseline/tf/tagger/model.py
+++ b/baseline/tf/tagger/model.py
@@ -162,10 +162,10 @@ class TaggerModelBase(tf.keras.Model, TaggerModel):
 
         return batch_for_model
 
-    def call(self, inputs, **kwargs):
+    def call(self, inputs, return_unaries=False):
         transduced = self.impl.transduce(inputs)
         best = self.impl.decode(transduced, self.lengths)
-        return transduced, best
+        return (transduced, best) if return_unaries else best
 
     @property
     def trainable_variables(self):
@@ -363,7 +363,7 @@ class TaggerModelBase(tf.keras.Model, TaggerModel):
 
         model.impl = TagSequenceModel(nc, embed_model, transduce_model, decode_model)
         if not tf.executing_eagerly():
-            model.probs, model.best = model(inputs)
+            model.probs, model.best = model(inputs, return_unaries=True)
         return model
 
 


### PR DESCRIPTION
Previously, when we called the tagger, we were calling
.transduce() followed by .decode() so that we could grab
the probabilities from .transduce(). This meant that we
werent actually calling the .call() method, which caused
us not to scope the name of the models as we do in the
classifier. This change makes the TaggerModelBase .call() function
take an boolean to support returning the LSTM layer output
optionally, which means that all sub-classes names will prepend to the graph names:

Previous behavior:
```
<tf.Variable 'embeddings_stack/word/word/LUT/Weight:0' shape=(7534, 200) dtype=float32>

```
Current behavior:
```
<tf.Variable 'rnn_tagger_model/embeddings_stack/word/word/LUT/Weight:0' shape=(7534, 200) dtype=float32>
```