### PR TITLE
fix for #493

### DIFF
--- a/addons/pool_embed.py
+++ b/addons/pool_embed.py
@@ -100,5 +100,5 @@ class MeanBoWEmbeddingsModel(TensorFlowEmbeddingsModel):
 
     @classmethod
     def create_placeholder(cls, name):
-        return tf.comat.v1.placeholder(tf.int32, [None, None, None], name=name)
+        return tf.compat.v1.placeholder(tf.int32, [None, None, None], name=name)
 

--- a/baseline/tf/lm/training/utils.py
+++ b/baseline/tf/lm/training/utils.py
@@ -96,7 +96,7 @@ class LanguageModelTrainerTf(Trainer):
         self.sess = self.model.sess
         self.loss = self.model.create_loss()
         self.test_loss = self.model.create_test_loss()
-        self.global_step, self.train_op = optimizer(self.loss, **kwargs)
+        self.global_step, self.train_op = optimizer(self.loss, colocate_gradients_with_ops=True, variables=self.model.trainable_variables, **kwargs)
         self.nsteps = kwargs.get('nsteps', 500)
         init = tf.compat.v1.global_variables_initializer()
         self.model.sess.run(init)

--- a/baseline/tf/seq2seq/model.py
+++ b/baseline/tf/seq2seq/model.py
@@ -53,7 +53,10 @@ def _temporal_cross_entropy_loss(logits, labels, label_lengths, mx_seq_length):
         return losses
 
 if not tf.executing_eagerly():
-    class EncoderDecoderModelBase(EncoderDecoderModel):
+    class EncoderDecoderModelBase(EncoderDecoderModel, tf.keras.Model):
+
+        def __init__(self, name=None):
+            super().__init__(name=name)
 
         def create_loss(self):
             with tf.variable_scope('loss'):
@@ -159,7 +162,7 @@ if not tf.executing_eagerly():
             model.sess = kwargs.get('sess', create_session())
             model.pdrop_value = kwargs.get('dropout', 0.5)
             model.dropin_value = kwargs.get('dropin', {})
-            model.layers = kwargs.get('layers', 1)
+            model.num_layers = kwargs.get('layers', 1)
             model.hsz = kwargs['hsz']
 
             embed_in = model.embed(**kwargs)

--- a/baseline/tf/seq2seq/training/utils.py
+++ b/baseline/tf/seq2seq/training/utils.py
@@ -94,7 +94,7 @@ class Seq2SeqTrainerTf(Trainer):
         self.test_loss = self.model.create_test_loss()
         self.tgt_rlut = kwargs['tgt_rlut']
         self.base_dir = kwargs['basedir']
-        self.global_step, self.train_op = optimizer(self.loss, colocate_gradients_with_ops=True, **kwargs)
+        self.global_step, self.train_op = optimizer(self.loss, colocate_gradients_with_ops=True, variables=self.model.trainable_variables, **kwargs)
         self.nsteps = kwargs.get('nsteps', 500)
         self.beam = kwargs.get('beam', 10)
         tables = tf.compat.v1.tables_initializer()

--- a/baseline/tf/tagger/training/utils.py
+++ b/baseline/tf/tagger/training/utils.py
@@ -193,7 +193,7 @@ class TaggerTrainerTf(EpochReportingTrainer):
         span_type = kwargs.get('span_type', 'iob')
         verbose = kwargs.get('verbose', False)
         self.evaluator = TaggerEvaluatorTf(self.model, span_type, verbose)
-        self.global_step, self.train_op = optimizer(self.loss, **kwargs)
+        self.global_step, self.train_op = optimizer(self.loss, colocate_gradients_with_ops=True, variables=self.model.trainable_variables, **kwargs)
         self.nsteps = kwargs.get('nsteps', six.MAXSIZE)
         tables = tf.compat.v1.tables_initializer()
         self.model.sess.run(tables)


### PR DESCRIPTION
closes #493 

We werent properly overriding a Keras Model for the encoder-decoder, so it
had no `model.trainable_variables`.  I changed this and it worked.
 
The only weird thing is that we were setting a `.layer` property on the class for the number of s2s layers.  I renamed this to `.num_layers`.