### PR TITLE
chore: add ability to split off conll extensions as well as just remove them

### DIFF
--- a/layers/eight_mile/utils.py
+++ b/layers/eight_mile/utils.py
@@ -796,18 +796,29 @@ def sniff_conll_file(f, delim=None, comment_pattern="#", doc_pattern="# begin do
             f.seek(start)
             return len(parts)
 
+@export
+def split_extensions(path: str, exts: Set[str]) -> Tuple[str, str]:
+    all_ext = []
+    path, ext = os.path.splitext(path)
+    while ext in exts:
+        all_ext.append(ext)
+        path, ext = os.path.splitext(path)
+    return path + ext, "".join(all_ext[::-1])
 
 @export
 def remove_extensions(path: str, exts: Set[str]) -> str:
-    path, ext = os.path.splitext(path)
-    while ext in exts:
-        path, ext = os.path.splitext(path)
-    return path + ext
+    path, _ = split_extensions(path, exts)
+    return path
 
 
 @export
 def remove_conll_extensions(path: str, exts: Set[str] = CONLL_EXTS) -> str:
     return remove_extensions(path, exts)
+
+
+@export
+def split_conll_extensions(path: str, exts: Set[str] = CONLL_EXTS) -> Tuple[str, str]:
+    return split_extensions(path, exts)
 
 
 @export

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,7 +6,15 @@ from itertools import chain
 import pytest
 import numpy as np
 from mock import patch
-from eight_mile.utils import get_env_gpus, idempotent_append, parse_module_as_path, to_numpy, get_version, remove_extensions
+from eight_mile.utils import (
+    get_env_gpus,
+    idempotent_append,
+    parse_module_as_path,
+    to_numpy,
+    get_version,
+    remove_extensions,
+    split_extensions,
+)
 
 
 @pytest.fixture
@@ -208,9 +216,30 @@ def test_remove_ext():
     res = remove_extensions(path, exts)
     assert res == gold
 
+
 def test_remove_ext_not_in_middle():
     gold = "example.bio.more-stuff"
     exts = {".bio"}
     path = deepcopy(gold)
     res = remove_extensions(path, exts)
     assert res == gold
+
+
+def test_split_ext():
+    exts = {"." + rand_str() for _ in range(np.random.randint(2, 4))}
+    ext_list = list(exts)
+    gold_path = rand_str()
+    gold_exts = "".join(random.choice(ext_list) for _ in range(np.random.randint(1, 4)))
+    path = gold_path + gold_exts
+    path, ext = split_extensions(path, exts)
+    assert path == gold_path
+    assert ext == gold_exts
+
+
+def test_split_ext_not_in_middle():
+    gold = "example.bio.more-stuff"
+    exts = {".bio"}
+    path = deepcopy(gold)
+    res, ext = split_extensions(path, exts)
+    assert res == gold
+    assert ext == ''


### PR DESCRIPTION
When I added the `remove_conll_extensions` function the idea was for converting files that are named like `train.bio` to `train.iobes` where we update the whole extension. Another common use-case I ran into again was something like changing the values in some column of the conll files without changing the encoding scheme, in this case we want to do a name change more like `train.iobes` -> `train-description-to-the-transform.iobes`. This new `split_extensions` function will let us do that by returning the extensions that we have removed from the file instead of just throwing them away.

I also added tests for these