### PR TITLE
accelerate eager mode with tf.function

### DIFF
--- a/baseline/tf/seq2seq/decoders/v2.py
+++ b/baseline/tf/seq2seq/decoders/v2.py
@@ -30,7 +30,6 @@ class AbstractArcPolicy(ArcPolicy):
     def get_state(self, encoder_outputs):
         pass
 
-    # TODO: figure out how to add back the beam
     def forward(self, encoder_output, hsz, beam_width=1):
         h_i = self.get_state(encoder_output)
         context = encoder_output.output

--- a/baseline/tf/tagger/training/eager.py
+++ b/baseline/tf/tagger/training/eager.py
@@ -5,20 +5,21 @@ import numpy as np
 import tensorflow as tf
 import logging
 from eight_mile.utils import listify, revlut, to_spans, write_sentence_conll, per_entity_f1, span_f1, conlleval_output
-from eight_mile.tf.layers import TRAIN_FLAG, SET_TRAIN_FLAG, reload_checkpoint, get_shape_as_list
+from eight_mile.tf.layers import TRAIN_FLAG, SET_TRAIN_FLAG, reload_checkpoint, get_shape_as_list, autograph_options
 from eight_mile.tf.optz import EagerOptimizer
 from baseline.progress import create_progress_bar
 from baseline.model import create_model_for
 from baseline.train import register_training_func, EpochReportingTrainer
 from baseline.utils import get_model_file, get_metric_cmp
 from baseline.tf.tagger.training.utils import to_tensors
-
+import contextlib
 # Number of batches to prefetch if using tf.datasets
 NUM_PREFETCH = 2
 # The shuffle buffer
 SHUF_BUF_SZ = 5000
 
 logger = logging.getLogger('baseline')
+
 
 
 def loss(model, x, y):
@@ -170,14 +171,14 @@ class TaggerTrainerEagerTf(EpochReportingTrainer):
     def _get_batchsz(batch_dict):
         return batch_dict['y'].shape[0]
 
-    def _train(self, ts, steps=0, **kwargs):
+    def _train(self, loader, steps=0, **kwargs):
         """Train an epoch of data using either the input loader or using `tf.dataset`
 
         In non-`tf.dataset` mode, we cycle the loader data feed, and pull a batch and feed it to the feed dict
         When we use `tf.dataset`s under the hood, this function simply uses the loader to know how many steps
         to train.  We do use a `feed_dict` for passing the `TRAIN_FLAG` in either case
 
-        :param ts: A data feed
+        :param loader: A data feed
         :param kwargs: See below
 
         :Keyword Arguments:
@@ -186,29 +187,42 @@ class TaggerTrainerEagerTf(EpochReportingTrainer):
 
         :return: Metrics
         """
+        SET_TRAIN_FLAG(True)
         reporting_fns = kwargs.get('reporting_fns', [])
-        step = 0
-        epoch_loss = 0
-        epoch_div = 0
         pg = create_progress_bar(steps)
-        for features, y in pg(ts):
+        epoch_loss = tf.keras.metrics.Sum()
+        epoch_div = tf.keras.metrics.Sum()
+        nstep_loss = tf.keras.metrics.Sum()
+        nstep_div = tf.keras.metrics.Sum()
+        self.nstep_start = time.time()
 
-            lossv = self.optimizer.update(self.model.impl, features, y).numpy()
-            step += 1
-            batchsz = get_shape_as_list(y)[0]
-            report_loss = lossv * batchsz
-            epoch_loss += report_loss
-            epoch_div += batchsz
-            self.nstep_agg += report_loss
-            self.nstep_div += batchsz
-            if (step + 1) % self.nsteps == 0:
-                metrics = self.calc_metrics(self.nstep_agg, self.nstep_div)
-                self.report(
-                    step + 1, metrics, self.nstep_start,
-                    'Train', 'STEP', reporting_fns, self.nsteps
-                )
-                self.reset_nstep()
+        @tf.function
+        def _train_step(inputs):
+            features, y = inputs
+            loss = self.optimizer.update(self.model.impl, features, y)
+            batchsz = tf.cast(get_shape_as_list(y)[0], tf.float32)
+            report_loss = loss * batchsz
+            epoch_loss.update_state(report_loss)
+            nstep_loss.update_state(report_loss)
+            epoch_div.update_state(batchsz)
+            nstep_div.update_state(batchsz)
 
+        with autograph_options({"function_optimization": False, "layout_optimizer": False}):
+            for inputs in pg(loader):
+                _train_step(inputs)
+                step = self.optimizer.global_step.numpy() + 1
+                if step % self.nsteps == 0:
+                    metrics = self.calc_metrics(nstep_loss.result().numpy(), nstep_div.result().numpy())
+                    self.report(
+                        step, metrics, self.nstep_start,
+                        'Train', 'STEP', reporting_fns, self.nsteps
+                    )
+                    nstep_loss.reset_states()
+                    nstep_div.reset_states()
+                    self.nstep_start = time.time()
+
+        epoch_loss = epoch_loss.result().numpy()
+        epoch_div = epoch_div.result().numpy()
         metrics = self.calc_metrics(epoch_loss, epoch_div)
         return metrics
 

--- a/baseline/tf/tagger/training/eager.py
+++ b/baseline/tf/tagger/training/eager.py
@@ -12,7 +12,6 @@ from baseline.model import create_model_for
 from baseline.train import register_training_func, EpochReportingTrainer
 from baseline.utils import get_model_file, get_metric_cmp
 from baseline.tf.tagger.training.utils import to_tensors
-import contextlib
 # Number of batches to prefetch if using tf.datasets
 NUM_PREFETCH = 2
 # The shuffle buffer

--- a/layers/eight_mile/tf/layers.py
+++ b/layers/eight_mile/tf/layers.py
@@ -3,12 +3,20 @@ import tensorflow as tf
 import numpy as np
 from eight_mile.utils import listify, Offsets, wraps, get_version, is_sequence
 from typing import Optional, Union, List, Dict, Any, Tuple
-
+import contextlib
 import math
 
 BASELINE_TF_TRAIN_FLAG = None
 LOGGER = logging.getLogger('mead.layers')
 
+@contextlib.contextmanager
+def autograph_options(options):
+    old_opts = tf.config.optimizer.get_experimental_options()
+    tf.config.optimizer.set_experimental_options(options)
+    try:
+        yield
+    finally:
+        tf.config.optimizer.set_experimental_options(old_opts)
 
 def set_tf_eager_mode(prefer_eager: bool = False):
     tf_version = get_version(tf)

--- a/layers/eight_mile/tf/optz.py
+++ b/layers/eight_mile/tf/optz.py
@@ -635,7 +635,7 @@ def optimizer(loss_fn, **kwargs):
 class EagerOptimizer(object):
     def __init__(self, loss, optimizer=None, **kwargs):
         self.loss = loss
-        self.global_step = kwargs.get('global_step', 0)
+        self.global_step = tf.Variable(int(kwargs.get('global_step', 0)))
         if "lr_function" in kwargs:
             lr_function = kwargs["lr_function"]
         else:
@@ -696,7 +696,7 @@ class EagerOptimizer(object):
         grads = tape.gradient(loss_value, model.trainable_variables)
         grads, _ = tf.clip_by_global_norm(grads, self.clip)
         self.optimizer.apply_gradients(zip(grads, model.trainable_variables))
-        self.global_step += 1
+        self.global_step.assign_add(1)
         return loss_value
 
     def update_with_hidden(self, model, h, x, y):
@@ -706,5 +706,5 @@ class EagerOptimizer(object):
         grads = tape.gradient(loss_value, model.trainable_variables)
         grads, _ = tf.clip_by_global_norm(grads, self.clip)
         self.optimizer.apply_gradients(zip(grads, model.trainable_variables))
-        self.global_step += 1
+        self.global_step.assign_add(1)
         return loss_value, h

--- a/mead/config/dbpedia.json
+++ b/mead/config/dbpedia.json
@@ -31,11 +31,10 @@
 	      "finetune": true
     },
     "train": {
-        "fit_func": "estimator",
-	      "epochs": 80,
-	      "optim": "sgd",
-	      "eta": 0.02,
-	      "early_stopping_metric": "acc",
+	"epochs": 80,
+	"optim": "sgd",
+	"eta": 0.02,
+	"early_stopping_metric": "acc",
         "verbose": true
     }
 }

--- a/mead/config/twpos.json
+++ b/mead/config/twpos.json
@@ -55,7 +55,7 @@
         "dropout": 0.5,
         "rnntype": "blstm",
         "layers": 1,
-        "crf": false
+        "crf": true 
     },
     "train": {
         "batchsz": 20,


### PR DESCRIPTION
- use tf.function in tagging, move layer keras logic

- For char-conv were previously declaring keras layers right in
the call() function which isnt right.  During tf.function
compilation, this was causing an error.

- Change moves the keras creation logic into the constructor
and leaves call(x) as an execution stream of keras objects

- support TF1 LM in eager mode without tf.function

- The global_step in the EagerOptimizer wasnt tracking
step number anymore.  Made it a tf.Variable and it works
now.
