### PR TITLE
Feature/layer norm after option tf

### DIFF
--- a/baseline/tf/seq2seq/training/eager.py
+++ b/baseline/tf/seq2seq/training/eager.py
@@ -105,8 +105,8 @@ class Seq2SeqTrainerEagerTf(Trainer):
             """Replicated training step."""
 
             loss = self.optimizer.update(self.model, features, y)
-            toks = tf.cast(self._num_toks(features['tgt_len']), tf.float32)
-            report_loss = loss * toks
+            toks = self._num_toks(features['tgt_len'])
+            report_loss = loss * tf.cast(toks, tf.float32)
             return report_loss, toks
 
         with autograph_options({"function_optimization": False, "layout_optimizer": False}):

--- a/layers/eight_mile/pytorch/layers.py
+++ b/layers/eight_mile/pytorch/layers.py
@@ -2809,12 +2809,12 @@ class TransformerDecoder(nn.Module):
         d_k: Optional[int] = None,
         rpr_k: Optional[int] = None,
         ffn_pdrop: Optional[float] = 0.0,
-        layer_norm_after: bool = False,
+        layer_norms_after: bool = False,
         layer_norm_eps: float = 1.0e-6
     ):
         super().__init__()
         self.d_model = d_model
-        self.layer_norm_after = layer_norm_after
+        self.layer_norms_after = layer_norms_after
         self.d_ff = d_ff if d_ff is not None else 4 * d_model
         if rpr_k is not None:
             self.self_attn = MultiHeadedRelativeAttention(num_heads, d_model, rpr_k, pdrop, scale, d_k=d_k)
@@ -2839,7 +2839,7 @@ class TransformerDecoder(nn.Module):
     def forward(self, inputs: Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]) -> torch.Tensor:
 
         x, memory, src_mask, tgt_mask = inputs
-        if not self.layer_norm_after:
+        if not self.layer_norms_after:
             x = self.ln1(x)
         x = x + self.dropout(self.self_attn((x, x, x, tgt_mask)))
 
@@ -2848,7 +2848,7 @@ class TransformerDecoder(nn.Module):
 
         x = self.ln3(x)
         x = x + self.dropout(self.ffn(x))
-        if self.layer_norm_after:
+        if self.layer_norms_after:
             x = self.ln1(x)
         return x
 
@@ -2907,8 +2907,8 @@ class TransformerEncoderStackWithLengths(TransformerEncoderStack):
         d_k: Optional[int] = None,
         rpr_k: Optional[Union[int, List[int]]] = None,
         input_sz: Optional[int] = None,
-        layer_norms_after = False,
-        layer_norm_eps=1.0e-6,
+        layer_norms_after: bool = False,
+        layer_norm_eps: float = 1.0e-6,
         **kwargs,
     ):
         super().__init__(num_heads, d_model, pdrop, scale, layers, activation, d_ff, d_k, rpr_k,
@@ -2964,13 +2964,13 @@ class TransformerDecoderStack(nn.Module):
         d_k: Optional[int] = None,
         rpr_k: Optional[Union[int, List[int]]] = None,
         ffn_pdrop: Optional[float] = 0.0,
-        layer_norm_after: bool = False,
+        layer_norms_after: bool = False,
         layer_norm_eps: float = 1.0e-6
 
     ):
         super().__init__()
         self.decoders = nn.ModuleList()
-        self.ln = nn.Identity() if layer_norm_after else nn.LayerNorm(d_model, eps=layer_norm_eps)
+        self.ln = nn.Identity() if layer_norms_after else nn.LayerNorm(d_model, eps=layer_norm_eps)
 
         if not is_sequence(rpr_k):
             rpr_k = [rpr_k] * layers
@@ -2979,7 +2979,7 @@ class TransformerDecoderStack(nn.Module):
             self.decoders.append(
                 TransformerDecoder(num_heads, d_model, pdrop, scale, activation_type, d_ff,
                                    d_k=d_k, rpr_k=rpr_k[i], ffn_pdrop=ffn_pdrop,
-                                   layer_norm_after=layer_norm_after, layer_norm_eps=layer_norm_eps)
+                                   layer_norms_after=layer_norms_after, layer_norm_eps=layer_norm_eps)
             )
 
     def forward(self, inputs):

--- a/layers/eight_mile/tf/embeddings.py
+++ b/layers/eight_mile/tf/embeddings.py
@@ -309,44 +309,6 @@ class CharTransformerEmbeddings(TensorFlowEmbeddings):
         return self.embed.get_vsz()
 
 
-def get_timing_signal_1d(length, channels, min_timescale=1.0, max_timescale=1.0e4, start_index=0):
-    """Gets a bunch of sinusoids of different frequencies.
-    Each channel of the input Tensor is incremented by a sinusoid of a different
-    frequency and phase.
-    This allows attention to learn to use absolute and relative positions.
-    Timing signals should be added to some precursors of both the query and the
-    memory inputs to attention.
-    The use of relative position is possible because sin(x+y) and cos(x+y) can be
-    expressed in terms of y, sin(x) and cos(x).
-    In particular, we use a geometric sequence of timescales starting with
-    min_timescale and ending with max_timescale.  The number of different
-    timescales is equal to channels / 2. For each timescale, we
-    generate the two sinusoidal signals sin(timestep/timescale) and
-    cos(timestep/timescale).  All of these sinusoids are concatenated in
-    the channels dimension.
-    Args:
-      length: scalar, length of timing signal sequence.
-      channels: scalar, size of timing embeddings to create. The number of
-          different timescales is equal to channels / 2.
-      min_timescale: a float
-      max_timescale: a float
-      start_index: index of first position
-    Returns:
-      a Tensor of timing signals [1, length, channels]
-    """
-    position = tf.cast(tf.range(length) + start_index, tf.float32)
-    num_timescales = channels // 2
-    log_timescale_increment = math.log(float(max_timescale) / float(min_timescale)) / tf.maximum(
-        tf.cast(num_timescales, tf.float32) - 1, 1
-    )
-    inv_timescales = min_timescale * tf.exp(tf.cast(tf.range(num_timescales), tf.float32) * -log_timescale_increment)
-    scaled_time = tf.expand_dims(position, 1) * tf.expand_dims(inv_timescales, 0)
-    signal = tf.concat([tf.sin(scaled_time), tf.cos(scaled_time)], axis=1)
-    signal = tf.pad(signal, [[0, 0], [0, channels % 2]])
-    signal = tf.reshape(signal, [1, length, channels])
-    return signal
-
-
 class PositionalMixin(tf.keras.layers.Layer):
     def positional(self, length):
         pass
@@ -374,20 +336,6 @@ class SinusoidalPositionalMixin(PositionalMixin):
 
     def positional(self, length):
         return self.pe[:, :length]
-
-
-class SinusoidalPositionalMixinT2T(PositionalMixin):
-    def __init__(self, trainable=True, name=None, dtype=tf.float32, **kwargs):
-        super().__init__(trainable=trainable, name=name, dtype=dtype, **kwargs)
-        self.max_timescale = kwargs.get("max_timescale", 1.0e4)
-        # Match the mxlen pytorch has because it precomputes the timing signal
-        self.mxlen = 10000
-        self.min_timescale = kwargs.get("min_timescale", 1.0)
-
-    def positional(self, length):
-        return get_timing_signal_1d(
-            length, self.get_dsz(), min_timescale=self.min_timescale, max_timescale=self.max_timescale, start_index=0
-        )
 
 
 class LearnedPositionalMixin(PositionalMixin):

--- a/layers/eight_mile/tf/layers.py
+++ b/layers/eight_mile/tf/layers.py
@@ -2341,7 +2341,7 @@ class TransformerDecoder(tf.keras.layers.Layer):
 
     def call(self, inputs):
         x, memory, src_mask, tgt_mask = inputs
-        if not self.layer_norm_after:
+        if not self.layer_norms_after:
             x = self.ln1(x)
         x = x + self.dropout(self.self_attn((x, x, x, tgt_mask)), TRAIN_FLAG())
 
@@ -2350,7 +2350,7 @@ class TransformerDecoder(tf.keras.layers.Layer):
 
         x = self.ln3(x)
         x = x + self.dropout(self.ffn(x), TRAIN_FLAG())
-        if self.layer_norm_after:
+        if self.layer_norms_after:
             x = self.ln1(x)
         return x
 


### PR DESCRIPTION
 for BERT checkpt load, transform TF needs LN after
    
    BERT is based on the original T2T architecture,
    where the layer norms happen after the transformation.
    
    This makes that optional, and also allows setting eps
    in the layer norm to make sure that BERT checkpoints
    can be loaded.
    
    Also RA attention needs to be supported in decoders,
    for some reason that never got added.
