### PR TITLE
chore: default batchsz to be in train section

### DIFF
--- a/mead/tasks.py
+++ b/mead/tasks.py
@@ -528,8 +528,8 @@ class ClassifierTask(Task):
 
     def _reorganize_params(self):
         train_params = self.config_params['train']
-        train_params['batchsz'] = self.config_params['batchsz']
-        train_params['test_batchsz'] = self.config_params.get('test_batchsz', 1)
+        train_params['batchsz'] = train_params['batchsz'] if 'batchsz' in train_params else self.config_params['batchsz']
+        train_params['test_batchsz'] = train_params.get('test_batchsz', self.config_params.get('test_batchsz', 1))
         unif = self.config_params.get('unif', 0.1)
         model = self.config_params['model']
         model['unif'] = model.get('unif', unif)
@@ -610,7 +610,7 @@ class TaggerTask(Task):
 
     def _reorganize_params(self):
         train_params = self.config_params['train']
-        train_params['batchsz'] = train_params.get('batchsz', self.config_params.get('batchsz'))
+        train_params['batchsz'] = train_params['batchsz'] if 'batchsz' in train_params else self.config_params['batchsz']
         train_params['test_batchsz'] = train_params.get('test_batchsz', self.config_params.get('test_batchsz', 1))
         labels = self.reader.label2index
         span_type = self.config_params['train'].get('span_type')
@@ -774,9 +774,8 @@ class EncoderDecoderTask(Task):
 
     def _reorganize_params(self):
         train_params = self.config_params['train']
-        train_params['batchsz'] = train_params.get('batchsz', self.config_params.get('batchsz'))
-        train_params['test_batchsz'] = train_params.get('test_batchsz',
-                                                        self.config_params.get('test_batchsz', 1))
+        train_params['batchsz'] = train_params['batchsz'] if 'batchsz' in train_params else self.config_params['batchsz']
+        train_params['test_batchsz'] = train_params.get('test_batchsz', self.config_params.get('test_batchsz', 1))
 
         self.config_params['model']["unif"] = self.config_params["unif"]
         model = self.config_params['model']
@@ -894,7 +893,7 @@ class LanguageModelingTask(Task):
 
         train_params = self.config_params['train']
         train_params['batchsz'] = train_params['batchsz'] if 'batchsz' in train_params else self.config_params['batchsz']
-        train_params['test_batchsz'] = self.config_params.get('test_batchsz', 1)
+        train_params['test_batchsz'] = train_params.get('test_batchsz', self.config_params.get('test_batchsz', 1))
         model = self.config_params['model']
         unif = self.config_params.get('unif', 0.1)
         model['unif'] = model.get('unif', unif)


### PR DESCRIPTION
This PR updates the various slightly divergent implementations of
`._reorganize_params()` Some allowed the batch size to be in the train
section some didn't. Some were looking in the main params for the test
batch size, some weren't.

This PR makes it so that a `batchsz` key in the train section will
be used first with a back off to the `batchsz` key in the whole params.
If no `batchsz` is specified at all then a KeyError is thrown.

This PR makes it so that a `test_batchsz` in the train section will be
used first with a back off to a `test_batchsz` key in the main parameter
section. If neither of these are defined a size of `1` is used.