### PR TITLE
Fix/pretrain restart ckpt

### DIFF
--- a/api-examples/pretrain-paired.py
+++ b/api-examples/pretrain-paired.py
@@ -28,7 +28,7 @@ def save_checkpoint(model: torch.nn.Module, model_base: str, count: int, tick_ty
     checkpoint_name = checkpoint_for(model_base, count, tick_type=tick_type)
     # Its possible due to how its called that we might save the same checkpoint twice if we dont check first
     if os.path.exists(checkpoint_name):
-        logger.info("Checkpoint already exists: %d", count+1)
+        logger.info("Checkpoint already exists: %s", checkpoint_name)
         return
     logger.info("Creating checkpoint: %s", checkpoint_name)
     if hasattr(model, 'module'):


### PR DESCRIPTION
- fix some small bugs in checkpoint saving and restarting from. Now in the middle of an epoch, it saves `checkpoint-step-[#step]`; and at the end of a epoch it saves `checkpoint-epoch-[#epoch]`. e.g. at the end of the 1st epoch, it saves `checkpoint-epoch-1`. 
- change definition of `steps_per_epoch` to that per GPU. According the log of our multi-gpu job on cluster, the `step` reaches (steps per epoch // # gpu) when an epoch is finished. 