### PR TITLE
Fix/tlm ups

### DIFF
--- a/addons/embed_tlm_pytorch.py
+++ b/addons/embed_tlm_pytorch.py
@@ -78,11 +78,6 @@ class WordPieceVectorizer1D(AbstractVectorizer):
         return self.mxlen,
 
 
-@register_vectorizer(name='tlm-bpe')
-class BPEVectorizer1DFT(BPEVectorizer1D):
-    pass
-
-
 class TransformerLMEmbeddings(PyTorchEmbeddings):
     """Support embeddings trained with the TransformerLanguageModel class
 

--- a/addons/embed_tlm_tf.py
+++ b/addons/embed_tlm_tf.py
@@ -11,37 +11,6 @@ from eight_mile.tf.embeddings import TensorFlowEmbeddings, PositionalLookupTable
 from baseline.tf.embeddings import TensorFlowEmbeddingsModel
 
 
-@register_vectorizer(name='tlm-bpe')
-class BPEVectorizer1DFT(BPEVectorizer1D):
-    """Override bpe1d to geneate [CLS] """
-    def iterable(self, tokens):
-        for t in tokens:
-            if t in Offsets.VALUES:
-                yield t
-            elif t == '<unk>':
-                yield Offsets.VALUES[Offsets.UNK]
-            elif t == '<eos>':
-                yield Offsets.VALUES[Offsets.EOS]
-            else:
-                subwords = self.tokenizer.apply([t])[0].split()
-                for x in subwords:
-                    yield x
-        yield '[CLS]'
-
-    def run(self, tokens, vocab):
-        if self.mxlen < 0:
-            self.mxlen = self.max_seen
-        vec1d = np.zeros(self.mxlen, dtype=np.long)
-        for i, atom in enumerate(self._next_element(tokens, vocab)):
-            if i == self.mxlen:
-                i -= 1
-                vec1d[i] = vocab.get('[CLS]')
-                break
-            vec1d[i] = atom
-        valid_length = i + 1
-        return vec1d, valid_length
-
-
 class TransformerLMEmbeddings(TensorFlowEmbeddings):
     def __init__(self, name=None, **kwargs):
         super().__init__(name=name)

--- a/layers/eight_mile/tf/optz.py
+++ b/layers/eight_mile/tf/optz.py
@@ -611,7 +611,7 @@ def optimizer(loss_fn, **kwargs):
         beta1 = float(kwargs.get("beta1", 0.9))
         beta2 = float(kwargs.get("beta2", 0.999))
         eps = float(kwargs.get("epsilon", 1e-8))
-        logger.info("adamw(eta=%f beta1=%f, beta2=%f, eps=%f)", eta, beta1, beta2, eps)
+        logger.info("adamw(eta=%f beta1=%f, beta2=%f, eps=%f, wd=%f)", eta, beta1, beta2, eps, wd)
         optz = lambda lr: AdamWOptimizer(lr, wd, beta1, beta2, eps)
     elif optim == "rmsprop":
         # Get mom again with difference default
@@ -683,7 +683,7 @@ class EagerOptimizer(object):
                 beta1 = float(kwargs.get("beta1", 0.9))
                 beta2 = float(kwargs.get("beta2", 0.999))
                 eps = float(kwargs.get("epsilon", 1e-8))
-                logger.info("adamw(eta=%f beta1=%f, beta2=%f, eps=%f)", lr, beta1, beta2, eps)
+                logger.info("adamw(eta=%f beta1=%f, beta2=%f, eps=%f, wd=%f)", lr, beta1, beta2, eps, wd)
                 self.optimizer = tfa.optimizers.AdamW(
                     weight_decay=wd, learning_rate=lr_function, beta_1=beta1, beta_2=beta2, epsilon=eps
                 )


### PR DESCRIPTION
- Remove unnecessary BPE vectorizer in TLM plugins
- Print weight decay in `adamw()` output in TF cases