### PR TITLE
fine-grain control over embedding placement

### DIFF
--- a/baseline/tf/tagger/training/eager.py
+++ b/baseline/tf/tagger/training/eager.py
@@ -5,7 +5,7 @@ import numpy as np
 import tensorflow as tf
 import logging
 from eight_mile.utils import listify, revlut, to_spans, write_sentence_conll, per_entity_f1, span_f1, conlleval_output
-from eight_mile.tf.layers import TRAIN_FLAG, SET_TRAIN_FLAG, reload_checkpoint
+from eight_mile.tf.layers import TRAIN_FLAG, SET_TRAIN_FLAG, reload_checkpoint, get_shape_as_list
 from eight_mile.tf.optz import EagerOptimizer
 from baseline.progress import create_progress_bar
 from baseline.model import create_model_for
@@ -195,7 +195,7 @@ class TaggerTrainerEagerTf(EpochReportingTrainer):
 
             lossv = self.optimizer.update(self.model.impl, features, y).numpy()
             step += 1
-            batchsz = y.shape[0]
+            batchsz = get_shape_as_list(y)[0]
             report_loss = lossv * batchsz
             epoch_loss += report_loss
             epoch_div += batchsz


### PR DESCRIPTION
Previously, we were explicitly forcing all
LUT embeddings onto the CPU in eager mode.
This is extremely bad for performance for optimizers
than can support GPU placed LUT updates and causes
issues with multi-worker distribution

This change adds an explicit variable that can
be passed via config and in cases where default
placement is not possible, will explicitly scope
to CPU device by checking the optimizer and seeing
if we are in eager mode