### PR TITLE
fix: fix fake datasize for no mxlen vector

### DIFF
--- a/api-examples/classify-text-onnx.py
+++ b/api-examples/classify-text-onnx.py
@@ -96,13 +96,13 @@ class ONNXClassifierService(object):
             directory = unzip_files(bundle)
 
         model_basename = find_model_basename(directory).replace(".pyt", "")
-        model_name = f"{model_basename}.pyt.onnx"
+        model_name = f"{model_basename}.onnx"
 
         vocabs = load_vocabs(directory)
         vectorizers = load_vectorizers(directory)
 
         # Currently nothing to do here
-        labels = read_json(os.path.join(directory, model_basename) + '.labels')
+        labels = read_json(model_basename + '.labels')
 
         model = ort.InferenceSession(model_name)
         return cls(vocabs, vectorizers, model, labels)

--- a/api-examples/tag-text-onnx.py
+++ b/api-examples/tag-text-onnx.py
@@ -103,7 +103,7 @@ class ONNXTaggerService(object):
         vectorizers = load_vectorizers(directory)
 
         # Currently nothing to do here
-        labels = revlut(read_json(os.path.join(directory, model_basename) + '.labels'))
+        labels = revlut(read_json(model_basename + '.labels'))
 
         model = ort.InferenceSession(model_name)
         return cls(vocabs, vectorizers, model, labels)

--- a/baseline/utils.py
+++ b/baseline/utils.py
@@ -363,7 +363,7 @@ def unzip_files(zip_path):
 
 @export
 def find_model_basename(directory):
-    path = os.path.join(directory, [x for x in os.listdir(directory) if 'model' in x and '-md' not in x and 'wgt' not in x][0])
+    path = os.path.join(directory, [x for x in os.listdir(directory) if 'model' in x and '-md' not in x and 'wgt' not in x and '.assets' not in x][0])
     logger.info(path)
     path = path.split('.')[:-1]
     return '.'.join(path)

--- a/baseline/vectorizers.py
+++ b/baseline/vectorizers.py
@@ -1,6 +1,7 @@
+import collections
+from typing import Tuple
 import numpy as np
 from baseline.utils import exporter, optional_params, listify, register, Offsets, import_user_module
-import collections
 
 
 __all__ = []
@@ -19,7 +20,7 @@ class Vectorizer(object):
     def count(self, tokens):
         pass
 
-    def get_dims(self):
+    def get_dims(self) -> Tuple[int]:
         pass
 
     def iterable(self, tokens):

--- a/mead/pytorch/exporters.py
+++ b/mead/pytorch/exporters.py
@@ -51,17 +51,11 @@ def create_fake_data(shapes, vectorizers, order, min_=0, max_=50,):
     return ordered_data, lengths
 
 
-def create_data_dict(shapes, vectorizers, transpose=False, min_=0, max_=50):
+def create_data_dict(shapes, vectorizers, transpose=False, min_=0, max_=50, default_size=100):
     data = {}
     for k, v in vectorizers.items():
-        mxlen = v.mxlen if hasattr(v, 'mxlen') else -1
-        mxwlen = v.mxwlen if hasattr(v, 'mxwlen') else -1
-        if mxwlen >= 0:
-            data[k] = torch.randint(min_, max_, (1, mxlen, mxwlen))
-        elif mxlen >= 0:
-            data[k] = torch.randint(min_, max_, (1, mxlen))
-        else:
-            data[k] = torch.randint(min_, max_, (1,))
+        dims = [d if d >= 0 else default_size for d in v.get_dims()]
+        data[k] = torch.randint(min_, max_, [1, *dims])
 
     lengths = torch.LongTensor([data[list(data.keys())[0]].shape[1]])
 

--- a/mead/pytorch/exporters.py
+++ b/mead/pytorch/exporters.py
@@ -73,6 +73,7 @@ class PytorchONNXExporter(Exporter):
         super().__init__(task, **kwargs)
         self.transpose = kwargs.get('transpose', False)
         self.tracing = kwargs.get('tracing', True)
+        self.default_size = int(kwargs.get('default_size', 100))
 
     def apply_model_patches(self, model):
         return model
@@ -89,7 +90,7 @@ class PytorchONNXExporter(Exporter):
         logger.info("Saving serialized model to %s", server_output)
         model, vectorizers, model_name = self.load_model(basename)
         model = self.apply_model_patches(model)
-        data = create_data_dict(VECTORIZER_SHAPE_MAP, vectorizers, transpose=self.transpose)
+        data = create_data_dict(VECTORIZER_SHAPE_MAP, vectorizers, transpose=self.transpose, self.default_size)
 
         inputs = [k for k, _ in model.embeddings.items()] + ['lengths']
 


### PR DESCRIPTION
This PR updates the way fake data is created in the pytorch exporting to handle the case where the both mxlen and mxwlen was `-1`. When that would happen the data would be of size `(1,)` when it should be `(1, X)`.

This also makes a few tweaks to the `-onnx` runners to get them working for me. Maybe I did something wrong?

One thing that is annoying about the onnx export is that is uses pytorchs `forward` function which for the pytorch models returns the `log_softmax` while the `predict` method of a local model turns this into a normal softmax function so there is a mis-match between how the scores look, I did test and the values are the same (calling `.exp()` on the predicted output produces the softmax output)