### PR TITLE
chore: function that remove common extensions for conll files

### DIFF
--- a/layers/eight_mile/utils.py
+++ b/layers/eight_mile/utils.py
@@ -20,6 +20,7 @@ from six.moves.urllib.request import urlretrieve
 logger = logging.getLogger("mead.layers")
 
 __all__ = ["exporter", "optional_params", "parameterize"]
+CONLL_EXTS = {".bio", ".iobes", ".iob", ".conll"}
 
 
 def optional_params(func):
@@ -794,6 +795,19 @@ def sniff_conll_file(f, delim=None, comment_pattern="#", doc_pattern="# begin do
         if len(parts) > 1:
             f.seek(start)
             return len(parts)
+
+
+@export
+def remove_extensions(path: str, exts: Set[str]) -> str:
+    path, ext = os.path.splitext(path)
+    while ext in exts:
+        path, ext = os.path.splitext(path)
+    return path + ext
+
+
+@export
+def remove_conll_extensions(path: str, exts: Set[str] = CONLL_EXTS) -> str:
+    return remove_extensions(path, exts)
 
 
 @export

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,11 +1,12 @@
 import os
 import string
 import random
+from copy import deepcopy
 from itertools import chain
 import pytest
 import numpy as np
 from mock import patch
-from eight_mile.utils import get_env_gpus, idempotent_append, parse_module_as_path, to_numpy, get_version
+from eight_mile.utils import get_env_gpus, idempotent_append, parse_module_as_path, to_numpy, get_version, remove_extensions
 
 
 @pytest.fixture
@@ -195,3 +196,21 @@ def test_to_numpy_pyt():
     tensor = torch.from_numpy(gold)
     np_ = to_numpy(tensor)
     np.testing.assert_allclose(np_, gold)
+
+
+def test_remove_ext():
+    exts = {"." + rand_str() for _ in range(np.random.randint(2, 4))}
+    ext_list = list(exts)
+    gold = rand_str()
+    path = deepcopy(gold)
+    for _ in range(np.random.randint(1, 2)):
+        path += random.choice(ext_list)
+    res = remove_extensions(path, exts)
+    assert res == gold
+
+def test_remove_ext_not_in_middle():
+    gold = "example.bio.more-stuff"
+    exts = {".bio"}
+    path = deepcopy(gold)
+    res = remove_extensions(path, exts)
+    assert res == gold


### PR DESCRIPTION
I have written a similar function that can strip off the conll
extensions like .conll or .iobes multiple times across various projects.
This is adding that function to baseline so we can reuse it instead of
copying it around everywhere. I made the decision to make the extension
removal case sensitive so like linux paths names are, we might want to
change that in the future.