### PR TITLE
feat: use reporting functions for exporting

### DIFF
--- a/baseline/reporting.py
+++ b/baseline/reporting.py
@@ -35,6 +35,8 @@ class ReportingHook(object):
             tick_type = 'STEP'
             if phase in {'Valid', 'Test'}:
                 tick_type = 'EPOCH'
+            if phase == 'Export':
+                tick_type = 'EXPORT'
         return tick_type
 
 

--- a/mead/exporters.py
+++ b/mead/exporters.py
@@ -40,7 +40,7 @@ class Exporter(object):
             "version": model_version
         }
         for rep in self.task.reporting:
-            rep.step(msg, 0, 'Export', 'EPOCH')
+            rep.step(msg, 0, 'Export', 'EXPORT')
         self.task._close_reporting_hooks()
         return client_loc, server_loc
 

--- a/mead/pytorch/exporters.py
+++ b/mead/pytorch/exporters.py
@@ -83,7 +83,7 @@ class PytorchONNXExporter(Exporter):
     def apply_model_patches(self, model):
         return model
 
-    def run(self, basename, output_dir, project=None, name=None, model_version=None, **kwargs):
+    def _run(self, basename, output_dir, project=None, name=None, model_version=None, **kwargs):
         logger.warning("Pytorch exporting is experimental and is not guaranteed to work for plugin models.")
         client_output, server_output = get_output_paths(
             output_dir,
@@ -130,6 +130,7 @@ class PytorchONNXExporter(Exporter):
         logger.info("Saving metadata.")
         save_to_bundle(client_output, basename, assets=meta)
         logger.info('Successfully exported model to %s', output_dir)
+        return client_output, server_output
 
     def load_model(self, model_dir):
         model_name = find_model_basename(model_dir)

--- a/mead/tf/exporters.py
+++ b/mead/tf/exporters.py
@@ -38,10 +38,7 @@ class TensorFlowExporter(Exporter):
     def __init__(self, task, **kwargs):
         super(TensorFlowExporter, self).__init__(task, **kwargs)
 
-    def _run(self, sess, basename, **kwargs):
-        pass
-
-    def run(self, basename, output_dir, project=None, name=None, model_version=None, **kwargs):
+    def _run(self, basename, output_dir, project=None, name=None, model_version=None, **kwargs):
         basename = get_tf_index_from_unzipped(basename)
 
         with tf.compat.v1.Graph().as_default():


### PR DESCRIPTION
This PR adds the use of the reporting hooks for the `mead-export` command so it is configurable just like `mead-train`