### PR TITLE
allow sub-layer hooks a name override. closes #547

### DIFF
--- a/baseline/pytorch/classify/model.py
+++ b/baseline/pytorch/classify/model.py
@@ -165,13 +165,19 @@ class EmbedPoolStackClassifier(ClassifierModelBase):
 
     def init_embed(self, embeddings: Dict[str, TensorDef], **kwargs) -> BaseLayer:
         """This method creates the "embedding" layer of the inputs, with an optional reduction
+
+        :param embeddings: A dictionary of embeddings
+
         :Keyword Arguments: See below
         * *embeddings_reduction* (defaults to `concat`) An operator to perform on a stack of embeddings
+        * *embeddings_dropout = float(kwargs.get('embeddings_dropout', 0.0))
 
         :return: The output of the embedding stack followed by its reduction.  This will typically be an output
           with an additional dimension which is the hidden representation of the input
         """
-        return EmbeddingsStack(embeddings, reduction=kwargs.get('embeddings_reduction', 'concat'))
+        reduction = kwargs.get('embeddings_reduction', 'concat')
+        embeddings_dropout = float(kwargs.get('embeddings_dropout', 0.0))
+        return EmbeddingsStack(embeddings, embeddings_dropout, reduction=reduction)
 
     def init_pool(self, input_dim: int, **kwargs) -> BaseLayer:
         """Produce a pooling operation that will be used in the model
@@ -326,11 +332,14 @@ class FineTuneModelClassifier(ClassifierModelBase):
 
         :Keyword Arguments: See below
         * *embeddings_reduction* (defaults to `concat`) An operator to perform on a stack of embeddings
+        * *embeddings_dropout = float(kwargs.get('embeddings_dropout', 0.0))
 
         :return: The output of the embedding stack followed by its reduction.  This will typically be an output
           with an additional dimension which is the hidden representation of the input
         """
-        return EmbeddingsStack(embeddings, reduction=kwargs.get('embeddings_reduction', 'concat'))
+        reduction = kwargs.get('embeddings_reduction', 'concat')
+        embeddings_dropout = float(kwargs.get('embeddings_dropout', 0.0))
+        return EmbeddingsStack(embeddings, embeddings_dropout, reduction=reduction)
 
     def init_stacked(self, input_dim: int, **kwargs) -> BaseLayer:
         """Produce a stacking operation that will be used in the model

--- a/mead/config/trec-bert-finetune-tf-eh.json
+++ b/mead/config/trec-bert-finetune-tf-eh.json
@@ -6,7 +6,8 @@
     {
       "name": "bert",
       "vectorizer": {
-	  "label": "bert-base-uncased-tf"
+	  "label": "bert-base-uncased",
+        "dtype": "int32"
       },
       "embeddings": {
 	  "label": "bert-base-uncased-pooled-tf"
@@ -27,7 +28,7 @@
   },
   "train": {
     "epochs": 5,
-    "optim": "adamw",
+    "optim": "adam",
     "eta":  0.00001,
     "weight_decay": 1.0e-8,
     "early_stopping_metric": "acc",

--- a/mead/tasks.py
+++ b/mead/tasks.py
@@ -428,6 +428,8 @@ class Task(object):
                     except Exception as e:
                         if is_stacked:
                             raise e
+                        logger.warning(f"We were not able to download {embed_file}, passing to the addon")
+                        embed_files.append(embed_file)
                 # If we have stacked embeddings (which only works with `default` model, we need to pass the list
                 # If not, grab the first item
                 embed_file = embed_files if is_stacked else embed_files[0]


### PR DESCRIPTION
In some cases we would like to be able to override the Keras layer name behavior for sub-modules.
The sub-class implementations of `TaggerModelBase` and `ClassifierModelBase` give us `init_*()` methods that create the sub-layer objects for us, but up until this change there wasnt any way to
override the name scope without actually reimplementing the method which is not convenient.

The solution proposed here is for each method, provide an optional keyword argument that can be overriden either by mead configuration (from the model block) or by overriding the `create_layers` method to inject this name if known in code.

*Classifier Layer Name Overrides*

- `init_embed` -> `embeddings_name` (injects name into `EmbeddingsStack`)
- `init_stacked` -> `stacked_name` (injects name into `DenseStack`)
- `init_output` -> `output_name` (injects name into `tf.keras.layers.Dense`)
- `init_pool` -> `pool_name` (injects name into whatever the sub-class pool Keras layer is defined as)

*Tagger Layer Name Overrides*

- `init_embed` -> `embeddings_name` (injects name into `EmbeddingsStack`)
- `init_encode` -> `encode_name`  (injects name into whatever the sub-class pool Keras layer is defined as)
- `init_proj` -> `proj_name` (injects name into `tf.keras.layers.Dense`)
- `init_decode` -> `decode_name` (injects name into `GreedyTaggerDecoder` or `CRF` in base impl.)

Also changes the Classifier `init_embed` in both PyTorch and TF to accept an optional `embeddings_dropout` which defaults to 0 that can be passed in.  The tagger currently uses the default pdrop for this, although perhaps that should change as well to `embeddings_dropout` 2with maybe a default of 0.5 in that case