### PR TITLE
chore: make eager debugging easier to use

### DIFF
--- a/layers/eight_mile/tf/layers.py
+++ b/layers/eight_mile/tf/layers.py
@@ -27,6 +27,13 @@ def set_tf_eager_mode(prefer_eager: bool = False):
         LOGGER.info('User requesting eager disabled on 2.x')
         tf.compat.v1.disable_eager_execution()
 
+
+def set_tf_eager_debug(debug: bool = False):
+    if tf.executing_eagerly():
+        if debug:
+            tf.config.experimental_run_functions_eagerly(debug)
+
+
 def set_tf_log_level(ll):
     # 0     | DEBUG            | [Default] Print all messages
     # 1     | INFO             | Filter out INFO messages

--- a/mead/tasks.py
+++ b/mead/tasks.py
@@ -21,6 +21,7 @@ from baseline.utils import (
     DataDownloader,
     show_examples,
     normalize_backend,
+    str2bool,
 )
 
 from mead.utils import (
@@ -68,9 +69,10 @@ class Backend(object):
     def load(self, task_name=None):
         if self.name == 'tf':
             prefer_eager = self.params.get('prefer_eager', False)
-            from eight_mile.tf.layers import set_tf_eager_mode, set_tf_log_level
+            from eight_mile.tf.layers import set_tf_eager_mode, set_tf_log_level, set_tf_eager_debug
             set_tf_eager_mode(prefer_eager)
             set_tf_log_level(os.getenv("MEAD_TF_LOG_LEVEL", "ERROR"))
+            set_tf_eager_debug(str2bool(os.getenv("MEAD_TF_EAGER_DEBUG", "FALSE")))
 
         base_pkg_name = 'baseline.{}'.format(self.name)
         # Backends may not be downloaded to the cache, they must exist locally


### PR DESCRIPTION
With the addition of `tf.function`s and the like in mead (which was def
worth it due to speed ups) it makes eager debugging harder to use. When
something is decorated with a `tf.function` the code will be compiled
into a graph by tensorflow. This allows for faster execution but makes
step-by-step debugging harder (They even issue an error when they detect
a call to `pdb.set_trace()` in your code).

This PR introduces a new function to `eight_mile.tf.layers` that will
disable the compilation of `tf.function`s. This is trigger-able with an
env variable `MEAD_TF_EAGER_DEGUB`. Setting this to a truthy value (as
parsed by `str2bool`) will make debugging easier by keeping the
functions in eager mode which lets you inspect the values directly in
your debugger