### PR TITLE
Feature/embeddings reduction

### DIFF
--- a/addons/embed_bert.py
+++ b/addons/embed_bert.py
@@ -4,9 +4,9 @@ from __future__ import print_function
 
 
 from eight_mile.pytorch.layers import TransformerEncoderStack, subsequent_mask
-from eight_mile.pytorch.embeddings import PyTorchEmbeddings, PositionalLookupTableEmbeddings, LearnedPositionalLookupTableEmbeddings
+from eight_mile.pytorch.embeddings import PyTorchEmbeddings, LearnedPositionalLookupTableEmbeddingsWithBias
 from baseline.embeddings import register_embeddings, create_embeddings
-from baseline.pytorch.embeddings import PyTorchEmbeddingsModel, BERTLookupTableEmbeddingsModel
+from baseline.pytorch.embeddings import PyTorchEmbeddingsModel
 from baseline.vectorizers import register_vectorizer, AbstractVectorizer, BPEVectorizer1D
 from baseline.pytorch.torchy import *
 from baseline.vectorizers import load_bert_vocab
@@ -30,7 +30,7 @@ class BERTEmbeddings(PyTorchEmbeddings):
         pdrop = kwargs.get('dropout', 0.1)
         self.d_model = int(kwargs.get('dsz', kwargs.get('d_model', 768)))
         d_ff = int(kwargs.get('d_ff', 3072))
-        x_embedding = BERTLookupTableEmbeddingsModel(vsz=self.vsz, dsz=self.d_model, tok_type_vsz=2)
+        x_embedding = LearnedPositionalLookupTableEmbeddingsWithBias(vsz=self.vsz, dsz=self.d_model)
         self.dsz = self.init_embed({'x': x_embedding})
         self.proj_to_dsz = pytorch_linear(self.dsz, self.d_model) if self.dsz != self.d_model else _identity
         self.transformer = TransformerEncoderStack(num_heads, d_model=self.d_model, pdrop=pdrop, scale=True,

--- a/baseline/pytorch/classify/model.py
+++ b/baseline/pytorch/classify/model.py
@@ -136,7 +136,7 @@ class ClassifierModelBase(nn.Module, ClassifierModel):
         :param kwargs:
         :return: An embeddings operation
         """
-        return EmbeddingsStack(self.embeddings)
+        return EmbeddingsStack(self.embeddings, reduction=kwargs.get('embeddings_reduction', 'concat'))
 
     def init_pool(self, dsz, **kwargs):
         """Produce a pooling operation that will be used in the model

--- a/baseline/pytorch/seq2seq/model.py
+++ b/baseline/pytorch/seq2seq/model.py
@@ -31,11 +31,8 @@ class EncoderDecoderModelBase(nn.Module, EncoderDecoderModel):
         :param kwargs:
         :return: Return the aggregate embedding input size
         """
-        self.src_embeddings = EmbeddingsStack(src_embeddings)
-        input_sz = 0
-        for k, embedding in src_embeddings.items():
-            input_sz += embedding.get_dsz()
-        return input_sz
+        self.src_embeddings = EmbeddingsStack(src_embeddings, reduction=kwargs.get('embeddings_reduction', 'concat'))
+        return self.src_embeddings.output_dim
 
     def init_encoder(self, input_sz, **kwargs):
         # This is a hack since TF never needs this one, there is not a general constructor param, so shoehorn

--- a/baseline/pytorch/tagger/model.py
+++ b/baseline/pytorch/tagger/model.py
@@ -42,7 +42,7 @@ class TaggerModelBase(nn.Module, TaggerModel):
         self.gpu = False
 
     def init_embed(self, **kwargs):
-        return EmbeddingsStack(self.embeddings, self.pdrop)
+        return EmbeddingsStack(self.embeddings, self.pdrop, reduction=kwargs.get('embeddings_reduction', 'concat'))
 
     def init_encoder(self, input_sz, **kwargs):
         pass

--- a/baseline/tf/classify/model.py
+++ b/baseline/tf/classify/model.py
@@ -357,7 +357,7 @@ class ClassifierModelBase(tf.keras.Model, ClassifierModel):
 
         :return: A 3-d vector where the last dimension is the concatenated dimensions of all embeddings
         """
-        return EmbeddingsStack(self.embeddings)
+        return EmbeddingsStack(self.embeddings, reduction=kwargs.get('embeddings_reduction', 'concat'))
 
 
 class EmbedPoolStackClassifier(ClassifierModelBase):

--- a/baseline/tf/seq2seq/training/eager.py
+++ b/baseline/tf/seq2seq/training/eager.py
@@ -105,8 +105,8 @@ class Seq2SeqTrainerEagerTf(Trainer):
             """Replicated training step."""
 
             loss = self.optimizer.update(self.model, features, y)
-            toks = tf.cast(self._num_toks(features['tgt_len']), tf.float32)
-            report_loss = loss * toks
+            toks = self._num_toks(features['tgt_len'])
+            report_loss = loss * tf.cast(toks, tf.float32)
             return report_loss, toks
 
         with autograph_options({"function_optimization": False, "layout_optimizer": False}):

--- a/baseline/tf/tagger/model.py
+++ b/baseline/tf/tagger/model.py
@@ -282,7 +282,7 @@ class TaggerModelBase(tf.keras.Model, TaggerModel):
 
         :return: A layer representing the embeddings
         """
-        return EmbeddingsStack(self.embeddings, self.pdrop_value)
+        return EmbeddingsStack(self.embeddings, self.pdrop_value, reduction=kwargs.get('embeddings_reduction', 'concat'))
 
     def encode(self, **kwargs):
         """Provide a layer object that represents the `encode` phase of the model

--- a/layers/eight_mile/pytorch/embeddings.py
+++ b/layers/eight_mile/pytorch/embeddings.py
@@ -250,9 +250,18 @@ class LearnedPositionalMixin(PositionalMixin):
             torch.arange(length, dtype=torch.long, device=self.pos_embeddings.weight.device)
         ).unsqueeze(0)
 
-
 class BERTLookupTableEmbeddings(LookupTableEmbeddings):
+    """
+    BERT style embeddings with a 0 token type
 
+    TODO: Get rid of this, we dont need it anymore
+    If you want to use BERT with token types, make a LearnedPositionalLookupTableEmbeddings feature
+    and a LookupTableEmbeddings feature (for the token type)
+    and put them in an EmbedStack with an embeddings_reduction='sum' on the model
+    And if you dont want that, use the LearnedPositionalLookupTableEmbeddingsWithBias, which
+    will add the BERT token_type=0 weights into the pos + word_embed and is more efficient
+    than this class, since it doesnt do any memory allocation on the fly
+    """
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.dropout = nn.Dropout(kwargs.get('dropout', 0.1))
@@ -276,7 +285,13 @@ class BERTLookupTableEmbeddings(LookupTableEmbeddings):
 
 
 class LearnedPositionalLookupTableEmbeddingsWithBias(LookupTableEmbeddings):
+    """Learned positional lookup table embeddings wih a bias and layer norm
 
+    This is just a typical learned positional embedding but with a learnable
+    bias and a layer norm.  This is equivalent to BERT embeddings when the
+    token_type is not set
+
+    """
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.dropout = nn.Dropout(kwargs.get('dropout', 0.1))

--- a/layers/eight_mile/tf/embeddings.py
+++ b/layers/eight_mile/tf/embeddings.py
@@ -309,44 +309,6 @@ class CharTransformerEmbeddings(TensorFlowEmbeddings):
         return self.embed.get_vsz()
 
 
-def get_timing_signal_1d(length, channels, min_timescale=1.0, max_timescale=1.0e4, start_index=0):
-    """Gets a bunch of sinusoids of different frequencies.
-    Each channel of the input Tensor is incremented by a sinusoid of a different
-    frequency and phase.
-    This allows attention to learn to use absolute and relative positions.
-    Timing signals should be added to some precursors of both the query and the
-    memory inputs to attention.
-    The use of relative position is possible because sin(x+y) and cos(x+y) can be
-    expressed in terms of y, sin(x) and cos(x).
-    In particular, we use a geometric sequence of timescales starting with
-    min_timescale and ending with max_timescale.  The number of different
-    timescales is equal to channels / 2. For each timescale, we
-    generate the two sinusoidal signals sin(timestep/timescale) and
-    cos(timestep/timescale).  All of these sinusoids are concatenated in
-    the channels dimension.
-    Args:
-      length: scalar, length of timing signal sequence.
-      channels: scalar, size of timing embeddings to create. The number of
-          different timescales is equal to channels / 2.
-      min_timescale: a float
-      max_timescale: a float
-      start_index: index of first position
-    Returns:
-      a Tensor of timing signals [1, length, channels]
-    """
-    position = tf.cast(tf.range(length) + start_index, tf.float32)
-    num_timescales = channels // 2
-    log_timescale_increment = math.log(float(max_timescale) / float(min_timescale)) / tf.maximum(
-        tf.cast(num_timescales, tf.float32) - 1, 1
-    )
-    inv_timescales = min_timescale * tf.exp(tf.cast(tf.range(num_timescales), tf.float32) * -log_timescale_increment)
-    scaled_time = tf.expand_dims(position, 1) * tf.expand_dims(inv_timescales, 0)
-    signal = tf.concat([tf.sin(scaled_time), tf.cos(scaled_time)], axis=1)
-    signal = tf.pad(signal, [[0, 0], [0, channels % 2]])
-    signal = tf.reshape(signal, [1, length, channels])
-    return signal
-
-
 class PositionalMixin(tf.keras.layers.Layer):
     def positional(self, length):
         pass
@@ -374,20 +336,6 @@ class SinusoidalPositionalMixin(PositionalMixin):
 
     def positional(self, length):
         return self.pe[:, :length]
-
-
-class SinusoidalPositionalMixinT2T(PositionalMixin):
-    def __init__(self, trainable=True, name=None, dtype=tf.float32, **kwargs):
-        super().__init__(trainable=trainable, name=name, dtype=dtype, **kwargs)
-        self.max_timescale = kwargs.get("max_timescale", 1.0e4)
-        # Match the mxlen pytorch has because it precomputes the timing signal
-        self.mxlen = 10000
-        self.min_timescale = kwargs.get("min_timescale", 1.0)
-
-    def positional(self, length):
-        return get_timing_signal_1d(
-            length, self.get_dsz(), min_timescale=self.min_timescale, max_timescale=self.max_timescale, start_index=0
-        )
 
 
 class LearnedPositionalMixin(PositionalMixin):

--- a/layers/eight_mile/tf/layers.py
+++ b/layers/eight_mile/tf/layers.py
@@ -2314,9 +2314,12 @@ class TransformerEncoder(tf.keras.layers.Layer):
         d_k: Optional[int] = None,
         rpr_k: Optional[int] = None,
         ffn_pdrop: Optional[float] = 0.0,
-        name: Optional[str] = None,
+        layer_norms_after: bool = False,
+        layer_norm_eps: float = 1.0e-6,
+        name: Optional[str] = None
     ):
         super().__init__(name=name)
+        self.layer_norms_after = layer_norms_after
         self.d_model = d_model
         self.d_ff = d_ff if d_ff is not None else 4 * d_model
         if rpr_k is not None:
@@ -2325,8 +2328,8 @@ class TransformerEncoder(tf.keras.layers.Layer):
             self.self_attn = MultiHeadedAttention(num_heads, d_model, pdrop, scale=scale, d_k=d_k)
 
         self.ffn = FFN(d_model, activation_type, d_ff, ffn_pdrop, name="ffn")
-        self.ln1 = tf.keras.layers.LayerNormalization(epsilon=1e-6)
-        self.ln2 = tf.keras.layers.LayerNormalization(epsilon=1e-6)
+        self.ln1 = tf.keras.layers.LayerNormalization(epsilon=layer_norm_eps)
+        self.ln2 = tf.keras.layers.LayerNormalization(epsilon=layer_norm_eps)
         self.dropout = tf.keras.layers.Dropout(pdrop)
 
     def call(self, inputs):
@@ -2335,13 +2338,14 @@ class TransformerEncoder(tf.keras.layers.Layer):
         :return: The output tensor
         """
         x, mask = inputs
-
-        x = self.ln1(x)
+        if not self.layer_norms_after:
+            x = self.ln1(x)
         h = self.self_attn((x, x, x, mask))
         x = x + self.dropout(h, TRAIN_FLAG())
-
         x = self.ln2(x)
         x = x + self.dropout(self.ffn(x), TRAIN_FLAG())
+        if self.layer_norms_after:
+            x = self.ln1(x)
         return x
 
 
@@ -2354,23 +2358,35 @@ class TransformerDecoder(tf.keras.layers.Layer):
         scale: bool = True,
         activation_type: str = "relu",
         d_ff: Optional[int] = None,
-        ffn_pdrop: float = 0.0,
-        name: str = None,
+        d_k: Optional[int] = None,
+        rpr_k: Optional[int] = None,
+        ffn_pdrop: Optional[float] = 0.0,
+        layer_norms_after: bool = False,
+        layer_norm_eps: float = 1.0e-6,
+        name: str = None
     ):
         super().__init__(name=name)
         self.d_model = d_model
+        self.layer_norms_after = layer_norms_after
         self.d_ff = d_ff if d_ff is not None else 4 * d_model
-        self.self_attn = MultiHeadedAttention(num_heads, self.d_model, pdrop, scale=scale, name="self_attention")
-        self.src_attn = MultiHeadedAttention(num_heads, self.d_model, pdrop, scale=scale, name="src_attention")
+        if rpr_k is not None:
+            self.self_attn = MultiHeadedRelativeAttention(num_heads, d_model, rpr_k, pdrop, scale, d_k=d_k, name="self_attention")
+            self.src_attn = MultiHeadedRelativeAttention(num_heads, d_model, rpr_k, pdrop, scale, d_k=d_k, name="src_attention")
+
+        else:
+            self.self_attn = MultiHeadedAttention(num_heads, d_model, pdrop, scale, d_k=d_k, name="self_attention")
+            self.src_attn = MultiHeadedAttention(num_heads, d_model, pdrop, scale, d_k=d_k, name="src_attention")
+
         self.ffn = FFN(d_model, activation_type, d_ff, pdrop=ffn_pdrop, name="ffn")
-        self.ln1 = tf.keras.layers.LayerNormalization(epsilon=1e-6)
-        self.ln2 = tf.keras.layers.LayerNormalization(epsilon=1e-6)
-        self.ln3 = tf.keras.layers.LayerNormalization(epsilon=1e-6)
+        self.ln1 = tf.keras.layers.LayerNormalization(epsilon=layer_norm_eps)
+        self.ln2 = tf.keras.layers.LayerNormalization(epsilon=layer_norm_eps)
+        self.ln3 = tf.keras.layers.LayerNormalization(epsilon=layer_norm_eps)
         self.dropout = tf.keras.layers.Dropout(pdrop)
 
     def call(self, inputs):
         x, memory, src_mask, tgt_mask = inputs
-        x = self.ln1(x)
+        if not self.layer_norms_after:
+            x = self.ln1(x)
         x = x + self.dropout(self.self_attn((x, x, x, tgt_mask)), TRAIN_FLAG())
 
         x = self.ln2(x)
@@ -2378,6 +2394,8 @@ class TransformerDecoder(tf.keras.layers.Layer):
 
         x = self.ln3(x)
         x = x + self.dropout(self.ffn(x), TRAIN_FLAG())
+        if self.layer_norms_after:
+            x = self.ln1(x)
         return x
 
 
@@ -2394,13 +2412,15 @@ class TransformerEncoderStack(tf.keras.layers.Layer):
         d_k: Optional[int] = None,
         rpr_k: Optional[Union[int, List[int]]] = None,
         ffn_pdrop: Optional[float] = 0.0,
+        layer_norms_after: bool = False,
+        layer_norm_eps: float = 1.0e-6,
         name=None,
         **kwargs,
     ):
 
         super().__init__(name=name)
         self.encoders = []
-        self.ln = tf.keras.layers.LayerNormalization(epsilon=1e-6)
+        self.ln = tf.identity if layer_norms_after else tf.keras.layers.LayerNormalization(epsilon=layer_norm_eps)
 
         if not is_sequence(rpr_k):
             rpr_k = [rpr_k] * layers
@@ -2408,15 +2428,9 @@ class TransformerEncoderStack(tf.keras.layers.Layer):
         for i in range(layers):
             self.encoders.append(
                 TransformerEncoder(
-                    num_heads,
-                    d_model,
-                    pdrop,
-                    scale,
-                    activation,
-                    d_ff,
-                    d_k,
-                    rpr_k=rpr_k[i],
-                    ffn_pdrop=ffn_pdrop,
+                    num_heads, d_model, pdrop, scale, activation, d_ff, d_k,
+                    rpr_k=rpr_k[i], ffn_pdrop=ffn_pdrop,
+                    layer_norms_after=layer_norms_after, layer_norm_eps=layer_norm_eps,
                     name=name,
                 )
             )
@@ -2440,10 +2454,12 @@ class TransformerEncoderStackWithLengths(TransformerEncoderStack):
         d_ff: Optional[int] = None,
         d_k: Optional[int] = None,
         rpr_k: Optional[Union[int, List[int]]] = None,
+        layer_norms_after: bool = False,
+        layer_norm_eps: float = 1.0e-6,
         name: Optional[str] = None,
         **kwargs,
     ):
-        super().__init__(num_heads, d_model, pdrop, scale, layers, activation, d_ff, d_k, rpr_k, name=name)
+        super().__init__(num_heads, d_model, pdrop, scale, layers, activation, d_ff, d_k, rpr_k, layer_norms_after, layer_norm_eps, name=name)
         self.proj = WithDropout(tf.keras.layers.Dense(d_model), pdrop)
 
     def call(self, inputs):
@@ -2466,10 +2482,12 @@ class TransformerEncoderStackWithTimeMask(TransformerEncoderStack):
         d_ff: Optional[int] = None,
         d_k: Optional[int] = None,
         rpr_k: Optional[Union[int, List[int]]] = None,
+        layer_norms_after: bool = False,
+        layer_norm_eps: float = 1.0e-6,
         name: Optional[str] = None,
         **kwargs,
     ):
-        super().__init__(num_heads, d_model, pdrop, scale, layers, activation, d_ff, d_k, rpr_k, name=name)
+        super().__init__(num_heads, d_model, pdrop, scale, layers, activation, d_ff, d_k, rpr_k, layer_norms_after, layer_norm_eps, name=name)
         self.proj = WithDropout(tf.keras.layers.Dense(d_model), pdrop)
 
     def call(self, inputs):
@@ -2490,13 +2508,17 @@ class TransformerDecoderStack(tf.keras.layers.Layer):
         layers: int = 1,
         activation: str = "relu",
         d_ff: Optional[int] = None,
+        d_k: Optional[int] = None,
+        rpr_k: Optional[Union[int, List[int]]] = None,
         ffn_pdrop: float = 0.0,
+        layer_norms_after: bool = False,
+        layer_norm_eps: float = 1.0e-6,
         name: Optional[str] = None,
         **kwargs,
     ):
         super().__init__(name=name)
         self.decoders = []
-        self.ln = tf.keras.layers.LayerNormalization(epsilon=1e-6)
+        self.ln = tf.identity if layer_norms_after else tf.keras.layers.LayerNormalization(epsilon=1e-6)
         for i in range(layers):
             self.decoders.append(
                 TransformerDecoder(d_model, num_heads, pdrop, scale, activation, d_ff, ffn_pdrop=ffn_pdrop)

--- a/layers/eight_mile/utils.py
+++ b/layers/eight_mile/utils.py
@@ -796,18 +796,29 @@ def sniff_conll_file(f, delim=None, comment_pattern="#", doc_pattern="# begin do
             f.seek(start)
             return len(parts)
 
+@export
+def split_extensions(path: str, exts: Set[str]) -> Tuple[str, str]:
+    all_ext = []
+    path, ext = os.path.splitext(path)
+    while ext in exts:
+        all_ext.append(ext)
+        path, ext = os.path.splitext(path)
+    return path + ext, "".join(all_ext[::-1])
 
 @export
 def remove_extensions(path: str, exts: Set[str]) -> str:
-    path, ext = os.path.splitext(path)
-    while ext in exts:
-        path, ext = os.path.splitext(path)
-    return path + ext
+    path, _ = split_extensions(path, exts)
+    return path
 
 
 @export
 def remove_conll_extensions(path: str, exts: Set[str] = CONLL_EXTS) -> str:
     return remove_extensions(path, exts)
+
+
+@export
+def split_conll_extensions(path: str, exts: Set[str] = CONLL_EXTS) -> Tuple[str, str]:
+    return split_extensions(path, exts)
 
 
 @export

--- a/mead/config/sst2-lstm.json
+++ b/mead/config/sst2-lstm.json
@@ -25,6 +25,7 @@
     },
     "unif": 0.25,
     "model": {
+	"embeddings_reduction": "sum",
 	"model_type": "lstm",
 	"hsz": 200,
 	"dropout": 0.5,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,7 +6,15 @@ from itertools import chain
 import pytest
 import numpy as np
 from mock import patch
-from eight_mile.utils import get_env_gpus, idempotent_append, parse_module_as_path, to_numpy, get_version, remove_extensions
+from eight_mile.utils import (
+    get_env_gpus,
+    idempotent_append,
+    parse_module_as_path,
+    to_numpy,
+    get_version,
+    remove_extensions,
+    split_extensions,
+)
 
 
 @pytest.fixture
@@ -208,9 +216,30 @@ def test_remove_ext():
     res = remove_extensions(path, exts)
     assert res == gold
 
+
 def test_remove_ext_not_in_middle():
     gold = "example.bio.more-stuff"
     exts = {".bio"}
     path = deepcopy(gold)
     res = remove_extensions(path, exts)
     assert res == gold
+
+
+def test_split_ext():
+    exts = {"." + rand_str() for _ in range(np.random.randint(2, 4))}
+    ext_list = list(exts)
+    gold_path = rand_str()
+    gold_exts = "".join(random.choice(ext_list) for _ in range(np.random.randint(1, 4)))
+    path = gold_path + gold_exts
+    path, ext = split_extensions(path, exts)
+    assert path == gold_path
+    assert ext == gold_exts
+
+
+def test_split_ext_not_in_middle():
+    gold = "example.bio.more-stuff"
+    exts = {".bio"}
+    path = deepcopy(gold)
+    res, ext = split_extensions(path, exts)
+    assert res == gold
+    assert ext == ''


### PR DESCRIPTION
adds a reduction option to `EmbeddingsStack` and makes it available through the mead config with `embeddings_reduction` from the `model` block of the file.

Not as flexible as it could be since we dont currently create a registry for reductions, but it is simpler for now this way.

A `sum` reduction currently requires that the dimensions of each embedding are the same size, which seems reasonable and doesnt hide any internal complexities.  

`concat` reductions remain the default behavior.

A major motivation for this is to make it simpler to use BERT features, which require a position embedding, a word (token) embedding and a token type embedding.  Using a sum reduction in the `EmbeddingsStack` means that we can easily support the composition of a token type and a `pos_word + token` combo (or alternately, if we really want to decompose it: `pos + token + token_type`, though this isnt really necessary since we can always compute a positional embedding internal to the library).

For BERT use-cases where the token type is not set, treating it as a constant bias is faster than doing a `zeros_like` on the input to generate token type indices.  We can just add this bias in as a learnable parameter intead.

One obnoxious difference is that BERT relies on doing a layer norm in the embeddings, b/c it follows the T2T style of placing layer norms at the end of blocks instead of at the beginning.  This measn that the learned positional embeddings with bias need a layer norm block in order to replicate BERT.  This doesnt seem like a big deal, but its a different from the non-bias version that a user might not expect.

One final point -- the reductions are implemented as a Keras layer -- we dont necessarily have to do this, but I didnt see any harm in that.