### PR TITLE
Remove 8mi models as internal calls from baseline

### DIFF
--- a/baseline/embeddings.py
+++ b/baseline/embeddings.py
@@ -68,6 +68,9 @@ def load_embeddings(name, **kwargs):
 
     :param name: A unique string name for these embeddings
     :param kwargs:
+
+    :Keyword Arguments:
+    * *embed_type*  The key identifying the embedding type in the registry
     :return:
     """
     embed_type = kwargs.pop("embed_type", "default")

--- a/baseline/pytorch/classify/model.py
+++ b/baseline/pytorch/classify/model.py
@@ -103,7 +103,7 @@ class ClassifierModelBase(nn.Module, ClassifierModel):
 
         return example_dict
 
-    def predict_batch(self, batch_dict, **kwargs):
+    def predict_batch(self, batch_dict: Dict[str, TensorDef], **kwargs) -> TensorDef:
         numpy_to_tensor = bool(kwargs.get('numpy_to_tensor', True))
         examples, perm_idx = self.make_input(batch_dict, perm=True, numpy_to_tensor=numpy_to_tensor)
         with torch.no_grad():
@@ -111,7 +111,7 @@ class ClassifierModelBase(nn.Module, ClassifierModel):
             probs = unsort_batch(probs, perm_idx)
         return probs
 
-    def predict(self, batch_dict, raw=False, dense=False, **kwargs):
+    def predict(self, batch_dict: Dict[str, TensorDef], raw: bool = False, dense: bool = False, **kwargs):
         probs = self.predict_batch(batch_dict, **kwargs)
         if raw and not dense:
             logger.warning(

--- a/baseline/pytorch/tagger/model.py
+++ b/baseline/pytorch/tagger/model.py
@@ -271,42 +271,6 @@ class TransducerTaggerModel(TaggerModelBase):
             )
         return decoder
 
-    def init_embed(self, embeddings: Dict[str, TensorDef], **kwargs) -> BaseLayer:
-        """This method creates the "embedding" layer of the inputs, with an optional reduction
-
-        :param embeddings: A dictionary of embeddings
-
-        :Keyword Arguments: See below
-        * *embeddings_reduction* (defaults to `concat`) An operator to perform on a stack of embeddings
-
-        :return: The output of the embedding stack followed by its reduction.  This will typically be an output
-          with an additional dimension which is the hidden representation of the input
-        """
-        return EmbeddingsStack(embeddings, self.pdrop, reduction=kwargs.get('embeddings_reduction', 'concat'))
-
-    def init_encode(self, input_dim, **kwargs) -> BaseLayer:
-        """Provide a layer object that represents the `encode` phase of the model
-        :param input_dim: The hidden input size
-        :param kwargs:
-        :return: The encoder
-        """
-
-    def init_decode(self, **kwargs) -> BaseLayer:
-        use_crf = bool(kwargs.get('crf', False))
-        constraint_mask = kwargs.get('constraint_mask')
-        if constraint_mask is not None:
-            constraint_mask = constraint_mask.unsqueeze(0)
-
-        if use_crf:
-            decoder = CRF(len(self.labels), constraint_mask=constraint_mask, batch_first=True)
-        else:
-            decoder = TaggerGreedyDecoder(
-                len(self.labels),
-                constraint_mask=constraint_mask,
-                batch_first=True,
-                reduction=kwargs.get('reduction', 'batch')
-            )
-        return decoder
 
     def create_layers(self, embeddings: Dict[str, TensorDef], **kwargs):
         """This class overrides this method to produce the outline of steps for a transduction tagger

--- a/baseline/pytorch/tagger/model.py
+++ b/baseline/pytorch/tagger/model.py
@@ -10,26 +10,39 @@ logger = logging.getLogger('baseline')
 
 
 class TaggerModelBase(nn.Module, TaggerModel):
+    """Base class for tagger models
 
-    def save(self, outname):
-        #m = torch.jit.script(self)
-        #m.save(f'{outname}.script')
+    This class provides the model base for tagging.  To create a tagger, overload `create_layers()` and `forward()`.
+    Most implementations should be able to subclass the TransducerTaggerModel, which inherits from this and imposes
+    additional structure
+    """
+    def __init__(self):
+        """Constructor"""
+        super().__init__()
+        self.gpu = False
+
+    def save(self, outname: str):
+        """Save out the model
+
+        :param outname:
+        :return:
+        """
         torch.save(self, outname)
         basename, _ = os.path.splitext(outname)
         write_json(self.labels, basename + ".labels")
 
-    #def save(self, outname):
-    #    torch.save(self, outname)
-    #    basename, _ = os.path.splitext(outname)
-    #    write_json(self.labels, basename + ".labels")
-
     def to_gpu(self):
+        """Put the model onto the GPU
+        """
         self.gpu = True
         self.cuda()
         return self
 
     @staticmethod
-    def load(filename, **kwargs):
+    def load(filename: str, **kwargs) -> 'TaggerModelBase':
+        """Create and load a tagger model from file
+
+        """
         device = kwargs.get('device')
         if not os.path.exists(filename):
             filename += '.pyt'
@@ -37,52 +50,17 @@ class TaggerModelBase(nn.Module, TaggerModel):
         model.gpu = False if device == 'cpu' else model.gpu
         return model
 
-    def __init__(self):
-        super().__init__()
-        self.gpu = False
-
-    def init_embed(self, **kwargs):
-        return EmbeddingsStack(self.embeddings, self.pdrop, reduction=kwargs.get('embeddings_reduction', 'concat'))
-
-    def init_encoder(self, input_sz, **kwargs):
-        pass
-
-    @classmethod
-    def create(cls, embeddings, labels, **kwargs):
-        model = cls()
-        model.lengths_key = kwargs.get('lengths_key')
-        model.activation_type = kwargs.get('activation', 'tanh')
-        model.embeddings = embeddings
-        model.pdrop = float(kwargs.get('dropout', 0.5))
-        model.dropin_values = kwargs.get('dropin', {})
-        model.labels = labels
-
-        embed_model = model.init_embed(**kwargs)
-        transducer_model = model.init_encoder(embed_model.output_dim, **kwargs)
-
-        use_crf = bool(kwargs.get('crf', False))
-
-        constraint_mask = kwargs.get('constraint_mask')
-        if constraint_mask is not None:
-            constraint_mask = constraint_mask.unsqueeze(0)
-
-        if use_crf:
-            decoder_model = CRF(len(labels), constraint_mask=constraint_mask, batch_first=True)
-        else:
-            decoder_model = TaggerGreedyDecoder(
-                len(labels),
-                constraint_mask=constraint_mask,
-                batch_first=True,
-                reduction=kwargs.get('reduction', 'batch')
-            )
-
-        model.layers = TagSequenceModel(len(labels), embed_model, transducer_model, decoder_model)
-        logger.info(model.layers)
-        return model
-
     def drop_inputs(self, key, x):
-        v = self.dropin_values.get(key, 0)
+        """Do dropout on inputs, using the dropout value (or none if not set)
+        This works by applying a dropout mask with the probability given by a
+        value within the `dropin_values: Dict[str, float]`, keyed off the text name
+        of the feature
 
+        :param key: The feature name
+        :param x: The tensor to drop inputs for
+        :return: The dropped out tensor
+        """
+        v = self.dropin_values.get(key, 0)
         if not self.training or v == 0:
             return x
 
@@ -92,6 +70,14 @@ class TaggerModelBase(nn.Module, TaggerModel):
         return x
 
     def input_tensor(self, key, batch_dict, perm_idx, numpy_to_tensor=False):
+        """Given a batch of input, and a key, prepare and noise the input
+
+        :param key: The key of the tensor
+        :param batch_dict: The batch of data as a dictionary of tensors
+        :param perm_idx: The proper permutation order to get lengths descending
+        :param numpy_to_tensor: Should this tensor be converted to a `torch.Tensor`
+        :return:
+        """
         tensor = batch_dict[key]
         if numpy_to_tensor:
             tensor = torch.from_numpy(tensor)
@@ -103,6 +89,13 @@ class TaggerModelBase(nn.Module, TaggerModel):
         return tensor
 
     def make_input(self, batch_dict, perm=False, numpy_to_tensor=False):
+        """Transform a `batch_dict` into format suitable for tagging
+
+        :param batch_dict: (``dict``) A dictionary containing all inputs to the embeddings for this model
+        :param perm: Should we sort data by length descending?
+        :param numpy_to_tensor: Do we need to convert the input from numpy to a torch.Tensor?
+        :return: A dictionary representation of this batch suitable for processing
+        """
         example_dict = dict({})
         lengths = batch_dict[self.lengths_key]
         if numpy_to_tensor:
@@ -136,52 +129,299 @@ class TaggerModelBase(nn.Module, TaggerModel):
             return example_dict, perm_idx
         return example_dict
 
-    def forward(self, input: Dict[str, torch.Tensor]) -> torch.Tensor:
-        return self.layers(input)
-
-    def compute_loss(self, inputs):
-        tags = inputs['y']
-        lengths = inputs['lengths']
-        unaries = self.layers.transduce(inputs)
-        return self.layers.neg_log_loss(unaries, tags, lengths)
-
     def get_vocab(self, vocab_type='word'):
+        """Produce a dictionary for the vocab feature name
+
+        :param vocab_type: The feature name
+        """
         return self.word_vocab if vocab_type == 'word' else self.char_vocab
 
-    def get_labels(self):
+    def get_labels(self) -> List[str]:
+        """Get the labels (names of each class)
+
+        :return: (`List[str]`) The labels
+        """
         return self.labels
 
-    def predict(self, batch_dict, **kwargs):
+    def predict(self, batch_dict: Dict[str, TensorDef], **kwargs):
+        """Take in a batch of data, and predict the tags
+
+        :param batch_dict: A batch of features that is to be predicted
+        :param kwargs: See Below
+
+        :Keyword Arguments:
+
+        * *numpy_to_tensor* (``bool``) Should we convert input from numpy to `torch.Tensor` Defaults to `True`
+        :return: A batch-sized list of predictions
+        """
         numpy_to_tensor = bool(kwargs.get('numpy_to_tensor', True))
         inputs, perm_idx = self.make_input(batch_dict, perm=True, numpy_to_tensor=numpy_to_tensor)
         outputs = self(inputs)
         return unsort_batch(outputs, perm_idx)
 
+    @classmethod
+    def create(cls, embeddings: Dict[str, TensorDef], labels: List[str], **kwargs) -> 'TaggerModelBase':
+        """Create a tagger from the inputs.  Most classes shouldnt extend this
+
+        :param embeddings: A dictionary containing the input feature indices
+        :param labels: A list of the labels (tags)
+        :param kwargs: See below
+
+        :Keyword Arguments:
+
+        * *lengths_key* (`str`) Which feature identifies the length of the sequence
+        * *activation* (`str`) What type of activation function to use (defaults to `tanh`)
+        * *dropout* (`str`) What fraction dropout to apply
+        * *dropin* (`str`) A dictionarwith feature keys telling what fraction of word masking to apply to each feature
+
+        :return:
+        """
+        model = cls()
+        model.lengths_key = kwargs.get('lengths_key')
+        model.activation_type = kwargs.get('activation', 'tanh')
+        model.pdrop = float(kwargs.get('dropout', 0.5))
+        model.dropin_values = kwargs.get('dropin', {})
+        model.labels = labels
+        model.create_layers(embeddings, **kwargs)
+        return model
+
+    def create_layers(self, embeddings: Dict[str, TensorDef], **kwargs):
+        """This method defines the model itself, and must be overloaded by derived classes
+
+        This function will update `self` with the layers required to execute the `call()` method
+
+        :param embeddings: The input feature indices
+        :param kwargs:
+        :return:
+        """
+    def compute_loss(self, inputs):
+        """Define a loss function from the inputs, which includes the gold tag values as `inputs['y']`
+
+        :param inputs:
+        :return:
+        """
+
+
+class TransducerTaggerModel(TaggerModelBase):
+    """Class defining a typical flow for taggers.  Most taggers should extend this class
+
+    This class provides the model base for tagging by providing specific hooks for each phase.  There are
+    3 basic operations identified in this class:
+
+    1. embed
+    2. encode (transduction)
+    3. decode
+
+    There is an `init_* method for each of this phases, allowing you to
+    define and return a custom layer.
+
+    The actual forward method is defined as a combination of these 3 steps, which includes a
+    projection from the encoder output to the number of labels.
+
+    Decoding in taggers refers to the process of selecting the best path through the labels and is typically
+    implemented either as a constrained greedy decoder or as a CRF layer
+    """
+    def __init__(self):
+        """Constructor"""
+        super().__init__()
+
+    def init_embed(self, embeddings: Dict[str, TensorDef], **kwargs) -> BaseLayer:
+        """This method creates the "embedding" layer of the inputs, with an optional reduction
+
+        :param embeddings: A dictionary of embeddings
+
+        :Keyword Arguments: See below
+        * *embeddings_reduction* (defaults to `concat`) An operator to perform on a stack of embeddings
+
+        :return: The output of the embedding stack followed by its reduction.  This will typically be an output
+          with an additional dimension which is the hidden representation of the input
+        """
+        return EmbeddingsStack(embeddings, self.pdrop, reduction=kwargs.get('embeddings_reduction', 'concat'))
+
+    def init_encode(self, input_dim, **kwargs) -> BaseLayer:
+        """Provide a layer object that represents the `encode` phase of the model
+        :param input_dim: The hidden input size
+        :param kwargs:
+        :return: The encoder
+        """
+
+    def init_decode(self, **kwargs) -> BaseLayer:
+        """Define a decoder from the inputs
+
+        :param kwargs: See below
+        :keyword Arguments:
+        * *crf* (``bool``) Should we create a CRF as the decoder
+        * *constraint_mask* (``tensor``) A constraint mask to apply to the transitions
+        * *reduction* (``str``) How to reduce the loss, defaults to `batch`
+        :return: A decoder layer
+        """
+        use_crf = bool(kwargs.get('crf', False))
+        constraint_mask = kwargs.get('constraint_mask')
+        if constraint_mask is not None:
+            constraint_mask = constraint_mask.unsqueeze(0)
+
+        if use_crf:
+            decoder = CRF(len(self.labels), constraint_mask=constraint_mask, batch_first=True)
+        else:
+            decoder = TaggerGreedyDecoder(
+                len(self.labels),
+                constraint_mask=constraint_mask,
+                batch_first=True,
+                reduction=kwargs.get('reduction', 'batch')
+            )
+        return decoder
+
+    def init_embed(self, embeddings: Dict[str, TensorDef], **kwargs) -> BaseLayer:
+        """This method creates the "embedding" layer of the inputs, with an optional reduction
+
+        :param embeddings: A dictionary of embeddings
+
+        :Keyword Arguments: See below
+        * *embeddings_reduction* (defaults to `concat`) An operator to perform on a stack of embeddings
+
+        :return: The output of the embedding stack followed by its reduction.  This will typically be an output
+          with an additional dimension which is the hidden representation of the input
+        """
+        return EmbeddingsStack(embeddings, self.pdrop, reduction=kwargs.get('embeddings_reduction', 'concat'))
+
+    def init_encode(self, input_dim, **kwargs) -> BaseLayer:
+        """Provide a layer object that represents the `encode` phase of the model
+        :param input_dim: The hidden input size
+        :param kwargs:
+        :return: The encoder
+        """
+
+    def init_decode(self, **kwargs) -> BaseLayer:
+        use_crf = bool(kwargs.get('crf', False))
+        constraint_mask = kwargs.get('constraint_mask')
+        if constraint_mask is not None:
+            constraint_mask = constraint_mask.unsqueeze(0)
+
+        if use_crf:
+            decoder = CRF(len(self.labels), constraint_mask=constraint_mask, batch_first=True)
+        else:
+            decoder = TaggerGreedyDecoder(
+                len(self.labels),
+                constraint_mask=constraint_mask,
+                batch_first=True,
+                reduction=kwargs.get('reduction', 'batch')
+            )
+        return decoder
+
+    def create_layers(self, embeddings: Dict[str, TensorDef], **kwargs):
+        """This class overrides this method to produce the outline of steps for a transduction tagger
+
+        :param embeddings: The input embeddings dict
+        :param kwargs:
+        :return:
+        """
+        self.embeddings = self.init_embed(embeddings, **kwargs)
+        self.encoder = self.init_encode(self.embeddings.output_dim, **kwargs)
+        self.proj_layer = Dense(self.encoder.output_dim, len(self.labels))
+        self.decoder = self.init_decode(**kwargs)
+
+    def transduce(self, inputs: Dict[str, TensorDef]) -> TensorDef:
+        """This operation performs embedding of the input, followed by encoding
+
+        :param inputs: The feature indices to embed
+        :return: Transduced (post-encoding) output
+        """
+        lengths = inputs["lengths"]
+        embedded = self.embeddings(inputs)
+        embedded = (embedded, lengths)
+        transduced = self.proj_layer(self.encoder(embedded))
+        return transduced
+
+    def decode(self, tensor: TensorDef, lengths: TensorDef) -> TensorDef:
+        """Take in the transduced (encoded) input and decode it
+
+        :param tensor: Transduced input
+        :param lengths: Valid lengths of the transduced input
+        :return: A best path through the output
+        """
+        return self.decoder((tensor, lengths))
+
+    def forward(self, inputs: Dict[str, TensorDef]) -> TensorDef:
+        """Take the input and produce the best path of labels out
+
+        :param inputs: The feature indices for the input
+        :return: The most likely path through the output labels
+        """
+        transduced = self.transduce(inputs)
+        path = self.decode(transduced, inputs.get("lengths"))
+        return path
+
+    def compute_loss(self, inputs):
+        """Provide the loss by requesting it from the decoder
+
+        :param inputs: A batch of inputs
+        :return:
+        """
+        tags = inputs['y']
+        lengths = inputs['lengths']
+        unaries = self.transduce(inputs)
+        return self.decoder.neg_log_loss(unaries, tags, lengths)
+
 
 @register_model(task='tagger', name='default')
-class RNNTaggerModel(TaggerModelBase):
+class RNNTaggerModel(TransducerTaggerModel):
+    """RNN-based tagger implementation: this is the default tagger for mead-baseline
 
+    Overload the encoder, typically as a BiLSTM
+    """
     def __init__(self):
         super().__init__()
 
-    def init_encoder(self, input_sz, **kwargs):
-        layers = int(kwargs.get('layers', 1))
-        pdrop = float(kwargs.get('dropout', 0.5))
+    def init_encode(self, input_dim: int, **kwargs) -> BaseLayer:
+        """Override the base method to produce an RNN transducer
+
+        :param input_dim: The size of the input
+        :param kwargs: See below
+
+        :Keyword Arguments:
+        * *rnntype* (``str``) The type of RNN, defaults to `blstm`
+        * *layers* (``int``) The number of layers to stack
+        * *hsz* (``int``) The number of hidden units for each layer in the encoder
+        * *dropout* (``float``) The dropout rate
+        * *weight_init* (``str``) The weight initializer, defaults to `uniform`
+        * *unif* (``float``) A value for the weight initializer
+        :return: An encoder
+        """
+        rnntype = kwargs.get('rnntype', 'blstm')
+        nlayers = int(kwargs.get('layers', 1))
         unif = kwargs.get('unif', 0)
         hsz = int(kwargs['hsz'])
+        pdrop = float(kwargs.get('dropout', 0.5))
         weight_init = kwargs.get('weight_init', 'uniform')
-        rnntype = kwargs.get('rnntype', 'blstm')
         Encoder = LSTMEncoderSequence if rnntype == 'lstm' else BiLSTMEncoderSequence
-        return Encoder(input_sz, hsz, layers, pdrop, unif=unif, initializer=weight_init, batch_first=True)
+        return Encoder(input_dim, hsz, nlayers, pdrop, unif=unif, initializer=weight_init, batch_first=True)
 
 
 @register_model(task='tagger', name='transformer')
-class TransformerTaggerModel(TaggerModelBase):
+class TransformerTaggerModel(TransducerTaggerModel):
+    """Transformer-based tagger model
 
+    Overload the encoder using a length-aware Transformer
+    """
     def __init__(self):
         super().__init__()
 
-    def init_encoder(self, input_sz, **kwargs):
+    def init_encode(self, input_dim: int, **kwargs) -> BaseLayer:
+        """Override the base method to produce an RNN transducer
+
+        :param input_dim: The size of the input
+        :param kwargs: See below
+
+        :Keyword Arguments:
+        * *num_heads* (``int``) The number of heads for multi-headed attention
+        * *layers* (``int``) The number of layers to stack
+        * *hsz* (``int``) The number of hidden units for each layer in the encoder
+        * *dropout* (``float``) The dropout rate, defaults
+        * *d_ff* (``int``) The feed-forward layer size
+        * *rpr_k* (``list`` or ``int``) The relative attention sizes.  If its a list, one scalar per layer, if its
+          a scalar, apply same size to each layer
+        :return: An encoder
+        """
         layers = int(kwargs.get('layers', 1))
         num_heads = int(kwargs.get('num_heads', 4))
         pdrop = float(kwargs.get('dropout', 0.5))
@@ -189,30 +429,58 @@ class TransformerTaggerModel(TaggerModelBase):
         hsz = int(kwargs['hsz'])
         rpr_k = kwargs.get('rpr_k', 100)
         d_ff = kwargs.get('d_ff')
-        encoder = TransformerEncoderStackWithLengths(num_heads, hsz, pdrop, scale, layers, d_ff=d_ff, rpr_k=rpr_k, input_sz=input_sz)
+        encoder = TransformerEncoderStackWithLengths(num_heads, hsz, pdrop, scale, layers, d_ff=d_ff, rpr_k=rpr_k, input_sz=input_dim)
         return encoder
 
 
 @register_model(task='tagger', name='cnn')
-class CNNTaggerModel(TaggerModelBase):
+class CNNTaggerModel(TransducerTaggerModel):
+    """Convolutional (AKA TDNN) tagger
 
+    Overload the encoder using a conv layer
+
+    """
     def __init__(self):
         super().__init__()
 
-    def init_encoder(self, input_sz, **kwargs):
+    def init_encode(self, input_dim: int, **kwargs) -> BaseLayer:
+        """Override the base method to produce an RNN transducer
+
+        :param input_dim: The size of the input
+        :param kwargs: See below
+
+        :Keyword Arguments:
+        * *layers* (``int``) The number of layers to stack
+        * *hsz* (``int``) The number of hidden units for each layer in the encoder
+        * *dropout* (``float``) The dropout rate, defaults
+        * *activation_type* (``str``) Defaults to `relu`
+        * *wfiltsz* (``int``) The 1D filter size for the convolution
+        :return: An encoder
+        """
         layers = int(kwargs.get('layers', 1))
         pdrop = float(kwargs.get('dropout', 0.5))
         filtsz = kwargs.get('wfiltsz', 5)
         activation_type = kwargs.get('activation_type', 'relu')
         hsz = int(kwargs['hsz'])
-        return WithoutLength(ConvEncoderStack(input_sz, hsz, filtsz, layers, pdrop, activation_type))
+        return WithoutLength(ConvEncoderStack(input_dim, hsz, filtsz, layers, pdrop, activation_type))
 
 
 @register_model(task='tagger', name='pass')
-class PassThruTaggerModel(TaggerModelBase):
+class PassThruTaggerModel(TransducerTaggerModel):
+    """A Pass-thru implementation of the encoder
 
+    When we fine-tune our taggers from things like BERT embeddings, we might want to just pass through our
+    embedding result directly to the output decoder.  This model provides a mechanism for this by providing
+    a simple identity layer
+    """
     def __init__(self):
         super().__init__()
 
-    def init_encoder(self, input_sz, **kwargs):
-        return WithoutLength(PassThru(input_sz))
+    def init_encode(self, input_dim: int, **kwargs) -> BaseLayer:
+        """Identity layer encoder
+
+        :param input_dim: The input dims
+        :param kwargs: None
+        :return: An encoder
+        """
+        return WithoutLength(PassThru(input_dim))

--- a/baseline/pytorch/tagger/model.py
+++ b/baseline/pytorch/tagger/model.py
@@ -13,7 +13,7 @@ class TaggerModelBase(nn.Module, TaggerModel):
     """Base class for tagger models
 
     This class provides the model base for tagging.  To create a tagger, overload `create_layers()` and `forward()`.
-    Most implementations should be able to subclass the TransducerTaggerModel, which inherits from this and imposes
+    Most implementations should be able to subclass the `AbstractEncoderTaggerModel`, which inherits from this and imposes
     additional structure
     """
     def __init__(self):
@@ -195,7 +195,7 @@ class TaggerModelBase(nn.Module, TaggerModel):
         """
 
 
-class TransducerTaggerModel(TaggerModelBase):
+class AbstractEncoderTaggerModel(TaggerModelBase):
     """Class defining a typical flow for taggers.  Most taggers should extend this class
 
     This class provides the model base for tagging by providing specific hooks for each phase.  There are
@@ -332,7 +332,7 @@ class TransducerTaggerModel(TaggerModelBase):
 
 
 @register_model(task='tagger', name='default')
-class RNNTaggerModel(TransducerTaggerModel):
+class RNNTaggerModel(AbstractEncoderTaggerModel):
     """RNN-based tagger implementation: this is the default tagger for mead-baseline
 
     Overload the encoder, typically as a BiLSTM
@@ -366,7 +366,7 @@ class RNNTaggerModel(TransducerTaggerModel):
 
 
 @register_model(task='tagger', name='transformer')
-class TransformerTaggerModel(TransducerTaggerModel):
+class TransformerTaggerModel(AbstractEncoderTaggerModel):
     """Transformer-based tagger model
 
     Overload the encoder using a length-aware Transformer
@@ -402,7 +402,7 @@ class TransformerTaggerModel(TransducerTaggerModel):
 
 
 @register_model(task='tagger', name='cnn')
-class CNNTaggerModel(TransducerTaggerModel):
+class CNNTaggerModel(AbstractEncoderTaggerModel):
     """Convolutional (AKA TDNN) tagger
 
     Overload the encoder using a conv layer
@@ -434,7 +434,7 @@ class CNNTaggerModel(TransducerTaggerModel):
 
 
 @register_model(task='tagger', name='pass')
-class PassThruTaggerModel(TransducerTaggerModel):
+class PassThruTaggerModel(AbstractEncoderTaggerModel):
     """A Pass-thru implementation of the encoder
 
     When we fine-tune our taggers from things like BERT embeddings, we might want to just pass through our

--- a/baseline/pytorch/tagger/model.py
+++ b/baseline/pytorch/tagger/model.py
@@ -129,13 +129,6 @@ class TaggerModelBase(nn.Module, TaggerModel):
             return example_dict, perm_idx
         return example_dict
 
-    def get_vocab(self, vocab_type='word'):
-        """Produce a dictionary for the vocab feature name
-
-        :param vocab_type: The feature name
-        """
-        return self.word_vocab if vocab_type == 'word' else self.char_vocab
-
     def get_labels(self) -> List[str]:
         """Get the labels (names of each class)
 

--- a/baseline/pytorch/torchy.py
+++ b/baseline/pytorch/torchy.py
@@ -10,6 +10,8 @@ from eight_mile.pytorch.layers import *
 
 PYT_MAJOR_VERSION = get_version(torch)
 
+BaseLayer = nn.Module
+TensorDef = torch.Tensor
 
 class SequenceCriterion(nn.Module):
 

--- a/baseline/tf/classify/model.py
+++ b/baseline/tf/classify/model.py
@@ -558,10 +558,13 @@ class FineTuneModelClassifier(ClassifierModelBase):
             return PassThru(input_dim)
         return DenseStack(input_dim, hszs, pdrop_value=self.pdrop_value)
 
+    def init_output(self, **kwargs):
+        return tf.keras.layers.Dense(len(self.labels))
+
     def create_layers(self, embeddings, **kwargs):
         self.embeddings = self.init_embed(embeddings, **kwargs)
         self.stack_model = self.init_stacked(self.embeddings.output_dim, **kwargs)
-        self.output_layer = tf.keras.layers.Dense(len(self.labels))
+        self.output_layer = self.init_output(**kwargs)
 
     def call(self, inputs):
         base_layers = self.embeddings(inputs)

--- a/baseline/tf/classify/model.py
+++ b/baseline/tf/classify/model.py
@@ -22,7 +22,9 @@ from baseline.tf.tfy import (
     reload_embeddings,
     new_placeholder_dict,
     tf_device_wrapper,
-    create_session
+    create_session,
+    BaseLayer,
+    TensorDef
 )
 
 
@@ -33,15 +35,10 @@ class ClassifierModelBase(tf.keras.Model, ClassifierModel):
     """Base for all baseline implementations of token-based classifiers
 
     This class provides a loose skeleton around which the baseline models
-    are built.  This essentially consists of dividing up the network into a logical separation between "embedding",
-    or composition of lookup tables to build a vector representation of a temporal input, "pooling",
-    or the conversion of temporal data to a fixed representation, and "stacking" layers, which are (optional)
-    fully-connected layers below, followed by a projection to output space and a softmax
-
-    For instance, the baseline convolutional and LSTM models implement pooling as CMOT, and LSTM last time
-    respectively, whereas, neural bag-of-words (NBoW) do simple max or mean pooling followed by multiple fully-
-    connected layers.
-
+    are built.  It is built on the Keras Model base, and fulfills the `ClassifierModel` interface.
+    To override this class, the use would typically override the `create_layers` function which will
+    create and attach all sub-layers of this model into the class, and the `call` function which will
+    give the model some implementation to call on forward.
     """
     def __init__(self, name=None):
         """Base
@@ -76,16 +73,16 @@ class ClassifierModelBase(tf.keras.Model, ClassifierModel):
             if hasattr(embedding, 'save_md'):
                 embedding.save_md('{}-{}-md.json'.format(basename, key))
 
-    def _record_state(self, **kwargs):
+    def _record_state(self, embeddings: Dict[str, TensorDef], **kwargs):
         embeddings_info = {}
-        for k, v in self.embeddings.items():
+        for k, v in embeddings.items():
             embeddings_info[k] = v.__class__.__name__
 
         blacklist = set(chain(
             self._unserializable,
             MAGIC_VARS,
-            self.embeddings.keys(),
-            (f'{k}_lengths' for k in self.embeddings.keys())
+            embeddings.keys(),
+            (f'{k}_lengths' for k in embeddings.keys())
         ))
         self._state = {k: v for k, v in kwargs.items() if k not in blacklist}
         self._state.update({
@@ -197,7 +194,7 @@ class ClassifierModelBase(tf.keras.Model, ClassifierModel):
 
         return batch_for_model
 
-    def get_labels(self):
+    def get_labels(self) -> List[str]:
         """Get the string labels back
 
         :return: labels
@@ -206,7 +203,7 @@ class ClassifierModelBase(tf.keras.Model, ClassifierModel):
 
     @classmethod
     @tf_device_wrapper
-    def load(cls, basename, **kwargs):
+    def load(cls, basename: str, **kwargs) -> 'ClassifierModelBase':
         """Reload the model from a graph file and a checkpoint
 
         The model that is loaded is independent of the pooling and stacking layers, making this class reusable
@@ -262,18 +259,18 @@ class ClassifierModelBase(tf.keras.Model, ClassifierModel):
         return model
 
     @property
-    def lengths_key(self):
+    def lengths_key(self) -> str:
         return self._lengths_key
 
     @lengths_key.setter
-    def lengths_key(self, value):
+    def lengths_key(self, value: str):
         self._lengths_key = value
 
     @classmethod
-    def create(cls, embeddings, labels, **kwargs):
+    def create(cls, embeddings: Dict[str, TensorDef], labels: List[str], **kwargs) -> 'ClassifierModelBase':
         """The main method for creating all :class:`ClassifierBasedModel` types.
 
-        This method instantiates a model with pooling and optional stacking layers.
+        This method typically instantiates a model with pooling and optional stacking layers.
         Many of the arguments provided are reused by each implementation, but some sub-classes need more
         information in order to properly initialize.  For this reason, the full list of keyword args are passed
         to the :method:`pool` and :method:`stacked` methods.
@@ -300,9 +297,9 @@ class ClassifierModelBase(tf.keras.Model, ClassifierModel):
         :return: A fully-initialized tensorflow classifier
         """
         model = cls(name=kwargs.get('name'))
-        model.embeddings = {}
+        embeddings_ = {}
         for k, embedding in embeddings.items():
-            model.embeddings[k] = embedding.detached_ref()
+            embeddings_[k] = embedding.detached_ref()
 
         model.lengths_key = kwargs.get('lengths_key')
 
@@ -316,12 +313,12 @@ class ClassifierModelBase(tf.keras.Model, ClassifierModel):
             else:
                 model.lengths = None
 
-        model._record_state(**kwargs)
+        model._record_state(embeddings_, **kwargs)
 
         nc = len(labels)
         if not tf.executing_eagerly():
             model.y = kwargs.get('y', tf.compat.v1.placeholder(tf.int32, [None, nc], name="y"))
-            for k, embedding in model.embeddings.items():
+            for k, embedding in embeddings_.items():
                 x = kwargs.get(k, embedding.create_placeholder(name=k))
                 inputs[k] = x
 
@@ -329,7 +326,7 @@ class ClassifierModelBase(tf.keras.Model, ClassifierModel):
 
         model.pdrop_value = kwargs.get('dropout', 0.5)
         model.labels = labels
-        model.create_layers(**kwargs)
+        model.create_layers(embeddings_, **kwargs)
 
         if not tf.executing_eagerly():
             model.logits = tf.identity(model(inputs), name="logits")
@@ -337,81 +334,97 @@ class ClassifierModelBase(tf.keras.Model, ClassifierModel):
             model.probs = tf.nn.softmax(model.logits, name="probs")
         return model
 
-    def call(self, *args, **kwargs):
-        return self.impl(*args, **kwargs)
+    def create_layers(self, embeddings: Dict[str, TensorDef], **kwargs):
+        """This method defines the model itself, and must be overloaded by derived classes
 
-    @property
-    def trainable_variables(self):
-        return self.impl.trainable_variables
+        This function will update `self` with the layers required to execute the `call()` method
 
-    @property
-    def variables(self):
-        return self.impl.variables
-
-    def create_layers(self, **kwargs):
-        pass
-
-    def embed(self, **kwargs):
-        """This method performs "embedding" of the inputs.  The base method here then concatenates along depth
-        dimension to form word embeddings
-
-        :return: A 3-d vector where the last dimension is the concatenated dimensions of all embeddings
+        :param embeddings: The input feature indices
+        :param kwargs:
+        :return:
         """
-        return EmbeddingsStack(self.embeddings, reduction=kwargs.get('embeddings_reduction', 'concat'))
 
 
 class EmbedPoolStackClassifier(ClassifierModelBase):
+    """Provides a simple but effective base for most `ClassifierModel`s
 
-    def create_layers(self, **kwargs):
-        embeddings_stack = self.embed(**kwargs)
+    This class provides a common base for classifiers by identifying and codifying
+    and idiomatic pattern where a typical classifier may be though of as a composition
+    between a stack of embeddings, followed by a pooling operation yielding a fixed length
+    tensor, followed by one or more dense layers, and ultimately, a projection to the output space.
 
-        nc = len(self.labels)
-        pool = self.pool(embeddings_stack.dsz, **kwargs)
-        stacking = self.stacked(**kwargs)
-        output = self.output(nc, **kwargs)
-        self.impl = EmbedPoolStackModel(nc, embeddings_stack, pool, stacking, output)
+    To provide an useful interface to sub-classes, we override the `create_layers` to provide a hook
+    for each layer identified in this idiom, and leave the implementations up to the sub-class.
 
-    def pool(self, dsz, **kwargs):
-        """This method performs a transformation between a temporal signal and a fixed representation
+    We also fully implement the `call` method.
 
-        :param word_embeddings: The output of the embedded lookup, which is the starting point for this operation
-            :param dsz: The depth of the embeddings
-        :param init: The tensorflow initializer to use for these methods
-            :param kwargs: Model-specific arguments
-        :return: A fixed representation of the data"""
+    """
+    def create_layers(self, embeddings: Dict[str, TensorDef], **kwargs):
+        self.embeddings = self.init_embed(embeddings, **kwargs)
+        self.pool_model = self.init_pool(self.embeddings.output_dim, **kwargs)
+        self.stack_model = self.init_stacked(self.pool_model.output_dim, **kwargs)
+        self.output_layer = self.init_output(**kwargs)
 
-    def stacked(self, **kwargs):
-        """Stack 1 or more hidden layers, optionally (forming an MLP)
+    def init_embed(self, embeddings: Dict[str, TensorDef], **kwargs) -> BaseLayer:
+        """This method creates the "embedding" layer of the inputs, with an optional reduction
+        :Keyword Arguments: See below
+        * *embeddings_reduction* (defaults to `concat`) An operator to perform on a stack of embeddings
 
-        :param pooled: The fixed representation of the model
-        :param init: The tensorflow initializer
-        :param kwargs: See below
+        :return: The output of the embedding stack followed by its reduction.  This will typically be an output
+          with an additional dimension which is the hidden representation of the input
+        """
+        return EmbeddingsStack(embeddings, reduction=kwargs.get('embeddings_reduction', 'concat'))
 
-        :Keyword Arguments:
-        * *hsz* -- (``int``) The number of hidden units (defaults to `100`)
+    def init_pool(self, input_dim: int, **kwargs) -> BaseLayer:
+        """Produce a pooling operation that will be used in the model
 
-        :return: The final layer
+        :param input_dim: The input dimension size
+        :param kwargs:
+        :return: A pooling operation
         """
 
-        hszs = listify(kwargs.get('hsz', []))
-        if len(hszs) == 0:
-            return None
-        return DenseStack(None, hszs, pdrop_value=self.pdrop_value)
+    def init_stacked(self, input_dim: int, **kwargs) -> BaseLayer:
+        """Produce a stacking operation that will be used in the model
 
-    def output(self, output_dim, **kwargs):
-        return tf.keras.layers.Dense(output_dim)
+        :param input_dim: The input dimension size
+        :param kwargs:
+        :return: A stacking operation (or None)
+        """
+        hszs = listify(kwargs.get('hsz', []))
+        if not hszs:
+            return PassThru(input_dim)
+        return DenseStack(input_dim, hszs, pdrop_value=self.pdrop_value)
+
+    def init_output(self, **kwargs) -> BaseLayer:
+        """Produce the final output layer in the model
+        :param kwargs:
+        :return:
+        """
+        return tf.keras.layers.Dense(len(self.labels))
+
+    def call(self, inputs: Dict[str, TensorDef]) -> TensorDef:
+        """Forward execution of the model.  Sub-classes typically shouldnt need to override
+
+        :param inputs: An input dictionary containing the features and the primary key length
+        :return: A tensor
+        """
+        lengths = inputs.get("lengths")
+        embedded = self.embeddings(inputs)
+        embedded = (embedded, lengths)
+        pooled = self.pool_model(embedded)
+        stacked = self.stack_model(pooled)
+        return self.output_layer(stacked)
 
 
 @register_model(task='classify', name='default')
 class ConvModel(EmbedPoolStackClassifier):
     """Current default model for `baseline` classification.  Parallel convolutions of varying receptive field width
-
     """
 
-    def pool(self, dsz, **kwargs):
+    def init_pool(self, input_dim: int, **kwargs) -> BaseLayer:
         """Do parallel convolutional filtering with varied receptive field widths, followed by max-over-time pooling
 
-        :param dsz: Embedding output size
+        :param input_dim: Embedding output size
         :param kwargs: See below
 
         :Keyword Arguments:
@@ -419,17 +432,16 @@ class ConvModel(EmbedPoolStackClassifier):
             These are MOT-filtered, leaving this # of units per parallel filter
         * *filtsz* -- (``list``) This is a list of filter widths to use
 
-        :return:
+        :return: A pooling layer
         """
         cmotsz = kwargs['cmotsz']
         filtsz = kwargs['filtsz']
-        return WithDropout(ParallelConv(dsz, cmotsz, filtsz), self.pdrop_value)
+        return WithoutLength(WithDropout(ParallelConv(input_dim, cmotsz, filtsz), self.pdrop_value))
 
 
 @register_model(task='classify', name='lstm')
 class LSTMModel(EmbedPoolStackClassifier):
     """A simple single-directional single-layer LSTM. No layer-stacking.
-
     """
 
     def __init__(self, name=None):
@@ -444,19 +456,19 @@ class LSTMModel(EmbedPoolStackClassifier):
     def vdrop(self, value):
         self._vdrop = value
 
-    def pool(self, dsz, **kwargs):
+    def init_pool(self, input_dim: int, **kwargs) -> BaseLayer:
         """LSTM with dropout yielding a final-state as output
 
-        :param word_embeddings: The input word embeddings
-        :param dsz: The input word embedding depth
+        :param input_dim: The input word embedding depth
         :param kwargs: See below
 
         :Keyword Arguments:
         * *rnnsz* -- (``int``) The number of hidden units (defaults to `hsz`)
+        * *rnntype/rnn_type* -- (``str``) The RNN type, defaults to `lstm`, other valid values: `blstm`
         * *hsz* -- (``int``) backoff for `rnnsz`, typically a result of stacking params.  This keeps things simple so
           its easy to do things like residual connections between LSTM and post-LSTM stacking layers
 
-        :return:
+        :return: A pooling layer
         """
         hsz = kwargs.get('rnnsz', kwargs.get('hsz', 100))
         vdrop = bool(kwargs.get('variational', False))
@@ -471,61 +483,90 @@ class LSTMModel(EmbedPoolStackClassifier):
         return LSTMEncoderHidden(None, hsz, nlayers, self.pdrop_value, vdrop)
 
 
-class NBowBase(EmbedPoolStackClassifier):
+class NBowModelBase(EmbedPoolStackClassifier):
     """Neural Bag-of-Words Model base class.  Defines stacking of fully-connected layers, but leaves pooling to derived
     """
 
-    def stacked(self, **kwargs):
-        """Force at least one hidden layer here
+    def init_stacked(self, **kwargs):
+        """Produce a stacking operation that will be used in the model, defaulting to a single layer
 
-        :param kwargs:
-        :return:
+        :param input_dim: The input dimension size
+        :param kwargs: See below
+
+        :Keyword Arguments:
+        * *hsz* -- (``List[int]``) The number of hidden units (defaults to 100)
         """
         kwargs.setdefault('hsz', [100])
-        return super(NBowBase, self).stacked(**kwargs)
+        return super().stacked(**kwargs)
 
 
 @register_model(task='classify', name='nbow')
-class NBowModel(NBowBase):
+class NBowModel(NBowModelBase):
     """Neural Bag-of-Words average pooling (standard) model"""
 
-    def pool(self, dsz, **kwargs):
+    def init_pool(self, input_dim: int, **kwargs):
         """Do average pooling on input embeddings, yielding a `dsz` output layer
 
-        :param word_embeddings: The word embedding input
-        :param dsz: The word embedding depth
-        :param init: The tensorflow initializer
+        :param input_dim: The word embedding depth
         :param kwargs: None
         :return: The average pooling representation
         """
-        return MeanPool1D(dsz)
+        return MeanPool1D(input_dim)
 
 
 @register_model(task='classify', name='nbowmax')
-class NBowMaxModel(NBowBase):
+class NBowMaxModel(NBowModelBase):
     """Max-pooling model for Neural Bag-of-Words.  Sometimes does better than avg pooling
     """
 
-    def pool(self, dsz, **kwargs):
+    def init_pool(self, input_dim: int, **kwargs) -> BaseLayer:
         """Do max pooling on input embeddings, yielding a `dsz` output layer
 
-        :param word_embeddings: The word embedding input
-        :param dsz: The word embedding depth
-        :param init: The tensorflow initializer
+        :param input_dim: The word embedding depth
         :param kwargs: None
         :return: The max pooling representation
         """
-        return tf.keras.layers.GlobalMaxPooling1D()
+        return WithoutLength(tf.keras.layers.GlobalMaxPooling1D())
 
 
 @register_model(task='classify', name='fine-tune')
 class FineTuneModelClassifier(ClassifierModelBase):
     """Fine-tune based on pre-pooled representations"""
 
-    def create_layers(self, **kwargs):
-        embeddings_stack = self.embed(**kwargs)
-        nc = len(self.labels)
-        self.impl = FineTuneModel(nc, embeddings_stack)
+    def init_embed(self, embeddings: Dict[str, TensorDef], **kwargs) -> BaseLayer:
+        """This method creates the "embedding" layer of the inputs, with an optional reduction
+
+        :param embeddings: A dictionary of embeddings
+
+        :Keyword Arguments: See below
+        * *embeddings_reduction* (defaults to `concat`) An operator to perform on a stack of embeddings
+
+        :return: The output of the embedding stack followed by its reduction.  This will typically be an output
+          with an additional dimension which is the hidden representation of the input
+        """
+        return EmbeddingsStack(embeddings, reduction=kwargs.get('embeddings_reduction', 'concat'))
+
+    def init_stacked(self, input_dim: int, **kwargs) -> BaseLayer:
+        """Produce a stacking operation that will be used in the model
+
+        :param input_dim: The input dimension size
+        :param kwargs:
+        :return: A stacking operation (or None)
+        """
+        hszs = listify(kwargs.get('hsz', []))
+        if not hszs:
+            return PassThru(input_dim)
+        return DenseStack(input_dim, hszs, pdrop_value=self.pdrop_value)
+
+    def create_layers(self, embeddings, **kwargs):
+        self.embeddings = self.init_embed(embeddings, **kwargs)
+        self.stack_model = self.init_stacked(self.embeddings.output_dim, **kwargs)
+        self.output_layer = tf.keras.layers.Dense(len(self.labels))
+
+    def call(self, inputs):
+        base_layers = self.embeddings(inputs)
+        stacked = self.stack_model(base_layers)
+        return self.output_layer(stacked)
 
 
 @register_model(task='classify', name='composite')

--- a/baseline/tf/classify/model.py
+++ b/baseline/tf/classify/model.py
@@ -73,7 +73,7 @@ class ClassifierModelBase(tf.keras.Model, ClassifierModel):
             if hasattr(embedding, 'save_md'):
                 embedding.save_md('{}-{}-md.json'.format(basename, key))
 
-    def _record_state(self, embeddings: Dict[str, TensorDef], **kwargs):
+    def _record_state(self, embeddings: Dict[str, BaseLayer], **kwargs):
         embeddings_info = {}
         for k, v in embeddings.items():
             embeddings_info[k] = v.__class__.__name__
@@ -267,7 +267,7 @@ class ClassifierModelBase(tf.keras.Model, ClassifierModel):
         self._lengths_key = value
 
     @classmethod
-    def create(cls, embeddings: Dict[str, TensorDef], labels: List[str], **kwargs) -> 'ClassifierModelBase':
+    def create(cls, embeddings: Dict[str, BaseLayer], labels: List[str], **kwargs) -> 'ClassifierModelBase':
         """The main method for creating all :class:`ClassifierBasedModel` types.
 
         This method typically instantiates a model with pooling and optional stacking layers.

--- a/baseline/tf/classify/training/distributed.py
+++ b/baseline/tf/classify/training/distributed.py
@@ -96,7 +96,7 @@ class ClassifyTrainerDistributedTf(EpochReportingTrainer):
             features, y = inputs
             per_replica_loss = self.optimizer.update(self.model, features, y, num_replicas)
             per_replica_batchsz = get_shape_as_list(y)[0]
-            per_replica_report_loss = per_replica_loss * per_replica_batchsz
+            per_replica_report_loss = per_replica_loss * tf.cast(per_replica_batchsz, tf.float32)
             return per_replica_report_loss, per_replica_batchsz
 
         with strategy.scope():
@@ -174,7 +174,7 @@ class ClassifyTrainerDistributedTf(EpochReportingTrainer):
             per_replica_cm = tf.compat.v1.sparse_add(per_replica_cm, sparse_ups)
             per_replica_loss = tf.compat.v1.losses.sparse_softmax_cross_entropy(labels=y, logits=logits)
             per_replica_batchsz = get_shape_as_list(y)[0]
-            per_replica_report_loss = per_replica_loss * per_replica_batchsz
+            per_replica_report_loss = per_replica_loss * tf.cast(per_replica_batchsz, tf.float32)
             return per_replica_report_loss, per_replica_batchsz, per_replica_cm
 
         @tf.function

--- a/baseline/tf/embeddings.py
+++ b/baseline/tf/embeddings.py
@@ -22,12 +22,14 @@ class TensorFlowEmbeddingsModel(tf.keras.Model):
     def detached_ref(self):
         """This will detach any attached input and reference the same sub-graph otherwise
 
+        TODO: this should not longer be required and can be removed
+
         :return:
         """
         if getattr(self.embedding_layer, '_weights', None) is not None:
             return type(self)(self._name, weights=self.embedding_layer._weights, **self._state)
-        if hasattr(self.embedding_layer, 'embed') and getattr(self.embedding_layer.embed, '_weights') is not None:
-            return type(self)(self._name, weights=self.embedding_layer.embed._weights, **self._state)
+        if hasattr(self.embedding_layer, 'embed') and getattr(self.embedding_layer.init_embed, '_weights') is not None:
+            return type(self)(self._name, weights=self.embedding_layer.init_embed._weights, **self._state)
         raise Exception('You must initialize `weights` in order to use this method')
 
     def get_dsz(self):

--- a/baseline/tf/tagger/model.py
+++ b/baseline/tf/tagger/model.py
@@ -17,7 +17,7 @@ class TaggerModelBase(tf.keras.Model, TaggerModel):
     """Base class for tagger models
 
     This class provides the model base for tagging.  To create a tagger, overload `create_layers()` and `forward()`.
-    Most implementations should be able to subclass the TransducerTaggerModel, which inherits from this and imposes
+    Most implementations should be able to subclass the `AbstractEncoderTaggerModel`, which inherits from this and imposes
     additional structure
     """
     def __init__(self):
@@ -336,7 +336,7 @@ class TaggerModelBase(tf.keras.Model, TaggerModel):
         """
 
 
-class TransducerTaggerModel(TaggerModelBase):
+class AbstractEncoderTaggerModel(TaggerModelBase):
     """Class defining a typical flow for taggers.  Most taggers should extend this class
 
     This class provides the model base for tagging by providing specific hooks for each phase.  There are
@@ -449,7 +449,7 @@ class TransducerTaggerModel(TaggerModelBase):
 
 
 @register_model(task='tagger', name='default')
-class RNNTaggerModel(TransducerTaggerModel):
+class RNNTaggerModel(AbstractEncoderTaggerModel):
     """RNN-based tagger implementation: this is the default tagger for mead-baseline
 
     Overload the encoder, typically as a BiLSTM
@@ -488,7 +488,7 @@ class RNNTaggerModel(TransducerTaggerModel):
 
 
 @register_model(task='tagger', name='transformer')
-class TransformerTaggerModel(TransducerTaggerModel):
+class TransformerTaggerModel(AbstractEncoderTaggerModel):
     """Transformer-based tagger model
 
     Overload the encoder using a length-aware Transformer
@@ -523,7 +523,7 @@ class TransformerTaggerModel(TransducerTaggerModel):
 
 
 @register_model(task='tagger', name='cnn')
-class CNNTaggerModel(TransducerTaggerModel):
+class CNNTaggerModel(AbstractEncoderTaggerModel):
     """Convolutional (AKA TDNN) tagger
 
     Overload the encoder using a conv layer
@@ -555,7 +555,7 @@ class CNNTaggerModel(TransducerTaggerModel):
 
 
 @register_model(task='tagger', name='pass')
-class PassThruTaggerModel(TransducerTaggerModel):
+class PassThruTaggerModel(AbstractEncoderTaggerModel):
     """A Pass-thru implementation of the encoder
 
     When we fine-tune our taggers from things like BERT embeddings, we might want to just pass through our

--- a/baseline/tf/tagger/training/eager.py
+++ b/baseline/tf/tagger/training/eager.py
@@ -20,10 +20,9 @@ SHUF_BUF_SZ = 5000
 logger = logging.getLogger('baseline')
 
 
-
 def loss(model, x, y):
     unary = model.transduce(x)
-    return model.decoder_model.neg_log_loss(unary, y, x['lengths'])
+    return model.decoder.neg_log_loss(unary, y, x['lengths'])
 
 
 class TaggerEvaluatorEagerTf:
@@ -198,7 +197,7 @@ class TaggerTrainerEagerTf(EpochReportingTrainer):
         @tf.function
         def _train_step(inputs):
             features, y = inputs
-            loss = self.optimizer.update(self.model.impl, features, y)
+            loss = self.optimizer.update(self.model, features, y)
             batchsz = get_shape_as_list(y)[0]
             report_loss = loss * batchsz
             return report_loss, batchsz

--- a/baseline/tf/tfy.py
+++ b/baseline/tf/tfy.py
@@ -4,6 +4,8 @@ from baseline.utils import transition_mask as transition_mask_np, listify, read_
 from eight_mile.tf.layers import *
 from functools import wraps
 
+BaseLayer = tf.keras.layers.Layer
+TensorDef = tf.Tensor
 
 def reload_embeddings(embeddings_dict, basename):
     embeddings = {}

--- a/docs/classify.md
+++ b/docs/classify.md
@@ -1,11 +1,11 @@
 # Sentence Classification
 
-There are several models built in to the `baseline` codebase.  These are summarized individually in the sections below, and an overall performance summary is given at the bottom
+There are several models built in to the `baseline` codebase.  These are summarized individually in the sections below, and an overall performance summary is given at the bottom.
+The final section provides information on the API design, and how to make your own models
 
 ## A Note About Fine-Tuning and Embeddings
 
 For the lookup-table embeddings, you can control whether or not the embeddings should be fine-tuned by passing a boolean `finetune` in for the `embeddings` section of the mead config.  If you are using random weights, you definitely should fine tune.  If you are using pre-trained embeddings, it may be worth experimenting with this option.  The default behavior is to fine-tune embeddings.  We randomly initialize unattested words and add them to the weight matrix for the Lookup Table.  This can be controlled with the 'unif' parameter in the driver program.
-
 
 ## Convolution Model
 
@@ -23,7 +23,7 @@ Early stopping with patience is supported.  There are many hyper-parameters that
 To run, use this command:
 
 ```
-python trainer.py --config config/sst2.json
+mead-train --config config/sst2.json
 ```
 
 ## LSTM Model
@@ -35,7 +35,7 @@ The LSTM's final hidden state is passed to the final layer.  The use of an LSTM 
 The command below executes an LSTM classifier with 2 sets of pre-trained word embeddings
 
 ```
-python trainer.py --config config/sst2-lstm.json
+mead-train --config config/sst2-lstm.json
 ```
 
 ## Neural Bag of Words (NBoW) Model (Max and Average Pooling)
@@ -69,3 +69,49 @@ When reporting the loss reported every nsteps is the total loss averaged over th
 When reporting the loss at the end of an epoch it is the total loss averaged over the number of examples seen in the whole epoch.
 
 Metrics like accuracy and f1 are computed at the example level.
+
+## API Design & Architecture
+
+There is a base interface `ClassifierModel` defined for classifiers inside of baseline/model.py
+
+This defines the base API for usage, but doesnt provide any implementation.  Each framework sub-module defines a sub-class of this callled `ClassifierModelBase` that all sub-models are built from.  Both Keras and Torch have a base model concept that needs to be extended in this base class.  In Keras, this is the `tf.keras.Model` and in PyTorch, it is the `nn.Module`.  Ultimately, for both Keras and PyTorch, we will need to define a function to create the layers (`create_layers`) and to perform the forward step for these layers (In PyTorch, this is `forward` and in Keras this is `call`.
+
+Most deep learning NLP classifiers tend to reduce to a few simple idioms.  For fine-tuning a language model like BERT, for example, the typical approach is to remove the head from the model (AKA the final linear projection out to the vocab and the normalizing softmax), and to put a final linear projection to the output number of classes in its place.  In MEAD-Baseline, the headless LM would be lodaded as an embedding object and passed into an `EmbeddingsStack` so the model finally just needs an output layer (and optionally, some MLP intermediate layers).
+
+The `FineTuneModelClassifier(ClassifierModelBase)` model provides this interface by overloading `create_layers()` to produce the penultimate stacking layers (if needed) and the output layer.
+
+For cases where we build an actual model from scratch on top of e.g. word embeddings, MEAD-Baseline the typical pattern can be reduced to:
+
+1. embedding
+2. pooling to a fixed representation
+3. optional MLP stacking
+4. output layer
+
+We provide a sub-class `EmbedPoolStackClassifier(ClassifierModelBase)` that fulfills this interface by extending `create_layers()` and providing `init_*` functions to create sub-layers for each of these steps, and providing a reasonable implementation of all but the pooling layer.
+
+We extend this model with our previously described Baseline models by simply overriding the pooling layer.
+
+By effectively separating out the concerns of layer creation, the formation of membeddings, saving and loading of features, our derived sub-classes are nearly identical between PyTorch and TensorFlow.
+
+### Writing your own classifier
+
+The only real requirement to provide mead with your own classifier is to extend the ClassifierModelBase from the framework you are using, and to register your model with the `@register_model` annotation to identify a key that uniquely identifies your model.  However, there are some things that make it very easy or succinct to define custom models that we recommend.
+
+#### Some best practices for writing your own classifier
+
+- Use the mead layers (8 mile) API to define your layers
+  - This will minimize any incompatibility and make it easy to switch frameworks later
+  - Determine if your model can sub-class the `EmbedPoolStackClassifer`.  If it follows this idiom, it may be very succinct to define a new classifer by overriding a single function (typically the `init_pool()` function).
+- If you are overriding the `EmbedPoolStackClassifier`, remember that the pooling layer is expecting 2 arguments -- the input tensor itself and a tensor containing the length.  If you want to adapt an existing Layer from Keras/PyTorch or elsewhere that requires a single input Tensor, use the `WithoutLengths(YourLayer)` adapter layer to provide the callee with the input tensor
+
+### Some Notes on the TensorFlow implementation
+
+### Eager vs Declarative
+
+In TensorFlow, we are supporting eager and declarative mode models.  This fundamentally changes how our objects must look, as in declarative mode, we must do a `session.run` identifying the graph outputs, vs eager mode, which can look nearly identical to PyTorch.
+
+If you wanted to write code to only support graph mode, especially prior to Keras integration, it was common to simply define the graph procedurally and expose its graph endpoints to the class for future use in `session.run`.  This is what previous versions of MEAD-Baseline did.  With Keras now becoming the primary and recommended interface to building neural networks in TensorFlow execution occurs in essentially 2 phases (initialization and execution) corresponding to creation of the layer by calling its constructor vs execution of the `call()` operator `layer(x)`.  In declarative mode, however, ultimately we do need something to call `session.run` on, so we typically will save the output as a property on the class that can be handed to that call.  In eager mode, storing an output property graph node makes no sense at all, so we just dont do it.  Also in eager mode with 2.x, we save and load models somewhat differently than in TF 1.x.
+
+Eager mode massively simplifies the experience of TensorFlow users, however it is not completely trivial to support a training loop for both side-by-side.  In an ideal world where everyone uses eager, we could just use a normal for loop over the input dataset to train the model with gradient tape.  Of course, this doesnt work with declarative mode.  We decided that the cleanest way to support both methods was to have a single classifier model, but to have multiple custom training loops that are defined as `fit_func`s.  The default `fit_func` for eager mode is the previously mentioned simple for loop with gradient tape whereas, for declarative model it a dataset based method relying on iterators.  In V1.x of MEAD-Baseline, the default `fit_func` was a `feed_dict` method.  We still support this method of training by providing a built-in `fit_func` with key `feed_dict`.
+
+When `mead-train` runs in declarative mode (which is controlled by the `--prefer_eager <bool>` argument), the training block of the MEAD config can contain a key `fit_func: feed_dict` to switch the training loop implementation to the previous default method (this can also be done at run-time by passing `--fit_func feed_dict` as a command-line argument to `mead-train`.

--- a/docs/classify.md
+++ b/docs/classify.md
@@ -102,7 +102,7 @@ The only real requirement to provide mead with your own classifier is to extend 
 - Use the mead layers (8 mile) API to define your layers
   - This will minimize any incompatibility and make it easy to switch frameworks later
   - Determine if your model can sub-class the `EmbedPoolStackClassifer`.  If it follows this idiom, it may be very succinct to define a new classifer by overriding a single function (typically the `init_pool()` function).
-- If you are overriding the `EmbedPoolStackClassifier`, remember that the pooling layer is expecting 2 arguments -- the input tensor itself and a tensor containing the length.  If you want to adapt an existing Layer from Keras/PyTorch or elsewhere that requires a single input Tensor, use the `WithoutLengths(YourLayer)` adapter layer to provide the callee with the input tensor
+- If you are overriding the `EmbedPoolStackClassifier`, remember that the pooling layer is expecting 2 arguments -- the input tensor itself and a tensor containing the length.  If you want to adapt an existing Layer from Keras/PyTorch or elsewhere that requires a single input Tensor, use the `WithoutLengths(YourLayer)` adapter which strips the length tensor and provides a single input tensor to `YourLayer`
 
 ### Some Notes on the TensorFlow implementation
 

--- a/docs/dataset-embedding.md
+++ b/docs/dataset-embedding.md
@@ -1,28 +1,54 @@
-### Datasets and Embedding Files
+# Datasets, Embeddings and Vectorizers in MEAD
 
-The datasets and embedding file locations should be provided in `mead/datasets.json`, and `mead/emeddings.json`. These files can exist in your local machine. We also provide methods for automated download. There are a couple of ways to specify the dataset or embedding file locations:
+This section describes the index files MEAD uses to load datasets, embeddings and vectorizers, as well as details on the API and architecture design for the Embeddings and Vectorizer objects and how to create and use your own from MEAD.
 
-#### Requirements
+## MEAD Indices
 
-`requests` is the dependency for automatic download of the files. This can be done in most environments with the command `pip install requests`.
+The driver programs use indices to map a unique identifier to a resource.  There are 3 types of resources that MEAD tracks with indices:
+
+- datasets: mappings of a unique key to a downloadable or stored dataset
+- embeddings: mappings of a unique key to some downloadable or stored embeddings model
+- vecs: mappings of a unique key to a vectorizer model
+
+Indices by default are in JSON, but if PyYAML is installed, they can also be in YAML format.
+
+By default, the trainer uses the installed locations for the indices (`mead/config/datasets.json`, `mead/config/embeddings.json` and `mead/config/vecs.json`), but these locations can be overridden at the command-line.  They also do no have to be on the local filesystem -- the user may pass in a URL reference and the index will then be downloaded to the local system.  Additionally, there are set of existing indices that can be found at [mead-hub](https://github.com/mead-ml/hub).  MEAD provides a shorthand way of referencing mead-hub indices so you dont have to type in the full URL:
+
+- embeddings: `hub:v1:embeddings`
+- vecs: `hub:v1:vecs`
+
+So as an example, to refer to the hub embeddings and vectorizers in your training, you can override them like this:
+```
+mead-train --embeddings hub:v1:embeddings --config config/sst2-bert-base-uncased.yml --vecs hub:v1:vecs
+```
  
-#### Datasets
+### Dataset Index Files
 
 - Path to the data files on your computer (provide the paths separately):
 
 ```
+[
     {
-      "train_file": "/data/datasets/ner/wnut-gaz/wnut17train.conll",
-      "valid_file": "/data/datasets/ner/wnut-gaz/wnut17dev.conll",
-      "test_file": "/data/datasets/ner/wnut-gaz/wnut17test.conll",
-      "label": "wnut-gaz"
-    }
+      "train_file": "/data/datasets/ner/wnut/wnut17train.conll",
+      "valid_file": "/data/datasets/ner/wnut/wnut17dev.conll",
+      "test_file": "/data/datasets/ner/wnut/wnut17test.conll",
+      "label": "wnut"
+    },
+    ...
+]
+```
+The YAML equivalent would be
+```
+- train_file: /data/datasets/ner/wnut17train.conll
+  valid_file: /data/datasets/ner/wnut17dev.conll
+  test_file" /data/datasets/ner/wnut17test.conll
+  label: wnut
 ```
 
-- Link to a directory zip, file names in the unzipped directory as keys (we provide _sha1_ for the zip file in this case. If you send a PR for a new dataset, please add the _sha1_ as well)
-
+Locations can also be a link to a zipped directory, with file names in the unzipped directory as keys (we provide _sha1_ for the zip file in this case. If you send a PR for a new dataset, please add the _sha1_ as well)
 
 ```
+[
  {
     "train_file": "eng.train",
     "valid_file": "eng.testa",
@@ -30,13 +56,8 @@ The datasets and embedding file locations should be provided in `mead/datasets.j
     "download": "https://www.dropbox.com/s/p6ogzhiex9yqsmn/conll.tar.gz?dl=1",
     "sha1":"521c44052a51699742cc63e39db514528e9c2640",
     "label": "conll"
-  }
-```
-
-or
-
-```
-{
+  },
+  {
     "vocab_file": "vocab.en_vi",
     "train_file": "train",
     "valid_file": "tst2012",
@@ -44,10 +65,12 @@ or
     "download": "https://www.dropbox.com/s/99petw2kdab69cr/iwslt15-en-vi.tar.gz?dl=1",
     "sha1":"418a2ccfa7c46a1a1db900295e95ac03e2ec6993",
     "label": "iwslt15-en-vi"
-  }
+  },
+  ...
+]
 ```
 
-- Each key points to a separate download link:
+Each file can also be downloaded individually via a separate download link:
 
 ```
 {
@@ -58,42 +81,52 @@ or
 }
 ```
 
-#### Embedding Files
+### Embedding Index Files
 
-- Compressed zip/tar.gz file with multiple embedding files. the files are uniquely identified by the dsz. Eg, in the zip below, we will pick the file `200` in the file name.
-
-```
-    {
-	"label": "glove-twitter-27B",
-	"file": "http://nlp.stanford.edu/data/glove.twitter.27B.zip",
-	"dsz": 200
-    },
-```
-
-- Direct download link
+The embeddings index supports downloading compressed zip/tar.gz file with multiple embedding files. the files are implicitly identified by the `dsz` field (representing the embedding output hidden unit size). Eg, in the zip below, we will pick the file `200` in the file name.
 
 ```
-    {
-        "label": "glove-6B-50",
-        "file": "https://www.dropbox.com/s/339mhx40t3q9bp5/glove.6B.50d.txt.gz?dl=1",
-        "dsz": 50
-    },
+[
+  {
+    "label": "glove-twitter-27B",
+    "file": "http://nlp.stanford.edu/data/glove.twitter.27B.zip",
+    "dsz": 200
+  },
+  ...
+]
 ```
 
-- On file system
+We also support direct download links:
 
 ```
-{
-        "label": "glove-6B-100",
-        "file": "/data/embeddings/glove.6B.100d.txt",
-        "dsz": 100
-    },
+[
+  {
+    "label": "glove-6B-50",
+    "file": "https://www.dropbox.com/s/339mhx40t3q9bp5/glove.6B.50d.txt.gz?dl=1",
+    "dsz": 50
+  },
+  ...
+]
 ```
 
-### File format
+Embeddings can also be referenced from the file system
+
+```
+[
+  {
+    "label": "glove-6B-100",
+    "file": "/data/embeddings/glove.6B.100d.txt",
+    "dsz": 100
+  },
+  ...
+]
+```
+
+### File formats supported for download
+
 The links can have the usual data format supported by `baseline` or standard zip formats such as `.gz, tar.gz, tgz, zip`. We automatically extract them as needed.
 
-#### Caching
+### Caching
 
 For faster download, all downloaded files are cached. A `<key,value>` store for the download links are maintained at an internal JSON file (datasets-embeddings-cache.json), which should not be committed. For eg:
 ```
@@ -113,7 +146,61 @@ x:config$ cat data-cache.json
 The location of the cache directory is `~/.bl-data/` by default, unless you explicitly mention it at `mead/config/meadconfig.json` and pass it to the trainer with the option `--meadconfig`: `python trainer.py --config config/twpos.json --task tagger --meadconfig config.json`
 
 
-#### Writing own downloaders
+### Writing your own downloaders
 
 You can write your own downloaders by extending the base Downloader class. Helper methods are provided.
 
+## API and Architecture Design
+
+
+### Vectorizers API
+
+The `Vectorizer` interface in mead accepts a `List[str]` as input and produces frequency dictionaries when the `count()` function is called, and `numpy.array`s when the `run()` function is called.
+
+The purpose of `count()` is to tabulate the frequencies to produce a vocabulary.  The returned object is a `Counter` and may be filtered by low-frequency terms, or manipulated in any other way that makes sense.  While the `Vectorizer` knows how to `count()` tokens, it does not store anything internally.
+
+When its time to execute code, the `run()` function is called on a `List[str]` input and an index that maps tokens to integers.  The vectorizer then produces a fixed dimensional `numpy.array` of `integers` that is typically zero-padded on the right side.  The `Vectorizer` interface is not expected to produce mini-batches of data, it is expected that the caller should be able to orchestrate the individual outputs of the `Vectorizer` into a proper batch.
+
+How the caller orchestrates these indices is unknown to the `Vectorizer`.  It just knows how execute those functions.  A `Vectorizer` also can contain a `transform` function, which it runs over each token.  Typically the purpose of this function is simply to lower-case the input, but it can be used for any purpose (e.g. stop-wording).
+
+`Vectorizer`s are currently persisted as `.pickle` files, which makes it easy to reload them in Python, but is quite limited for other languages, and this is likely to change in the near future.
+
+`Vectorizer`s currently a one-to-one relationship with features.  This is almost always desirable as it provides better Separation of Concerns, but on rare occrasions, it can cause some complexities.
+
+#### The dimensionality of Vectorizer output
+
+For words or sub-words, usually the vectorizer will be 1D.  The return of `run()` would be a tensor padded out to `mxlen` and a scalar for that tensor's valid length.  Note that byte-pair (BPE) and WordPiece vectorizers are typically simple 1D vectorizers, but that in those cases, the output sequence length will usually be greater than the number of input tokens, because these tokenizers split words into sub-words.  Care must be taken to ensure that the `mxlen` is sufficient to fit the sub-word vectors or the results may be truncated.
+
+To produce characters for each word, the vectorizer will typically be 2D, with `mxwlen` describing the length of each "word" and `mxlen` defining the overall sequence max length.  Another use-case for 2D vectorizers would be in Dialogue Act Recognition (DAR), where we may have a dimension for word-level tokenization for each turn, and a dimension for the turn itself.  In this case, `mxlen` is the maximum number of turns and `mxwlen` is the maximum turn length.
+
+Sometimes models provide multiple features representing the same tokens.  This quite common in tagging, where the input file is typically in CONLL format, where each desired features is tab or space-delimited with a different feature identifier.  The `DictVectorizer` exists for these cases.  There are 1D and 2D representations of each feature when using `DictVectorizer`s.
+
+One unusual and slightly complex use-case for `Vectorizers` occur when implementing taggers with BPE.  In those cases, typically we want our label vectorizer to produce "<PAD>" (zero-pad) features whenever the input is a non-first subword token.  But the only way to know that it would a sub-word is to first tokenize the surface tokens and test each to see if it is the start of a sub-word or not.  Because the problem arises during tagging, where our input is typically a CONLL file and we are using a dict based vectorizer, which has access to all the features including the surface terms.  In this case, we provide a special label dict vectorizer for BPE, as well as a surface version that simply reads and emits the surface and connect both of these to the reader.
+
+#### Writing your own vectorizers
+
+Here are some best practices for writing your own vectorizers
+  - Determine if you only need a single representation of each token (or multiple representations via multiple embeddings).  If you want to use multiple pre-trained word embeddings with the same Vectorizer, this is possible by putting a list of labels in your mead-config for a single embedding.  If you need slightly different transforms of the same token, you should create separate list items defining a Vectorizer/Embedding pair.
+  - Determine if you need to support multiple features per token or aggregate features (for instance `word-POS`. If so consider using a dictionary-style Vectorizer.  This is common for tagger use cases
+  - Do you need to load a model in order to tokenize?  This is common for BPE and WordPiece.  If you are just using one of those, you can use our existing BPE or WordPiece vectorizers.  If not, you should load your vocab in the constructor
+
+#### Embeddings API
+
+TODO: update after this converges
+
+#### How MEAD calls Embeddings and Vectorizers
+
+Embeddings and Vectorizers are exposed to MEAD via `register_embeddings()` and `register_vectorizer()` respectively.  If you have your own object that you are providing and you wish for MEAD to call it, you should register your objects.
+
+The core library provides a function to load embeddings `load_embeddings(name, **kwargs)`.  This function expects a previously loaded global registry of embeddings (named `MEAD_LAYERS_EMBEDDINGS`) with string keys and class values.
+
+If your mead config specifies a `module` in its `embedding` section, this module will be dynamically added into the program (first it will be downloaded if the reference is  a URL) and will also be added dynamically to the `MEAD_LAYER_EMBEDDINGS` registry, making it immediately available to the function.
+
+
+### Referring to your own Embeddings and Vectorizers
+
+TODO:
+
+### Calling objects from code
+
+TODO:

--- a/docs/tagging.md
+++ b/docs/tagging.md
@@ -128,7 +128,7 @@ There is a base interface `TaggerModel` defined for taggers inside of baseline/m
 
 The `TaggerModelBase` provides fulfills the `create()` function required in the base interface (`TaggerModel`) but leaves an abstract method for creation of the layers: `create_layers()` and leaves an abstract forward method (`forward()` for PyTorch and `call()` for Keras).
 
-While this interface provides lots of flexibility, its sub-class `TransducerTaggerModel(TaggerModelBase)` provides much more utility and structure to tagging and as typically the best place to extend from when writing your own tagger.
+While this interface provides lots of flexibility, its sub-class `AbstractEncoderTaggerModel(TaggerModelBase)` provides much more utility and structure to tagging and as typically the best place to extend from when writing your own tagger.
 
 The `TaggerModelBase` follows a single basic pattern for modeling tagging consisting for 4 basic steps:
 
@@ -157,7 +157,7 @@ For fine-tuning a language model like BERT, the typical approach is to remove th
 - Do not override the `create()` from the base class unless absolutely necessary.  `create_layers()` is the typical extension point for the `TaggerModelBase`
 - Use the mead layers (8 mile) API to define your layers
   - This will minimize any incompatibility and make it easy to switch frameworks later
-- Use `TransducerTaggerModel` for simple models involving overriding the `init_encode()` method.  If you can do this, avoid overidding `create_layers()`
+- Use `AbstractEncoderTaggerModel` for simple models involving overriding the `init_encode()` method.  If you can do this, avoid overidding `create_layers()`
 
 ### Some Notes on the TensorFlow implementation
 

--- a/docs/tagging.md
+++ b/docs/tagging.md
@@ -130,11 +130,12 @@ The `TaggerModelBase` provides fulfills the `create()` function required in the 
 
 While this interface provides lots of flexibility, its sub-class `TransducerTaggerModel(TaggerModelBase)` provides much more utility and structure to tagging and as typically the best place to extend from when writing your own tagger.
 
-The `TaggerModelBase` follows a single basic pattern for modeling tagging consisting for 3 basic steps:
+The `TaggerModelBase` follows a single basic pattern for modeling tagging consisting for 4 basic steps:
 
 1. embeddings
 2. encoder (transduction and projection to final number of labels)
-3. decoder (typically a constrained greedy decoder or a CRF)
+3. projection to logits space (the number of labels)
+4. decoder (typically a constrained greedy decoder or a CRF)
 
 All of the MEAD-Baseline tagger models reuse steps 1. and 3. and define their own encoders by overriding the `init_encode()` method.  These hooks are called from the concrete implementation of `create_layers()`, and the forward method is implemented by a simple flow that executes these layers.
 
@@ -142,7 +143,8 @@ Most taggers can be composed together by providing the encoder layer and wiring 
 
 1. embeddings via concatenation of `LookupTableEmbeddingsModel` and `CharConvEmbeddingsModel`
 2. encoder via `RNNTaggerModel`
-3. decoder via `CRF`
+3. default linear projection
+4. decoder via `CRF`
 
 For fine-tuning a language model like BERT, the typical approach is to remove the head from the model (AKA the final linear projection out to the vocab and the normalizing softmax), and to put a final linear projection to the output number of classes in its place.  In MEAD-Baseline, the headless LM would be lodaded as an embedding object and passed into an `EmbeddingsStack` so the encoder itself should be pass through.
 

--- a/layers/eight_mile/pytorch/layers.py
+++ b/layers/eight_mile/pytorch/layers.py
@@ -1616,6 +1616,7 @@ class EmbeddingsStack(nn.Module):
     def output_dim(self):
         return self.dsz
 
+
 class DenseStack(nn.Module):
     """A stack of one or more hidden layers
     """

--- a/layers/eight_mile/tf/layers.py
+++ b/layers/eight_mile/tf/layers.py
@@ -232,6 +232,16 @@ class ConvEncoderStack(tf.keras.layers.Layer):
         return x
 
 
+class PassThru(tf.keras.layers.Layer):
+
+    def __init__(self, input_dim):
+        super().__init__()
+        self.output_dim = input_dim
+
+    def call(self, inputs: tf.Tensor) -> tf.Tensor:
+        return inputs
+
+
 # Mapped
 class ParallelConv(tf.keras.layers.Layer):
     DUMMY_AXIS = 1

--- a/mead/config/conll-no-crf.json
+++ b/mead/config/conll-no-crf.json
@@ -54,7 +54,7 @@
     "dropout": 0.5,
     "rnntype": "blstm",
     "layers": 1,
-    "constrain_decode": true,
+    "constrain_decode": true, 
     "crf": 0 
   },
   "train": {

--- a/mead/config/conll-no-crf.json
+++ b/mead/config/conll-no-crf.json
@@ -54,7 +54,7 @@
     "dropout": 0.5,
     "rnntype": "blstm",
     "layers": 1,
-    "constrain_decode": true, 
+    "constrain_decode": true,
     "crf": 0 
   },
   "train": {

--- a/mead/config/trec-bert-finetune-pytorch-eh.json
+++ b/mead/config/trec-bert-finetune-pytorch-eh.json
@@ -2,16 +2,14 @@
   "task": "classify",
   "basedir": "./trec-bert",
   "batchsz": 10,
-  "modules": ["hub:v1:addons:embed_bert_pytorch"],
   "features": [
     {
       "name": "bert",
       "vectorizer": {
-        "type": "wordpiece1d",
-        "embed_file": "bert-base-uncased"
+        "label": "bert-base-uncased"
       },
       "embeddings": {
-	"label": "bert-base-uncased-pooled-pytorch"
+	    "label": "bert-base-uncased-pooled-pytorch"
       }
     }
   ],


### PR DESCRIPTION
make same classify interface between PyTorch/TF

also I updated the comments and added documentation
on the MEAD-Baseline classify architecture to
docs/classify.md

normalize and unify the implementations TF/PyTorch

Tagger ABC follows same flow as Classifier ABCs

update docs on vectorizers

more docs