### PR TITLE
fix: correct transition mask when there are `-` in the labels

### DIFF
--- a/layers/eight_mile/utils.py
+++ b/layers/eight_mile/utils.py
@@ -210,15 +210,15 @@ def iob_mask(vocab, start, end, pad=None):
                 if from_.startswith("B-"):
                     # Can't move from a B to a B of another type
                     if to.startswith("B-"):
-                        from_type = from_.split("-")[1]
-                        to_type = to.split("-")[1]
+                        from_type = from_.split("-", maxsplit=1)[1]
+                        to_type = to.split("-", maxsplit=1)[1]
                         if from_type != to_type:
                             mask[vocab[to], vocab[from_]] = small
                 elif from_.startswith("I-"):
                     # Can't move from an I to a B of another type
                     if to.startswith("B-"):
-                        from_type = from_.split("-")[1]
-                        to_type = to.split("-")[1]
+                        from_type = from_.split("-", maxsplit=1)[1]
+                        to_type = to.split("-", maxsplit=1)[1]
                         if from_type != to_type:
                             mask[vocab[to], vocab[from_]] = small
                 elif from_.startswith("O"):
@@ -252,15 +252,15 @@ def iob2_mask(vocab, start, end, pad=None):
                 if from_.startswith("B-"):
                     # Can't move from a B to an I of a different type
                     if to.startswith("I-"):
-                        from_type = from_.split("-")[1]
-                        to_type = to.split("-")[1]
+                        from_type = from_.split("-", maxsplit=1)[1]
+                        to_type = to.split("-", maxsplit=1)[1]
                         if from_type != to_type:
                             mask[vocab[to], vocab[from_]] = small
                 elif from_.startswith("I-"):
                     # Can't move from an I to an I of another type
                     if to.startswith("I-"):
-                        from_type = from_.split("-")[1]
-                        to_type = to.split("-")[1]
+                        from_type = from_.split("-", maxsplit=1)[1]
+                        to_type = to.split("-", maxsplit=1)[1]
                         if from_type != to_type:
                             mask[vocab[to], vocab[from_]] = small
                 elif from_.startswith("O"):
@@ -297,8 +297,8 @@ def iobes_mask(vocab, start, end, pad=None):
                         mask[vocab[to], vocab[from_]] = small
                     # Can only move to matching I or E
                     elif to.startswith("I-") or to.startswith("E-"):
-                        from_type = from_.split("-")[1]
-                        to_type = to.split("-")[1]
+                        from_type = from_.split("-", maxsplit=1)[1]
+                        to_type = to.split("-", maxsplit=1)[1]
                         if from_type != to_type:
                             mask[vocab[to], vocab[from_]] = small
                 elif from_.startswith("I-"):
@@ -307,13 +307,12 @@ def iobes_mask(vocab, start, end, pad=None):
                         mask[vocab[to], vocab[from_]] = small
                     # Can only move to matching I or E
                     elif to.startswith("I-") or to.startswith("E-"):
-                        from_type = from_.split("-")[1]
-                        to_type = to.split("-")[1]
+                        from_type = from_.split("-", maxsplit=1)[1]
+                        to_type = to.split("-", maxsplit=1)[1]
                         if from_type != to_type:
                             mask[vocab[to], vocab[from_]] = small
-                elif from_.startswith(("E-", "I-", "S-", "O")):
+                elif from_.startswith(("E-", "S-", "O")):
                     # Can't move from E to I or E
-                    # Can't move from I to I or E
                     # Can't move from S to I or E
                     # Can't move from O to I or E
                     if to.startswith("I-") or to.startswith("E-"):

--- a/tests/test_transition_masks.py
+++ b/tests/test_transition_masks.py
@@ -1,7 +1,7 @@
 import pytest
 from eight_mile.utils import transition_mask
 
-IOBv = {"<PAD>": 0, "<GO>": 1, "<EOS>": 2, "B-X": 3, "I-X": 4, "B-Y": 5, "I-Y": 6, "O": 7}
+IOBv = {"<PAD>": 0, "<GO>": 1, "<EOS>": 2, "B-X": 3, "I-X": 4, "B-X-Y": 5, "I-X-Y": 6, "O": 7}
 
 BIOv = IOBv
 
@@ -13,10 +13,10 @@ IOBESv = {
     "I-X": 4,
     "E-X": 5,
     "S-X": 6,
-    "B-Y": 7,
-    "I-Y": 8,
-    "E-Y": 9,
-    "S-Y": 10,
+    "B-X-Y": 7,
+    "I-X-Y": 8,
+    "E-X-Y": 9,
+    "S-X-Y": 10,
     "O": 11,
 }
 
@@ -51,7 +51,7 @@ def test_IOBES_shape(IOBES):
 
 
 def test_IOB_I_B_mismatch(IOB):
-    assert IOB[IOBv["B-X"], IOBv["I-Y"]] == 0
+    assert IOB[IOBv["B-X"], IOBv["I-X-Y"]] == 0
 
 
 def test_ION_I_I_match(IOB):
@@ -59,7 +59,7 @@ def test_ION_I_I_match(IOB):
 
 
 def test_IOB_I_I_mismatch(IOB):
-    assert IOB[IOBv["I-Y"], IOBv["I-X"]] == 1
+    assert IOB[IOBv["I-X-Y"], IOBv["I-X"]] == 1
 
 
 def test_IOB_to_pad(IOB):
@@ -124,8 +124,8 @@ def test_IOBES_O(IOBES):
 def test_IOBES_B(IOBES):
     assert IOBES[IOBESv["I-X"], IOBESv["B-X"]] == 1
     assert IOBES[IOBESv["E-X"], IOBESv["B-X"]] == 1
-    assert IOBES[IOBESv["I-Y"], IOBESv["B-X"]] == 0
-    assert IOBES[IOBESv["E-Y"], IOBESv["B-X"]] == 0
+    assert IOBES[IOBESv["I-X-Y"], IOBESv["B-X"]] == 0
+    assert IOBES[IOBESv["E-X-Y"], IOBESv["B-X"]] == 0
     assert IOBES[IOBESv["S-X"], IOBESv["B-X"]] == 0
     assert IOBES[IOBESv["B-X"], IOBESv["B-X"]] == 0
     assert IOBES[IOBESv["O"], IOBESv["B-X"]] == 0
@@ -134,8 +134,8 @@ def test_IOBES_B(IOBES):
 def test_IOBES_I(IOBES):
     assert IOBES[IOBESv["I-X"], IOBESv["I-X"]] == 1
     assert IOBES[IOBESv["E-X"], IOBESv["I-X"]] == 1
-    assert IOBES[IOBESv["I-Y"], IOBESv["I-X"]] == 0
-    assert IOBES[IOBESv["E-Y"], IOBESv["I-X"]] == 0
+    assert IOBES[IOBESv["I-X-Y"], IOBESv["I-X"]] == 0
+    assert IOBES[IOBESv["E-X-Y"], IOBESv["I-X"]] == 0
     assert IOBES[IOBESv["S-X"], IOBESv["I-X"]] == 0
     assert IOBES[IOBESv["B-X"], IOBESv["I-X"]] == 0
     assert IOBES[IOBESv["O"], IOBESv["I-X"]] == 0
@@ -153,11 +153,11 @@ def test_IOBES_to_E(IOBES):
     assert IOBES[IOBESv["E-X"], IOBESv["B-X"]] == 1
     assert IOBES[IOBESv["E-X"], IOBESv["I-X"]] == 1
     assert IOBES[IOBESv["E-X"], IOBESv["E-X"]] == 0
-    assert IOBES[IOBESv["E-X"], IOBESv["B-Y"]] == 0
-    assert IOBES[IOBESv["E-X"], IOBESv["I-Y"]] == 0
-    assert IOBES[IOBESv["E-X"], IOBESv["E-Y"]] == 0
+    assert IOBES[IOBESv["E-X"], IOBESv["B-X-Y"]] == 0
+    assert IOBES[IOBESv["E-X"], IOBESv["I-X-Y"]] == 0
+    assert IOBES[IOBESv["E-X"], IOBESv["E-X-Y"]] == 0
     assert IOBES[IOBESv["E-X"], IOBESv["S-X"]] == 0
-    assert IOBES[IOBESv["E-X"], IOBESv["S-Y"]] == 0
+    assert IOBES[IOBESv["E-X"], IOBESv["S-X-Y"]] == 0
     assert IOBES[IOBESv["E-X"], IOBESv["O"]] == 0
 
 


### PR DESCRIPTION
Right now if you have a `-` in your tag label the transition mask function might not create the correct mask, for example if you had two tags `I-X-Y` and `I-X-Z` then when it calls `tag.split("-")[1]` it would return `X` for both tags and the transition would be marked as legal. This is wrong, we should get the types as `X-Y` and `X-Z` and the move between should be marked illegal.

This PR fixes that using the `maxsplit` parameter to `.split` and updates the tests to use fake label names that would trigger this error without the fix.