### PR TITLE
fix: give the eight_mile.tf.EmbeddingStack class a `.keys()` method

### DIFF
--- a/layers/eight_mile/tf/layers.py
+++ b/layers/eight_mile/tf/layers.py
@@ -1791,6 +1791,9 @@ class EmbeddingsStack(tf.keras.layers.Layer):
     #        total_dsz += embeddings.get_dsz()
     #    return total_dsz
 
+    def keys(self):
+        return self.embeddings.keys()
+
     @property
     def requires_length(self) -> bool:
         return self._requires_length


### PR DESCRIPTION
In the old layout of models we had a attribute called embeddings which
was a dict that mapped embeddings names to the embedding obejcts. This
mapping was then used in `make_input` to know what to pull out of the
batch_dict. In the refactor this embedding dict was overwritten with an
EmbeddingStack layer. The Tensorflow version didn't have a `.keys()`
method so when make input was called we didn't know what input keys to
grab. This wasn't found because make_input wasn't being called when the
default tf.dataset was use. It is used when you reload though so a model
trained with tf.datasets would fail on reload. This PR addes a .keys()
method to the EmbeddingStack like the pytorch version has.

One consideration is that we are assuming that the output of the
`init_embed` method is something with a `.keys()` method. This is
normally true because we always return an EmbeddingStack but it seems
like it would cause problems if they don't want to use our
EmbeddingStack object.