### PR TITLE
chore: make the masks non-trainable variables

### DIFF
--- a/baseline/services.py
+++ b/baseline/services.py
@@ -329,7 +329,7 @@ class TaggerService(Service):
                         tokens_batch += [utt_dict_seq]
                 # Its already in List[List[dict]] form, do nothing
                 elif isinstance(tokens[0][0], dict):
-                    tokens_batch = [tokens]
+                    tokens_batch = tokens
             # If its a dict, we just wrap it up
             elif isinstance(tokens[0], dict):
                 tokens_batch = [tokens]

--- a/baseline/tf/tagger/model.py
+++ b/baseline/tf/tagger/model.py
@@ -215,7 +215,7 @@ class TaggerModelBase(tf.keras.Model, TaggerModel):
                 labels = read_json("{}.labels".format(basename))
                 if _state.get('constraint_mask') is not None:
                     # Dummy constraint values that will be filled in by the check pointing
-                    _state['constraint_mask'] = [tf.zeros((len(labels), len(labels))) for _ in range(2)]
+                    _state['constraint_mask'] = [np.zeros((len(labels), len(labels))) for _ in range(2)]
                 model = cls.create(embeddings, labels, **_state)
                 model._state = _state
                 model.create_loss()
@@ -234,7 +234,7 @@ class TaggerModelBase(tf.keras.Model, TaggerModel):
             labels = read_json("{}.labels".format(basename))
             if _state.get('constraint_mask') is not None:
                 # Dummy constraint values that will be filled in by the check pointing
-                _state['constraint_mask'] = [tf.zeros((len(labels), len(labels))) for _ in range(2)]
+                _state['constraint_mask'] = [np.zeros((len(labels), len(labels))) for _ in range(2)]
             model = cls.create(embeddings, labels, **_state)
             model._state = _state
             model.load_weights(f"{basename}.wgt")

--- a/baseline/tf/tfy.py
+++ b/baseline/tf/tfy.py
@@ -81,7 +81,7 @@ def transition_mask(vocab, span_type, s_idx, e_idx, pad_idx=None):
     """
     mask = transition_mask_np(vocab, span_type, s_idx, e_idx, pad_idx).T
     inv_mask = (mask == 0).astype(np.float32)
-    return tf.constant(mask), tf.constant(inv_mask)
+    return mask, inv_mask
 
 
 def dense_layer(output_layer_depth):


### PR DESCRIPTION
In the master branch we used to wrap the crf/constrained decoding in non-trainable variables. When we reloaded a model we would initialize the masks to zero and let the reloading re-populate the masks, this let us fill the masks automatically without having to know the span type or anything like that.

In `feature/v2` we didn't do this so when we reload the taggers they don't have the masks loaded, they are all zeros. In order to make this work we had to convert the masks into `np.array`s so that they can be used with `tf.constant_initializer`, the old version using `tf.get_variable` used to let us initialize with a `tf.Tensor` but we can't do that and use the `self.add_weight` method.

On `feature/v2`

```
In [4]: m.model.sess.run(m.model.impl.decoder_model.inv_mask)                                                         
Out[4]: 
array([[-0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0.,
        -0., -0., -0., -0., -0., -0., -0.],
       [-0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0.,
        -0., -0., -0., -0., -0., -0., -0.],
       [-0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0.,
        -0., -0., -0., -0., -0., -0., -0.],
       [-0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0.,
        -0., -0., -0., -0., -0., -0., -0.],
       [-0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0.,
        -0., -0., -0., -0., -0., -0., -0.],
       [-0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0.,
        -0., -0., -0., -0., -0., -0., -0.],
       [-0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0.,
        -0., -0., -0., -0., -0., -0., -0.],
       [-0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0.,
        -0., -0., -0., -0., -0., -0., -0.],
       [-0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0.,
        -0., -0., -0., -0., -0., -0., -0.],
       [-0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0.,
        -0., -0., -0., -0., -0., -0., -0.],
       [-0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0.,
        -0., -0., -0., -0., -0., -0., -0.],
       [-0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0.,
        -0., -0., -0., -0., -0., -0., -0.],
       [-0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0.,
        -0., -0., -0., -0., -0., -0., -0.],
       [-0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0.,
        -0., -0., -0., -0., -0., -0., -0.],
       [-0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0.,
        -0., -0., -0., -0., -0., -0., -0.],
       [-0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0.,
        -0., -0., -0., -0., -0., -0., -0.],
       [-0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0.,
        -0., -0., -0., -0., -0., -0., -0.],
       [-0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0.,
        -0., -0., -0., -0., -0., -0., -0.],
       [-0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0.,
        -0., -0., -0., -0., -0., -0., -0.],
       [-0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0., -0.,
        -0., -0., -0., -0., -0., -0., -0.]], dtype=float32)
```

On this branch

```
In [3]: m.model.sess.run(m.model.impl.decoder_model.inv_mask)                                                         
Out[3]: 
array([[    -0., -10000.,     -0., -10000., -10000., -10000., -10000.,
        -10000., -10000., -10000., -10000., -10000., -10000., -10000.,
        -10000., -10000., -10000., -10000., -10000., -10000.],
       [    -0., -10000.,     -0.,     -0.,     -0.,     -0.,     -0.,
        -10000.,     -0.,     -0., -10000., -10000.,     -0.,     -0.,
        -10000., -10000., -10000.,     -0., -10000., -10000.],
       [-10000., -10000., -10000., -10000., -10000., -10000., -10000.,
        -10000., -10000., -10000., -10000., -10000., -10000., -10000.,
        -10000., -10000., -10000., -10000., -10000., -10000.],
       [    -0., -10000.,     -0.,     -0.,     -0.,     -0.,     -0.,
        -10000.,     -0.,     -0., -10000., -10000.,     -0.,     -0.,
        -10000., -10000., -10000.,     -0., -10000., -10000.],
       [    -0., -10000.,     -0.,     -0.,     -0.,     -0.,     -0.,
        -10000.,     -0.,     -0., -10000., -10000.,     -0.,     -0.,
        -10000., -10000., -10000.,     -0., -10000., -10000.],
       [    -0., -10000.,     -0.,     -0.,     -0.,     -0.,     -0.,
        -10000.,     -0.,     -0., -10000., -10000.,     -0.,     -0.,
        -10000., -10000., -10000.,     -0., -10000., -10000.],
       [-10000., -10000., -10000., -10000., -10000., -10000., -10000.,
            -0., -10000., -10000., -10000.,     -0., -10000., -10000.,
        -10000., -10000., -10000., -10000., -10000., -10000.],
       [    -0., -10000.,     -0.,     -0.,     -0.,     -0.,     -0.,
        -10000.,     -0.,     -0., -10000., -10000.,     -0.,     -0.,
        -10000., -10000., -10000.,     -0., -10000., -10000.],
       [    -0., -10000.,     -0.,     -0.,     -0.,     -0.,     -0.,
        -10000.,     -0.,     -0., -10000., -10000.,     -0.,     -0.,
        -10000., -10000., -10000.,     -0., -10000., -10000.],
       [-10000., -10000., -10000., -10000., -10000., -10000., -10000.,
        -10000., -10000., -10000.,     -0., -10000., -10000., -10000.,
        -10000., -10000.,     -0., -10000., -10000., -10000.],
       [    -0., -10000.,     -0.,     -0.,     -0.,     -0.,     -0.,
        -10000.,     -0.,     -0., -10000., -10000.,     -0.,     -0.,
        -10000., -10000., -10000.,     -0., -10000., -10000.],
       [-10000., -10000., -10000., -10000., -10000., -10000., -10000.,
            -0., -10000., -10000., -10000.,     -0., -10000., -10000.,
        -10000., -10000., -10000., -10000., -10000., -10000.],
       [    -0., -10000.,     -0.,     -0.,     -0.,     -0.,     -0.,
        -10000.,     -0.,     -0., -10000., -10000.,     -0.,     -0.,
        -10000., -10000., -10000.,     -0., -10000., -10000.],
       [-10000., -10000., -10000., -10000., -10000., -10000., -10000.,
        -10000., -10000., -10000., -10000., -10000., -10000., -10000.,
            -0.,     -0., -10000., -10000., -10000., -10000.],
       [-10000., -10000., -10000., -10000., -10000., -10000., -10000.,
        -10000., -10000., -10000., -10000., -10000., -10000., -10000.,
            -0.,     -0., -10000., -10000., -10000., -10000.],
       [    -0., -10000.,     -0.,     -0.,     -0.,     -0.,     -0.,
        -10000.,     -0.,     -0., -10000., -10000.,     -0.,     -0.,
        -10000., -10000., -10000.,     -0., -10000., -10000.],
       [-10000., -10000., -10000., -10000., -10000., -10000., -10000.,
        -10000., -10000., -10000.,     -0., -10000., -10000., -10000.,
        -10000., -10000.,     -0., -10000., -10000., -10000.],
       [-10000., -10000., -10000., -10000., -10000., -10000., -10000.,
        -10000., -10000., -10000., -10000., -10000., -10000., -10000.,
        -10000., -10000., -10000., -10000.,     -0.,     -0.],
       [    -0., -10000.,     -0.,     -0.,     -0.,     -0.,     -0.,
        -10000.,     -0.,     -0., -10000., -10000.,     -0.,     -0.,
        -10000., -10000., -10000.,     -0., -10000., -10000.],
       [-10000., -10000., -10000., -10000., -10000., -10000., -10000.,
        -10000., -10000., -10000., -10000., -10000., -10000., -10000.,
        -10000., -10000., -10000., -10000.,     -0.,     -0.]],
      dtype=float32)
```

This also fixes a bug I found when testing this where a token batch which is a list of lists of dicts would wrap that in another list and cause the service to crash.