### PR TITLE
WIP: chore: added posterior decoding and updating the tagger decoder API, add tests

### DIFF
--- a/baseline/pytorch/tagger/model.py
+++ b/baseline/pytorch/tagger/model.py
@@ -50,6 +50,7 @@ class TaggerModelBase(nn.Module, TaggerModel):
         model.gpu = False if device == 'cpu' else model.gpu
         return model
 
+
     def drop_inputs(self, key, x):
         """Do dropout on inputs, using the dropout value (or none if not set)
         This works by applying a dropout mask with the probability given by a
@@ -268,12 +269,19 @@ class AbstractEncoderTaggerModel(TaggerModelBase):
         if use_crf:
             decoder = CRF(len(self.labels), constraint_mask=constraint_mask, batch_first=True)
         else:
-            decoder = TaggerGreedyDecoder(
-                len(self.labels),
-                constraint_mask=constraint_mask,
-                batch_first=True,
-                reduction=kwargs.get('reduction', 'batch')
-            )
+            if constraint_mask is not None:
+                decoder = ConstrainedGreedyTaggerDecoder(
+                    len(self.labels),
+                    batch_first=True,
+                    constraint_mask=constraint_mask,
+                    reduction=kwargs.get('reduction', 'batch')
+                )
+            else:
+                decoder = GreedyTaggerDecoder(
+                    len(self.labels),
+                    batch_first=True,
+                    reduction=kwargs.get('reduction', 'batch')
+                )
         return decoder
 
     def create_layers(self, embeddings: Dict[str, TensorDef], **kwargs):

--- a/baseline/tf/tagger/model.py
+++ b/baseline/tf/tagger/model.py
@@ -435,7 +435,10 @@ class AbstractEncoderTaggerModel(TaggerModelBase):
         name = kwargs.get('decode_name')
         if self.crf:
             return CRF(len(self.labels), self.constraint_mask, name=name)
-        return TaggerGreedyDecoder(len(self.labels), self.constraint_mask, name=name)
+        if self.constraint_mask is None:
+            return GreedyTaggerDecoder(len(self.labels), name=name)
+        else:
+            return ConstrainedGreedyTaggerDecoder(len(self.labels), self.constraint_mask, name=name)
 
     def transduce(self, inputs: Dict[str, TensorDef]) -> TensorDef:
         """This operation performs embedding of the input, followed by encoding and projection to logits

--- a/layers/eight_mile/pytorch/layers.py
+++ b/layers/eight_mile/pytorch/layers.py
@@ -2138,140 +2138,220 @@ def ident(x):
     return x
 
 
-class TaggerGreedyDecoder(nn.Module):
+class TaggerDecoder(nn.Module):
+    def __init__(self, num_tags: int, batch_first: bool = True, **kwargs):
+        """Assign a tag to each token in a sequence."""
+        super().__init__()
+        self.num_tags = num_tags
+        self.batch_first = batch_first
+
+    def extra_repr(self) -> str:
+        return f"num_tags={self.num_tags}, batch_first={self.batch_first}"
+
+    def neg_log_loss(self, unary: torch.Tensor, tags: torch.Tensor, lengths: torch.Tensor) -> torch.Tensor:
+        """Calculate the loss associated with this decoder.
+
+        :param unary: [B, T, C] The score distribution over tags for each timestep.
+        :param tags: [B, T] The gold tag for each token.
+        :param lengths: [B] The length of each element in the batch.
+
+        :returns: [] The average loss over the batch
+        """
+
+    def score_sentence(self, unary: torch.Tensor, tags: torch.Tensor, lengths: torch.Tensor) -> torch.Tensor:
+        """Calculate the score the model gives a sequence of tags.
+
+        :param unary: [B, T, C] The score distribution over tags for each timestep.
+        :param tags: [B, T] The sequence of tags we are scoring.
+        :param lengths: [B] The length of each example.
+
+        :returns: [B] The score for each example in the batch
+        """
+
+    def posterior(self, unary: torch.Tensor, lengths: torch.Tensor) -> torch.Tensor:
+        """Calculate score distributions over tags for each timesteps.
+
+        :param unary: [B, T, C] The score distribution over tags for each timestep.
+        :param lengths: [B] The length of each example.
+
+        :returns: [B, T, C] The score distribution over tags for each timestep.
+        """
+        return unary
+
+    def decode(self, unary: torch.Tensor, lengths: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Return the best scoring sequence of tags.
+
+        :param unary: [B, T, C] The score distribution over tags for each timestep.
+        :param lengths: [B] The length of each example.
+
+        :returns: [B, T] The best scoring tag sequences.
+        """
+
+    def forward(self, inputs: Tuple[torch.Tensor]) -> torch.Tensor:
+        pass
+
+
+class GreedyTaggerDecoder(TaggerDecoder):
+    def __init__(self, num_tags: int, batch_first: bool = True, reduction: str = "batch"):
+        """Assign a tag to each token in a sequence independent of the decisions made for other tokens."""
+        super().__init__(num_tags, batch_first)
+        self.to_batch_first = ident if batch_first else tbh2bth
+        self.to_time_first = bth2tbh if batch_first else ident
+        self.loss = SequenceLoss(LossFn=nn.CrossEntropyLoss, avg=reduction)
+
+    def neg_log_loss(self, unary: torch.Tensor, tags: torch.Tensor, lengths: torch.Tensor) -> torch.Tensor:
+        """Calculate the loss for these gold tags.
+
+        :param unary: [B, T, C] The score distribution over tags for each timestep.
+        :param tags: [B, T] The gold tag for each token.
+        :param lengths: [B] The length of each element in the batch.
+
+        :returns: [] The average loss over the batch
+        """
+        unary = self.to_batch_first(unary)
+        tags = self.to_batch_first(tags)
+        return self.loss(unary, tags)
+
+    def score_sentence(self, unary: torch.Tensor, tags: torch.Tensor, lengths: torch.Tensor) -> torch.Tensor:
+        """Calculate the score the model gives a sequence of tags.
+
+        :param unary: [B, T, C] The score distribution over tags for each timestep.
+        :param tags: [B, T] The sequence of tags we are scoring.
+        :param lengths: [B] The length of each example.
+
+        :returns: [B] The score for each example in the batch
+        """
+        unary = self.to_time_first(unary)
+        tags = self.to_time_first(tags)
+        mask = sequence_mask(lengths).transpose(0, 1).to(tags.device)
+        scores = unary.gather(2, tags[1:].unsqueeze(-1)).squeeze(-1)
+        scores = scores.masked_fill(mask == MASK_FALSE, 0)
+        scores = scores.sum(0)
+        return scores
+
+    def decode(self, unary: torch.Tensor, lengths: torch.Tensor) -> Tuple[torch.Tensor]:
+        """Return the best scoring sequence of tags.
+
+        Note:
+            This is done with independent argmaxes at each timestep. This is a local model
+            and the decisions made for one tag do not effect others.
+
+        :param unary: [B, T, C] The score distribution over tags for each timestep.
+        :param lengths: [B] The length of each example.
+
+        :returns: [B, T] The best scoring tag sequences.
+        """
+        # Decoding doesn't care about batch/time first
+        scores, preds = torch.max(unary, -1)
+        mask = sequence_mask(lengths, unary.shape[1]).to(preds.device)
+        # The mask gets generated as batch first
+        mask = mask if self.batch_first else mask.transpose(0, 1)
+        preds = preds.masked_fill(mask == MASK_FALSE, 0)
+        scores = scores.masked_fill(mask == MASK_FALSE, 0)
+        scores = torch.sum(scores, dim=1 if self.batch_first else 0)
+        return preds, scores
+
+    def forward(self, inputs: Tuple[torch.Tensor]) -> torch.Tensor:
+        unary, lengths = tensor_and_lengths(inputs)
+        return self.decode(unary, lengths)[0]
+
+
+
+class StructuredTaggerDecoder(TaggerDecoder):
+        """Assign a tag to each token in a sequence conditioned of the decisions made for other tokens."""
+
+        def partition(self, unary: torch.Tensor, lengths: torch.Tensor) -> torch.Tensor:
+            """Calculate Z the partition function (normalization factor) for all possible paths.
+
+            :param unary: [B, T, C] The score distribution over tags for each timestep.
+            :param lengths: [B] The length of each example.
+
+            :returns: [B] The sequence normalization number for each element in the path.
+            """
+            raise NotImplementedError
+
+        def partition_over_time(self, unary: torch.Tensor, lengths: torch.Tensor) -> torch.Tensor:
+            """Calculate the partition function Z up to some point in time for each point in time.
+
+            :param unary: [B, T, C] The score distribution over tags for each timestep.
+            :param lengths: [B] The length of each example.
+
+            :returns: [B, T, C] The partition scores at time `t` for each class `c`. This represents the score of being at some state (t, c) considering all paths that get there.
+            """
+            raise NotImplementedError
+
+        def partition_backward_over_time(self, unary: torch.Tensor, lengths: torch.Tensor) -> torch.Tensor:
+            """Calculate the partition function Z up to some point in time for each point in time start from the end and moving towards the front.
+
+            :param unary: [B, T, C] The score distribution over tags for each timestep.
+            :param lengths: [B] The length of each example.
+
+            :returns: [B, T, C] The partition scores at time `t` for each class `c`. This represents the score of being at some state (t, c) considering all paths that get there.
+            """
+            raise NotImplementedError
+
+        def posterior_decode(self, unary: torch.Tensor, lengths: torch.Tensor) -> torch.Tensor:
+            """Decode the best tag sequence by selecting the most probable tag at each timestep.
+
+            :param unary: [B, T, C] The score distribution over tags for each timestep.
+            :param lengths: [B] The length of each example.
+
+            :returns: [B, T] The tag sequence created by doing an argmax over the posterior probability over tags for each timestep independently.
+            """
+            raise NotImplementedError
+
+
+class ConstrainedGreedyTaggerDecoder(StructuredTaggerDecoder, GreedyTaggerDecoder):
     def __init__(
         self,
         num_tags: int,
-        constraint_mask: Optional[torch.Tensor] = None,
+        constraint_mask: torch.Tensor,
+        idxs: Tuple[int, int] = (Offsets.GO, Offsets.EOS),
         batch_first: bool = True,
         reduction: str = "batch",
     ):
-        """A Greedy decoder and loss module for taggers.
+        """Assign tags to a sequence using locally normalized distributions over possible tags but use
+           heuristically created transition scores to avoid illegal moves.
 
-        :param num_tags: `int` The number of output classes
-        :param constraint_mask: `Tensor[1, N, N]` A mask with valid transitions as 1 and invalid as 0
-        :param batch_first: `bool` Should the batch dimensions be first?
-        :param reduction: `str` Should the loss be calculated at the token level or batch level
+        :param num_tags: The number of possible tags.
+        :param constraint_mask: A [1, num_tags, num_tags] tensor where a 1 at (tgt, src) indicates an illegal
+            transition from src tag to tgt tag.
+        :param batch_first: Are the unaries coming in a [B, T, C] (True) or [T, B, C] (False)?
+        :param reduction: How the reduction over the sequence happen in the loss, use `token` to
+            average the loss or `batch` to sum
         """
-        super().__init__()
-        self.num_tags = num_tags
-
-        if constraint_mask is not None:
-            constraint_mask = F.log_softmax(
-                torch.zeros(constraint_mask.shape).masked_fill(constraint_mask, -1e4), dim=1
-            )
-            self.register_buffer("constraint_mask", constraint_mask)
-        else:
-            self.constraint_mask = None
-        # FIXME: we cant do it like this if using TorchScript
-        self.to_batch_first = ident if batch_first else tbh2bth
-        self.to_time_first = bth2tbh if batch_first else ident
-        self.batch_first = batch_first
-        self.loss = SequenceLoss(LossFn=nn.CrossEntropyLoss, avg=reduction)
-        self.viterbi = ViterbiLogSoftmaxNorm(Offsets.GO, Offsets.EOS)
+        super().__init__(num_tags, batch_first, reduction)
+        constraint_mask = F.log_softmax(torch.zeros(*constraint_mask.shape, dtype=torch.float, device=constraint_mask.device).masked_fill(constraint_mask, -1e4), dim=1)
+        self.register_buffer("constraint_mask", constraint_mask)
+        self.start_idx, self.end_idx = idxs
+        self.viterbi = ViterbiLogSoftmaxNorm(self.start_idx, self.end_idx)
 
     @property
     def transitions(self):
         return self.constraint_mask
 
-    def neg_log_loss(self, inputs, tags, lengths):
-        unaries = self.to_batch_first(inputs)
-        tags = self.to_batch_first(tags)
-        return self.loss(unaries, tags)
-
-    def forward(self, inputs) -> torch.Tensor:
-        unaries, lengths = tensor_and_lengths(inputs)
-        # If there is a constraint mask do a masked viterbi
-        if self.constraint_mask is not None:
-            probv = self.to_time_first(unaries)
-            probv = F.log_softmax(probv, dim=-1)
-            preds, scores = self.viterbi(probv, self.constraint_mask, lengths)
-            if self.batch_first:
-                return tbh2bth(preds)  # , scores
-            else:
-                return preds
-        else:
-            # Decoding doesn't care about batch/time first
-            _, preds = torch.max(unaries, -1)
-            mask = sequence_mask(lengths, unaries.shape[1]).to(preds.device)
-            # The mask gets generated as batch first
-            mask = mask if self.batch_first else mask.transpose(0, 1)
-            preds = preds.masked_fill(mask == MASK_FALSE, 0)
-        return preds  # , None
-
     def extra_repr(self) -> str:
-        str_ = f"n_tags={self.num_tags}, batch_first={self.batch_first}"
-        if self.constraint_mask is not None:
-            str_ += ", constrained=True"
-        return str_
+        return f"{super().extra_repr()}, constrained=True"
 
-
-class CRF(nn.Module):
-    def __init__(
-        self,
-        num_tags: int,
-        constraint_mask: Optional[torch.Tensor] = None,
-        batch_first: bool = True,
-        idxs: Tuple[int, int] = (Offsets.GO, Offsets.EOS),
-    ):
-        """Initialize the object.
-        :param num_tags: int, The number of tags in your output (emission size)
-        :param constraint: torch.ByteTensor, Constraints on the transitions [1, N, N]
-        :param idxs: Tuple(int. int), The index of the start and stop symbol
-            in emissions.
-        :param batch_first: bool, if the input [B, T, ...] or [T, B, ...]
+    def decode(self, unary: torch.Tensor, lengths: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Return the best scoring sequence of tags.
 
         Note:
-            if idxs is none then the CRF adds these symbols to the emission
-            vectors and n_tags is assumed to be the number of output tags.
-            if idxs is not none then the first element is assumed to be the
-            start index and the second idx is assumed to be the end index. In
-            this case n_tags is assumed to include the start and end symbols.
+            This is done with the viterbi algorithms (bigram based) to find the best tags
+            subject to the transition constraints found in the transition mask.
+
+        :param unary: [B, T, C] The score distribution over tags for each timestep.
+        :param lengths: [B] The length of each example.
+
+        :returns: [B, T] The best scoring tag sequences.
         """
-        super().__init__()
-        self.start_idx, self.end_idx = idxs
-        self.num_tags = num_tags
-        if constraint_mask is not None:
-            self.register_buffer("constraint_mask", constraint_mask)
-        else:
-            self.constraint_mask = None
-
-        self.transitions_p = nn.Parameter(torch.Tensor(1, self.num_tags, self.num_tags).zero_())
-        self.batch_first = batch_first
-        self.viterbi = Viterbi(self.start_idx, self.end_idx)
-
-    def extra_repr(self) -> str:
-        str_ = "n_tags=%d, batch_first=%s" % (self.num_tags, self.batch_first)
-        if self.constraint_mask is not None:
-            str_ += ", constrained=True"
-        return str_
-
-    @property
-    def transitions(self):
-        if self.constraint_mask is not None:
-            return self.transitions_p.masked_fill(self.constraint_mask, -1e4)
-        return self.transitions_p
-
-    def neg_log_loss(self, unary, tags, lengths):
-        """Neg Log Loss with a Batched CRF.
-
-        :param unary: torch.FloatTensor: [T, B, N] or [B, T, N]
-        :param tags: torch.LongTensor: [T, B] or [B, T]
-        :param lengths: torch.LongTensor: [B]
-
-        :return: torch.FloatTensor: [B]
-        """
-        # Convert from [B, T, N] -> [T, B, N]
+        probv = self.to_time_first(unary)
+        probv = F.log_softmax(probv, dim=-1)
+        preds, scores = self.viterbi(probv, self.transitions, lengths)
         if self.batch_first:
-            unary = unary.transpose(0, 1)
-            tags = tags.transpose(0, 1)
-        _, batch_size, _ = unary.size()
-        fwd_score = self._forward_alg(unary, lengths)
-        gold_score = self.score_sentence(unary, tags, lengths)
-
-        loss = fwd_score - gold_score
-        batch_loss = torch.mean(loss)
-        return batch_loss
+            return tbh2bth(preds), scores
+        else:
+            return preds, scores
 
     def score_sentence(self, unary: torch.Tensor, tags: torch.Tensor, lengths: torch.Tensor) -> torch.Tensor:
         """Score a batch of sentences.
@@ -2279,7 +2359,6 @@ class CRF(nn.Module):
         :param unary: torch.FloatTensor: [T, B, N]
         :param tags: torch.LongTensor: [T, B]
         :param lengths: torch.LongTensor: [B]
-        :param min_length: torch.LongTensor: []
 
         :return: torch.FloatTensor: [B]
         """
@@ -2306,7 +2385,268 @@ class CRF(nn.Module):
         scores = scores + eos_scores
         return scores
 
-    def _forward_alg(self, unary: torch.Tensor, lengths: torch.Tensor) -> torch.Tensor:
+    def partition(self, unary: torch.Tensor, lengths: torch.Tensor) -> torch.Tensor:
+        """Calculate the score for all paths forward on a batch.
+
+        :param unary: torch.FloatTensor: [T, B, N]
+        :param lengths: torch.LongTensor: [B]
+
+        :return: torch.FloatTensor: [B]
+        """
+        # alphas: [B, 1, N]
+        min_length = torch.min(lengths)
+        batch_size = lengths.shape[0]
+        alphas = torch.full((batch_size, 1, self.num_tags), -1e4, device=unary.device)
+        alphas[:, 0, self.start_idx] = 0.0
+
+        trans = self.transitions  # [1, N, N]
+
+        for i, unary_t in enumerate(unary):
+            # unary_t: [B, N]
+            unary_t = unary_t.unsqueeze(2)  # [B, N, 1]
+            # Broadcast alphas along the rows of trans
+            # Broadcast trans along the batch of alphas
+            # [B, 1, N] + [1, N, N] -> [B, N, N]
+            # Broadcast unary_t along the cols of result
+            # [B, N, N] + [B, N, 1] -> [B, N, N]
+            scores = alphas + trans + unary_t
+            new_alphas = torch.sum(scores, 2, keepdim=True).transpose(1, 2)
+            # If we haven't reached your length zero out old alpha and take new one.
+            # If we are past your length, zero out new_alpha and keep old one.
+
+            if i >= min_length:
+                mask = (i < lengths).view(-1, 1, 1)
+                alphas = alphas.masked_fill(mask, 0) + new_alphas.masked_fill(mask == MASK_FALSE, 0)
+            else:
+                alphas = new_alphas
+
+        terminal_vars = alphas + trans[:, self.end_idx]
+        alphas = torch.sum(terminal_vars, 2)
+        return alphas.view(batch_size)
+
+    def partition_over_time(self, unary: torch.Tensor, lengths: torch.Tensor, start: Optional[int] = None) -> torch.Tensor:
+        """Calculate the partition function Z up to some point in time for each point in time.
+
+        :param unary: [B, T, C] The score distribution over tags for each timestep.
+        :param lengths: [B] The length of each example.
+
+        :returns: [B, T, C] The partition scores at time `t` for each class `c`. This represents the score of being at some state (t, c) considering all paths that get there.
+        """
+        # alphas: [B, 1, N]
+        min_length = torch.min(lengths)
+        batch_size = lengths.shape[0]
+        alphas = []
+        alpha = torch.full((batch_size, 1, self.num_tags), -1e4, device=unary.device)
+        alpha[:, 0, start if start is not None else self.start_idx] = 0.0
+
+        trans = self.transitions  # [1, N, N]
+
+        for i, unary_t in enumerate(unary):
+            # unary_t: [B, N]
+            unary_t = unary_t.unsqueeze(2)  # [B, N, 1]
+            # Broadcast alphas along the rows of trans
+            # Broadcast trans along the batch of alphas
+            # [B, 1, N] + [1, N, N] -> [B, N, N]
+            # Broadcast unary_t along the cols of result
+            # [B, N, N] + [B, N, 1] -> [B, N, N]
+            scores = alpha + trans + unary_t
+            new_alpha = torch.sum(scores, 2, keepdim=True).transpose(1, 2)
+            # If we haven't reached your length zero out old alpha and take new one.
+            # If we are past your length, zero out new_alpha and keep old one.
+
+            if i >= min_length:
+                mask = (i < lengths).view(-1, 1, 1)
+                alpha = alpha.masked_fill(mask, 0) + new_alpha.masked_fill(mask == MASK_FALSE, 0)
+            else:
+                alpha = new_alpha
+            alphas.append(alpha)
+
+        alphas = torch.cat(alphas, dim=1)
+        mask = sequence_mask(lengths).to(alphas.device).unsqueeze(-1)
+        alphas = alphas.masked_fill(mask == MASK_FALSE, 0.0)
+        return alphas.transpose(0, 1)
+
+    def partition_backward_over_time(self, unary: torch.Tensor, lengths: torch.Tensor) -> torch.Tensor:
+        """Calculate the partition function Z up to some point in time for each point in time starting from the end and moving towards the start.
+
+        :param unary: [B, T, C] The score distribution over tags for each timestep.
+        :param lengths: [B] The length of each example.
+
+        :returns: [B, T, C] The partition scores at time `t` for each class `c`. This represents the score of being at some state (t, c) considering all paths that get there.
+        """
+        seq_len, batch_size, num_tags = unary.shape
+        rev_lengths = seq_len - lengths - 1
+        alphas = []
+        # alpha: [B, 1, N]
+        alpha = torch.full((batch_size, 1, self.num_tags), -1e4, device=unary.device)
+        alpha[:, 0, self.end_idx] = 0.0
+
+        trans = self.transitions.transpose(1, 2)  # [1, N, N]
+
+        for i, unary_t in enumerate(unary.flip(0)):
+            # unary_t: [B, N]
+            unary_t = unary_t.unsqueeze(2)  # [B, N, 1]
+            # Broadcast alphas along the rows of trans
+            # Broadcast trans along the batch of alphas
+            # [B, 1, N] + [1, N, N] -> [B, N, N]
+            # Broadcast unary_t along the cols of result
+            # [B, N, N] + [B, N, 1] -> [B, N, N]
+            scores = alpha + trans + unary_t
+            new_alpha = torch.sum(scores, 2, keepdim=True).transpose(1, 2)
+            # If we haven't reached your length zero out old alpha and take new one.
+            # If we are past your length, zero out new_alpha and keep old one.
+            mask = (i > rev_lengths).view(-1, 1, 1)
+            alpha = alpha.masked_fill(mask, 0) + new_alpha.masked_fill(mask == MASK_FALSE, 0)
+            alphas.append(alpha)
+
+        alphas = torch.cat(alphas, dim=1).flip(1)
+        mask = sequence_mask(lengths).to(alphas.device).unsqueeze(-1)
+        alphas = alphas.masked_fill(mask == MASK_FALSE, 0.0)
+        return alphas.transpose(0, 1)
+
+    def posterior(self, unary: torch.Tensor, lengths: torch.Tensor) -> torch.Tensor:
+        """Calculate score distributions over tags for each timesteps.
+
+        :param unary: [B, T, C] The score distribution over tags for each timestep.
+        :param lengths: [B] The length of each example.
+
+        :returns: [B, T, C] The score distribution over tags for each timestep.
+        """
+        if self.batch_first:
+            unary = unary.transpose(0, 1)
+        fwd = self.partition_over_time(unary, lengths)
+        bwd = self.partition_backward_over_time(unary, lengths)
+        # Is this addition the right way to combine the forward and backward scores of a CRF?
+        joint = fwd + bwd
+        norm = torch.sum(joint, dim=-1, keepdims=True)
+        norm = norm.masked_fill(norm == 0.0, 1.0)
+        conditional = joint / norm
+        if self.batch_first:
+            return conditional.transpose(0, 1)
+        return conditional
+
+    def posterior_decode(self, unary: torch.Tensor, lengths: torch.Tensor) -> torch.Tensor:
+        """Decode the best tag sequence by selecting the most probable tag at each timestep.
+
+        :param unary: [B, T, C] The score distribution over tags for each timestep.
+        :param lengths: [B] The length of each example.
+
+        :returns: [B, T] The tag sequence created by doing an argmax over the posterior probability over tags for each timestep independently.
+        """
+        post = self.posterior(unary, lengths)
+        scores, preds = torch.max(post, dim=-1)
+        mask = sequence_mask(lengths).to(preds.device)
+        mask = mask if self.batch_first else mask.transpose(0, 1)
+        preds = preds.masked_fill(mask == MASK_FALSE, 0)
+        scores = scores.masked_fill(mask == MASK_FALSE, 0)
+        scores = torch.sum(scores, dim=1 if self.batch_first else 0)
+        return preds, scores
+
+    def forward(self, inputs: Tuple[torch.Tensor, torch.Tensor]) -> torch.Tensor:
+        unary, lengths = tensor_and_lengths(inputs)
+        return self.decode(unary, lengths)[0]
+
+
+class CRF(StructuredTaggerDecoder):
+    def __init__(
+        self,
+        num_tags: int,
+        constraint_mask: Optional[torch.Tensor] = None,
+        batch_first: bool = True,
+        idxs: Tuple[int, int] = (Offsets.GO, Offsets.EOS),
+    ):
+        """A Bigram-based Linear Chain Conditional Random Field for sequence tagging.
+
+        :param num_tags: The number of tags in your output (emission size)
+        :param constraint: Constraints on the transitions [1, N, N]
+        :param idxs: The index of the start and stop symbol
+            in emissions.
+        :param batch_first: If the input [B, T, ...] or [T, B, ...]
+
+        Note:
+            The first element of idxs is assumed to be the start index and the
+            second idx is assumed to be the end index.
+
+            num_tags is assumed to include the start and end symbols.
+        """
+        super().__init__(num_tags, batch_first)
+        self.start_idx, self.end_idx = idxs
+        self.num_tags = num_tags
+        if constraint_mask is not None:
+            self.register_buffer("constraint_mask", constraint_mask)
+        else:
+            self.constraint_mask = None
+
+        self.transitions_p = nn.Parameter(torch.Tensor(1, self.num_tags, self.num_tags).zero_())
+        self.batch_first = batch_first
+        self.viterbi = Viterbi(self.start_idx, self.end_idx)
+
+    def extra_repr(self) -> str:
+        str_ = super().extra_repr()
+        if self.constraint_mask is not None:
+            str_ += ", constrained=True"
+        return str_
+
+    @property
+    def transitions(self):
+        if self.constraint_mask is not None:
+            return self.transitions_p.masked_fill(self.constraint_mask, -1e4)
+        return self.transitions_p
+
+    def neg_log_loss(self, unary, tags, lengths):
+        """Neg Log Loss with a Batched CRF.
+
+        :param unary: torch.FloatTensor: [T, B, N] or [B, T, N]
+        :param tags: torch.LongTensor: [T, B] or [B, T]
+        :param lengths: torch.LongTensor: [B]
+
+        :return: torch.FloatTensor: [B]
+        """
+        # Convert from [B, T, N] -> [T, B, N]
+        if self.batch_first:
+            unary = unary.transpose(0, 1)
+            tags = tags.transpose(0, 1)
+        _, batch_size, _ = unary.size()
+        fwd_score = self.partition(unary, lengths)
+        gold_score = self.score_sentence(unary, tags, lengths)
+
+        loss = fwd_score - gold_score
+        batch_loss = torch.mean(loss)
+        return batch_loss
+
+    def score_sentence(self, unary: torch.Tensor, tags: torch.Tensor, lengths: torch.Tensor) -> torch.Tensor:
+        """Score a batch of sentences.
+
+        :param unary: torch.FloatTensor: [T, B, N]
+        :param tags: torch.LongTensor: [T, B]
+        :param lengths: torch.LongTensor: [B]
+
+        :return: torch.FloatTensor: [B]
+        """
+        batch_size = lengths.shape[0]
+        assert lengths.shape[0] == unary.shape[1]
+
+        trans = self.transitions.squeeze(0)  # [N, N]
+        start = torch.full((1, batch_size), self.start_idx, dtype=tags.dtype, device=tags.device)  # [1, B]
+        tags = torch.cat([start, tags], 0)  # [T + 1, B]
+
+        # Unfold gives me all slices of size 2 (this tag next tag) from dimension T
+        tag_pairs = tags.unfold(0, 2, 1)
+        # Move the pair dim to the front and split it into two
+        indices = tag_pairs.permute(2, 0, 1).chunk(2)
+        trans_score = trans[[indices[1], indices[0]]].squeeze(0)
+        # Pull out the values of the tags from the unary scores.
+        unary_score = unary.gather(2, tags[1:].unsqueeze(-1)).squeeze(-1)
+        mask = sequence_mask(lengths).transpose(0, 1).to(tags.device)
+        scores = unary_score + trans_score
+        scores = scores.masked_fill(mask == MASK_FALSE, 0)
+        scores = scores.sum(0)
+
+        eos_scores = trans[self.end_idx, tags.gather(0, lengths.unsqueeze(0)).squeeze(0)]
+        scores = scores + eos_scores
+        return scores
+
+    def partition(self, unary: torch.Tensor, lengths: torch.Tensor) -> torch.Tensor:
         """For CRF forward on a batch.
 
         :param unary: torch.FloatTensor: [T, B, N]
@@ -2317,10 +2657,8 @@ class CRF(nn.Module):
         # alphas: [B, 1, N]
         min_length = torch.min(lengths)
         batch_size = lengths.shape[0]
-        lengths.shape[0] == unary.shape[1]
         alphas = torch.full((batch_size, 1, self.num_tags), -1e4, device=unary.device)
         alphas[:, 0, self.start_idx] = 0.0
-        # alphas.requires_grad = True
 
         trans = self.transitions  # [1, N, N]
 
@@ -2347,12 +2685,130 @@ class CRF(nn.Module):
         alphas = vec_log_sum_exp(terminal_vars, 2)
         return alphas.view(batch_size)
 
+    def partition_over_time(self, unary: torch.Tensor, lengths: torch.Tensor, start: Optional[int] = None) -> torch.Tensor:
+        """Calculate the partition function Z up to some point in time for each point in time.
+
+        :param unary: [B, T, C] The score distribution over tags for each timestep.
+        :param lengths: [B] The length of each example.
+
+        :returns: [B, T, C] The partition scores at time `t` for each class `c`. This represents the score of being at some state (t, c) considering all paths that get there.
+        """
+        # alphas: [B, 1, N]
+        min_length = torch.min(lengths)
+        batch_size = lengths.shape[0]
+        alphas = []
+        alpha = torch.full((batch_size, 1, self.num_tags), -1e4, device=unary.device)
+        alpha[:, 0, start if start is not None else self.start_idx] = 0.0
+
+        trans = self.transitions  # [1, N, N]
+
+        for i, unary_t in enumerate(unary):
+            # unary_t: [B, N]
+            unary_t = unary_t.unsqueeze(2)  # [B, N, 1]
+            # Broadcast alphas along the rows of trans
+            # Broadcast trans along the batch of alphas
+            # [B, 1, N] + [1, N, N] -> [B, N, N]
+            # Broadcast unary_t along the cols of result
+            # [B, N, N] + [B, N, 1] -> [B, N, N]
+            scores = alpha + trans + unary_t
+            new_alpha = vec_log_sum_exp(scores, 2).transpose(1, 2)
+            # If we haven't reached your length zero out old alpha and take new one.
+            # If we are past your length, zero out new_alpha and keep old one.
+
+            if i >= min_length:
+                mask = (i < lengths).view(-1, 1, 1)
+                alpha = alpha.masked_fill(mask, 0) + new_alpha.masked_fill(mask == MASK_FALSE, 0)
+            else:
+                alpha = new_alpha
+            alphas.append(alpha)
+
+        alphas = torch.cat(alphas, dim=1)
+        mask = sequence_mask(lengths).to(alphas.device).unsqueeze(-1)
+        alphas = alphas.masked_fill(mask == MASK_FALSE, 0.0)
+        return alphas.transpose(0, 1)
+
+    def partition_backward_over_time(self, unary: torch.Tensor, lengths: torch.Tensor) -> torch.Tensor:
+        """Calculate the partition function Z up to some point in time for each point in time starting from the end and moving towards the start.
+
+        :param unary: [B, T, C] The score distribution over tags for each timestep.
+        :param lengths: [B] The length of each example.
+
+        :returns: [B, T, C] The partition scores at time `t` for each class `c`. This represents the score of being at some state (t, c) considering all paths that get there.
+        """
+        seq_len, batch_size, num_tags = unary.shape
+        rev_lengths = seq_len - lengths - 1
+        alphas = []
+        # alpha: [B, 1, N]
+        alpha = torch.full((batch_size, 1, self.num_tags), -1e4, device=unary.device)
+        alpha[:, 0, self.end_idx] = 0.0
+
+        trans = self.transitions.transpose(1, 2)  # [1, N, N]
+
+        for i, unary_t in enumerate(unary.flip(0)):
+            # unary_t: [B, N]
+            unary_t = unary_t.unsqueeze(2)  # [B, N, 1]
+            # Broadcast alphas along the rows of trans
+            # Broadcast trans along the batch of alphas
+            # [B, 1, N] + [1, N, N] -> [B, N, N]
+            # Broadcast unary_t along the cols of result
+            # [B, N, N] + [B, N, 1] -> [B, N, N]
+            scores = alpha + trans + unary_t
+            new_alpha = vec_log_sum_exp(scores, 2).transpose(1, 2)
+            # If we haven't reached your length zero out old alpha and take new one.
+            # If we are past your length, zero out new_alpha and keep old one.
+            mask = (i > rev_lengths).view(-1, 1, 1)
+            alpha = alpha.masked_fill(mask, 0) + new_alpha.masked_fill(mask == MASK_FALSE, 0)
+            alphas.append(alpha)
+
+        alphas = torch.cat(alphas, dim=1).flip(1)
+        mask = sequence_mask(lengths).to(alphas.device).unsqueeze(-1)
+        alphas = alphas.masked_fill(mask == MASK_FALSE, 0.0)
+        return alphas.transpose(0, 1)
+
+    def posterior(self, unary: torch.Tensor, lengths: torch.Tensor) -> torch.Tensor:
+        """Calculate score distributions over tags for each timesteps.
+
+        :param unary: [B, T, C] The score distribution over tags for each timestep.
+        :param lengths: [B] The length of each example.
+
+        :returns: [B, T, C] The score distribution over tags for each timestep.
+        """
+        if self.batch_first:
+            unary = unary.transpose(0, 1)
+        fwd = self.partition_over_time(unary, lengths)
+        bwd = self.partition_backward_over_time(unary, lengths)
+        # Is this addition the right way to combine the forward and backward scores of a CRF?
+        joint = fwd + bwd
+        norm = torch.sum(joint, dim=-1, keepdims=True)
+        norm = norm.masked_fill(norm == 0.0, 1.0)
+        conditional = joint / norm
+        if self.batch_first:
+            return conditional.transpose(0, 1)
+        return conditional
+
+    def posterior_decode(self, unary: torch.Tensor, lengths: torch.Tensor) -> torch.Tensor:
+        """Decode the best tag sequence by selecting the most probable tag at each timestep.
+
+        :param unary: [B, T, C] The score distribution over tags for each timestep.
+        :param lengths: [B] The length of each example.
+
+        :returns: [B, T] The tag sequence created by doing an argmax over the posterior probability over tags for each timestep independently.
+        """
+        post = self.posterior(unary, lengths)
+        scores, preds = torch.max(post, dim=-1)
+        mask = sequence_mask(lengths).to(preds.device)
+        mask = mask if self.batch_first else mask.transpose(0, 1)
+        preds = preds.masked_fill(mask == MASK_FALSE, 0)
+        scores = scores.masked_fill(mask == MASK_FALSE, 0)
+        scores = torch.sum(scores, dim=1 if self.batch_first else 0)
+        return preds, scores
+
     def forward(self, inputs: Tuple[torch.Tensor, torch.Tensor]) -> torch.Tensor:
         unary, lengths = inputs
         if self.training:
             if self.batch_first:
                 unary = unary.transpose(0, 1)
-            forward = self._forward_alg(unary, lengths)
+            forward = self.partition(unary, lengths)
             # if self.batch_first:
             #    forward = forward.transpose(0, 1)
             return forward

--- a/layers/eight_mile/tf/layers.py
+++ b/layers/eight_mile/tf/layers.py
@@ -1707,7 +1707,7 @@ else:
     BiLSTMEncoderHidden = BiLSTMEncoderHidden2
     BiLSTMEncoderHiddenContext = BiLSTMEncoderHiddenContext2
     BiLSTMEncoderAll = BiLSTMEncoderAll2
-    from tensorflow_addons.text.crf import crf_decode, crf_sequence_score, crf_log_norm
+    from tensorflow_addons.text.crf import crf_decode, crf_sequence_score, crf_unary_score, crf_log_norm
 
 
 
@@ -2604,7 +2604,7 @@ class FFN(tf.keras.layers.Layer):
         activation: str = "relu",
         d_ff: Optional[int] = None,
         pdrop: float = 0.0,
-        name: Optional[int] = None,
+        name: Optional[str] = None,
     ):
         """Constructor, takes in model size (which is the external currency of each block) and the feed-forward size
 
@@ -2624,43 +2624,70 @@ class FFN(tf.keras.layers.Layer):
         return self.squeeze(self.dropout(self.act(self.expansion(inputs))))
 
 
-class TaggerGreedyDecoder(tf.keras.layers.Layer):
-    def __init__(self, num_tags: int, constraint_mask: Optional[Tuple[Any, Any]] = None, name: Optional[str] = None):
-        """Initialize the object.
-        :param num_tags: int, The number of tags in your output (emission size)
-        :param constraint_mask: Tuple[np.ndarray, np.ndarray], Constraints on the transitions [1, N, N]
-        :param name: str, Optional name, defaults to `None`
-        """
+class TaggerDecoder(tf.keras.layers.Layer):
+    def __init__(self, num_tags: int, name: Optional[str] = None, **kwargs):
+        """Assign a tag to each token in a sequence."""
         super().__init__(name=name)
         self.num_tags = num_tags
-        self.inv_mask = None
-        if constraint_mask is not None:
-            _, inv_mask = constraint_mask
-            inv_mask = inv_mask * -1e4
-
-            self.A = self.add_weight(
-                "transitions_raw",
-                shape=(num_tags, num_tags),
-                dtype=tf.float32,
-                initializer="zeros",
-                trainable=False
-            )
-            self.inv_mask = self.add_weight(
-                "inv_constraint_mask",
-                shape=(num_tags, num_tags),
-                dtype=tf.float32,
-                initializer=tf.constant_initializer(inv_mask),
-                trainable=False
-            )
-
-    @property
-    def transitions(self):
-        if self.inv_mask is not None:
-            return tf.nn.log_softmax(self.A + self.inv_mask)
-        return self.A
 
     def neg_log_loss(self, unary, tags, lengths):
+        """Calculate the loss associated with this decoder.
 
+        :param unary: [B, T, C] The score distribution over tags for each timestep.
+        :param tags: [B, T] The gold tag for each token.
+        :param lengths: [B] The length of each element in the batch.
+
+        :returns: [] The average loss over the batch
+        """
+
+    def score_sentence(self, unary, tags, lengths):
+        """Calculate the score the model gives a sequence of tags.
+
+        :param unary: [B, T, C] The score distribution over tags for each timestep.
+        :param tags: [B, T] The sequence of tags we are scoring.
+        :param lengths: [B] The length of each example.
+
+        :returns: [B] The score for each example in the batch
+        """
+
+    def posterior(self, unary, lengths):
+        """Calculate score distributions over tags for each timesteps.
+
+        :param unary: [B, T, C] The score distribution over tags for each timestep.
+        :param lengths: [B] The length of each example.
+
+        :returns: [B, T, C] The score distribution over tags for each timestep.
+        """
+        return unary
+
+    def decode(self, unary, lengths):
+        """Return the best scoring sequence of tags.
+
+        :param unary: [B, T, C] The score distribution over tags for each timestep.
+        :param lengths: [B] The length of each example.
+
+        :returns: [B, T] The best scoring tag sequences.
+        """
+
+    def forward(self, inputs, training=False, mask=None):
+        pass
+
+
+class GreedyTaggerDecoder(TaggerDecoder):
+    def __init__(self, num_tags: int, reduction: str = "batch", name: Optional[str] = None):
+        """Assign a tag to each token in a sequence independent of the decisions made for other tokens."""
+        super().__init__(num_tags, name=name)
+        self.reduction = reduction
+
+    def neg_log_loss(self, unary, tags, lengths):
+        """Calculate the loss for these gold tags.
+
+        :param unary: [B, T, C] The score distribution over tags for each timestep.
+        :param tags: [B, T] The gold tag for each token.
+        :param lengths: [B] The length of each element in the batch.
+
+        :returns: [] The average loss over the batch
+        """
         lengths = tf.cast(lengths, tf.int32)
         max_length = tf.reduce_max(lengths)
         tags = tags[:, :max_length]
@@ -2669,62 +2696,330 @@ class TaggerGreedyDecoder(tf.keras.layers.Layer):
         cross_entropy = tf.nn.sparse_softmax_cross_entropy_with_logits(labels=tags, logits=unary)
         cross_entropy *= tf.cast(mask, tf.float32)
         cross_entropy = tf.reduce_sum(cross_entropy, axis=1)
+        if self.reduction == "token":
+            corss_entropy /= lengths
         return tf.reduce_mean(cross_entropy, name="loss")
 
+    def score_sentence(self, unary, tags, lengths):
+        return crf_unary_score(tags, lengths, unary)
+
+    def decode(self, unary, lengths):
+        lengths = tf.cast(lengths, tf.int32)
+        paths = tf.argmax(unary, axis=2)
+        mask = tf.sequence_mask(lengths)
+        paths = tf.multiply(paths, tf.cast(mask, tf.int64), name="best")
+        scores = tf.reduce_max(unary, axis=2)
+        scores = tf.multiply(scores, tf.cast(mask, tf.float32))
+        return paths, scores
+
     def call(self, inputs, training=False, mask=None):
-
         unary, lengths = inputs
-
-        if self.inv_mask is not None:
-            bsz = tf.shape(unary)[0]
-            lsz = self.num_tags
-            np_gos = np.full((1, 1, lsz), -1e4, dtype=np.float32)
-            np_gos[:, :, Offsets.GO] = 0
-            gos = tf.constant(np_gos)
-            start = tf.tile(gos, [bsz, 1, 1])
-            probv = tf.concat([start, unary], axis=1)
-            viterbi, path_scores = crf_decode(probv, self.transitions, lengths + 1)
-            return tf.identity(viterbi[:, 1:], name="best"), path_scores
-        else:
-            return tf.argmax(unary, 2, name="best"), None
+        return self.decode(unary, lengths)
 
 
-class CRF(tf.keras.layers.Layer):
+class StructuredTaggerDecoder(TaggerDecoder):
+    """Assign a tag to each token in a sequence conditioned of the decisions made for other tokens."""
+
+    def partition(self, unary, lengths):
+        """Calculate Z the partition function (normalization factor) for all possible paths.
+
+        :param unary: [B, T, C] The score distribution over tags for each timestep.
+        :param lengths: [B] The length of each example.
+
+        :returns: [B] The sequence normalization number for each element in the path.
+        """
+        raise NotImplementedError
+
+    def partition_over_time(self, unary, lengths):
+        """Calculate the partition function Z up to some point in time for each point in time.
+
+        :param unary: [B, T, C] The score distribution over tags for each timestep.
+        :param lengths: [B] The length of each example.
+
+        :returns: [B, T, C] The partition scores at time `t` for each class `c`. This represents the score of being at some state (t, c) considering all paths that get there.
+        """
+        raise NotImplementedError
+
+    def partition_backward_over_time(self, unary, lengths):
+        """Calculate the partition function Z up to some point in time for each point in time start from the end and moving towards the front.
+
+        :param unary: [B, T, C] The score distribution over tags for each timestep.
+        :param lengths: [B] The length of each example.
+
+        :returns: [B, T, C] The partition scores at time `t` for each class `c`. This represents the score of being at some state (t, c) considering all paths that get there.
+        """
+        raise NotImplementedError
+
+    def posterior_decode(self, unary, lengths):
+        """Decode the best tag sequence by selecting the most probable tag at each timestep.
+
+        :param unary: [B, T, C] The score distribution over tags for each timestep.
+        :param lengths: [B] The length of each example.
+
+        :returns: [B, T] The tag sequence created by doing an argmax over the posterior probability over tags for each timestep independently.
+        """
+        raise NotImplementedError
+
+    @staticmethod
+    def _add_states_to_unary(unary, lengths, start=Offsets.GO, end=Offsets.EOS):
+        """Add a GO and EOS token to the unary tensor."""
+        with tf.name_scope("add_states_to_unary"):
+            # Get the shape, we need `h` to be an actual int opposed to the result of tf.shape. If we use tf.shape
+            # then the last dim is unknown at graph build time and later steps will fail
+            b, _, h = get_shape_as_list(unary)
+            # Adding a GO at the start
+            # Initialize GO to have very negative scores for all tags
+            gos = tf.fill((h,), -1e4)
+            # Set the score for the GO token to be zero
+            gos = tf.tensor_scatter_nd_update(
+                gos,
+                tf.constant(start, shape=[1, 1], dtype=tf.int32),
+                tf.constant(0, shape=[1], dtype=unary.dtype),
+            )
+            # Expand and duplicate the GO score distribution for each item in the batch
+            gos = tf.reshape(gos, [1, 1, -1])
+            gos = tf.tile(gos, [b, 1, 1])
+
+            # Initialize EOS to have very negative scores for all tags
+            ends = tf.fill((h,), -1e4)
+            # Set the score for the EOS token to be zero
+            ends = tf.tensor_scatter_nd_update(
+                ends,
+                tf.constant(end, shape=[1, 1], dtype=tf.int32),
+                tf.constant(0, shape=[1], dtype=unary.dtype)
+            )
+            # Expand and duplicate the EOS score distribution for each item in the batch
+            ends = tf.reshape(ends, [1, -1])
+            ends = tf.tile(ends, [b, 1])
+
+            # Create a empty timestep that EOS might go into
+            spacer = tf.zeros((b, 1, h))
+
+            # All of the examples start with GO so add that to the beginning.
+            # Add the spacer at the end so we don't over write a token with EOS
+            unary = tf.concat([gos, unary, spacer], axis=1)
+            # Add one to the lengths to account for the GO
+            lengths = lengths + 1
+
+            # Get the max len of the batch, this changes at run time so we need to use tf.shape
+            t = tf.shape(unary)[1]
+
+            # Flatten the unaries into a long list of score dists
+            flat_unary = tf.reshape(unary, (-1, h))
+            # Flatten the lengths and scale the lengths to index into that list
+            flat_lengths = tf.reshape(
+                tf.range(tf.cast(b, tf.int64), dtype=tf.int64) * tf.cast(t, tf.int64) + tf.cast(lengths, tf.int64),
+                (-1, 1)
+            )
+            # Overwrite the vectors at float_lengths with the values in ends. There are [B] indices in the flat lengths
+            # that we are scatter values from end with. This is why we needed to tile the end vector batch times.
+            flat_unary = tf.tensor_scatter_nd_update(flat_unary, flat_lengths, ends)
+            # Reshape the unaries
+            unary = tf.reshape(flat_unary, (b, t, h))
+            return unary
+
+    @staticmethod
+    def _add_states_to_tags(tags, lengths, start=Offsets.GO, end=Offsets.EOS, pad=Offsets.PAD):
+        """Add the GO and EOS tags to the tags tensor."""
+        with tf.name_scope("add_states_to_tags"):
+            b = tf.shape(tags)[0]
+            # Create batch size many GO and EOS tokens
+            gos = tf.cast(tf.fill((b, 1), start), tags.dtype)
+            ends = tf.cast(tf.fill((b, 1), end), tags.dtype)
+            # Create an padding time step that will be added to the end so that EOS can be written into it.
+            spacer = tf.cast(tf.fill((b, 1), pad), tags.dtype)
+            # Add the GO (all examples start at the same place) to the start and the pad at the end.
+            tags = tf.concat([gos, tags, spacer], axis=1)
+            # Add one to the lengths to account for the GO
+            lengths = lengths + 1
+            # Get the size of the longest example in the batch. This changes at runtime so use tf.shape
+            h = tf.shape(tags)[1]
+            # Flatten the tags into a big list of tags
+            flat_tags = tf.reshape(tags, (-1, 1))
+            # Flatten the lengths and re-scale them to index into this new list of tags
+            flat_length = tf.reshape(
+                tf.range(tf.cast(b, tf.int64), dtype=tf.int64) * tf.cast(h, tf.int64) + tf.cast(lengths, tf.int64),
+                (-1, 1)
+            )
+            # Scatter the values in ends (EOS) into the flat_tags at the indices given in flat_length
+            flat_tags = tf.tensor_scatter_nd_update(flat_tags, flat_length, ends)
+            tags = tf.reshape(flat_tags, (b, -1))
+            return tags
+
+    @staticmethod
+    def _add_states(unary, tags, lengths, start=Offsets.GO, end=Offsets.EOS):
+        with tf.name_scope("add_states"):
+            unary = StructuredTaggerDecoder._add_states_to_unary(unary, lengths, start, end)
+            if tags is not None:
+                tags = StructuredTaggerDecoder._add_states_to_tags(tags, lengths, start, end)
+            lengths += 2
+            return unary, tags, lengths
+
+
+class CRFRNNCell(tf.keras.layers.AbstractRNNCell):
+    """Computes the partition in a linear-chain CRF."""
+
+    def __init__(self, transition_params, start=Offsets.GO, backward=False, name=None, **kwargs):
+        """Initialize the CrfForwardRnnCell.
+
+        Args:
+          transition_params: A [num_tags, num_tags] matrix of binary
+            potentials. This matrix is expanded into a
+            [1, num_tags, num_tags] in preparation for the broadcast
+            summation occurring within the cell.
+        """
+        super().__init__(name=name, **kwargs)
+        self.transition_params = transition_params
+        self.num_tags = transition_params.shape[-1]
+        self.start = start
+        self.backward = backward
+
+    @property
+    def state_size(self):
+        return self.num_tags
+
+    @property
+    def output_size(self):
+        return self.num_tags
+
+    @property
+    def transitions(self):
+        ts = self.transition_params
+        if self.backward:
+            ts = tf.transpose(self.transition_params, [1, 0])
+        return tf.expand_dims(ts, 0)
+
+    def get_initial_state(self, inputs = None, batch_size = None, dtype=None):
+        initial_state = tf.fill((self.num_tags,), -1e4)
+        initial_state = tf.tensor_scatter_nd_update(
+            initial_state,
+            tf.constant(self.start, shape=[1, 1], dtype=tf.int32),
+            tf.constant(0, shape=[1], dtype=initial_state.dtype)
+        )
+        initial_state = tf.reshape(initial_state, (1, -1))
+        return tf.tile(initial_state, [batch_size, 1])
+
+    def get_config(self):
+        config = super().get_config().copy()
+        config.update({
+            'transition_params': self.transition_params,
+            'start': self.start,
+            'backward': self.backward
+        })
+        return config
+
+    def call(self, inputs, state):
+        """Build the CRFRnnCell.
+        Args:
+          inputs: A [batch_size, num_tags] matrix of unary potentials.
+          state: A [batch_size, num_tags] matrix containing the previous step's
+                score values.
+        Returns:
+          backpointers: A [batch_size, num_tags] matrix of backpointers.
+          new_state: A [batch_size, num_tags] matrix of new score values.
+        """
+        state = tf.expand_dims(state[0], 2)
+        transition_scores = state + self.transitions
+        new_state = inputs + tf.reduce_logsumexp(transition_scores, [1])
+        return new_state, new_state
+
+
+class ConstrainedGreedyTaggerDecoder(StructuredTaggerDecoder, GreedyTaggerDecoder):
+    def __init__(
+        self,
+        num_tags: int,
+        constraint_mask: Tuple[np.ndarray, np.ndarray],
+        reduction: str = "batch",
+        name: Optional[str] = None
+    ):
+        super().__init__(num_tags, reduction, name=name)
+        _, inv_mask = constraint_mask
+        self.inv_mask = inv_mask * -1e4
+        self.A = None
+
+    def build(self, input_shape):
+        self.A = self.add_weight(
+            "transitions_raw",
+            shape=(self.num_tags, self.num_tags),
+            dtype=tf.float32,
+            initializer=tf.initializers.zeros,
+            trainable=False,
+        )
+        self.inv_mask = self.add_weight(
+            "inv_constraint_mask",
+            shape=(self.num_tags, self.num_tags),
+            dtype=tf.float32,
+            initializer=tf.constant_initializer(self.inv_mask),
+            trainable=False
+        )
+
+    @property
+    def transitions(self):
+        return tf.nn.log_softmax(self.A + self.inv_mask)
+
+    def decode(self, unary, lengths):
+        unary, _, lengths = StructuredTaggerDecoder._add_states(unary, None, lengths)
+        unary = tf.nn.log_softmax(unary, axis=-1)
+        viterbi, path_scores = crf_decode(unary, self.transitions, lengths)
+        # We want to mask out the EOS so remove 1 from the length so it get covered.
+        # The GO will be selected off later
+        mask = tf.sequence_mask(lengths - 1, tf.shape(viterbi)[1])
+        viterbi = tf.multiply(viterbi, tf.cast(mask, dtype=viterbi.dtype))
+        return tf.identity(viterbi[:, 1:-1], name="best"), path_scores
+
+
+class CRF(StructuredTaggerDecoder):
     def __init__(self, num_tags: int, constraint_mask: Optional[Tuple[Any, Any]] = None, name: Optional[str] = None):
         """Initialize the object.
         :param num_tags: int, The number of tags in your output (emission size)
         :param constraint_mask: Tuple[np.ndarray, np.ndarray], Constraints on the transitions [1, N, N]
+            Should be two masks, the first with invalid positions marked as 0 and the second 1
         :param name: str, Optional name, defaults to `None`
         """
-        super().__init__(name=name)
+        super().__init__(num_tags, name=name)
 
-        self.A = self.add_weight("transitions_raw", shape=(num_tags, num_tags), dtype=tf.float32)
         self.num_tags = num_tags
         self.mask = None
         self.inv_mask = None
         if constraint_mask is not None:
-            mask, inv_mask = constraint_mask
-            inv_mask = inv_mask * -1e4
+            self.mask, self.inv_mask = constraint_mask
+            self.inv_mask = self.inv_mask * -1e4
+
+    def build(self, input_shape):
+        self.A = self.add_weight(
+            "transitions",
+            shape=(self.num_tags, self.num_tags),
+            dtype=tf.float32,
+            initializer=tf.initializers.zeros,
+        )
+        if self.mask is not None:
             self.mask = self.add_weight(
                 "constraint_mask",
-                shape=(num_tags, num_tags),
+                shape=(self.num_tags, self.num_tags),
                 dtype=tf.float32,
                 trainable=False,
-                initializer=tf.constant_initializer(mask)
+                initializer=tf.constant_initializer(self.mask)
             )
+        if self.inv_mask is not None:
             self.inv_mask = self.add_weight(
                 "inverse_constraint_mask",
-                shape=(num_tags, num_tags),
+                shape=(self.num_tags, self.num_tags),
                 dtype=tf.float32,
                 trainable=False,
-                initializer=tf.constant_initializer(inv_mask)
+                initializer=tf.constant_initializer(self.inv_mask)
             )
+        fwd_cell = CRFRNNCell(self.A, start=Offsets.GO)
+        self.fwd_layer = tf.keras.layers.RNN(fwd_cell, return_sequences=True, return_state=False)
+        bwd_cell = CRFRNNCell(self.A, start=Offsets.EOS, backward=True)
+        self.bwd_layer = tf.keras.layers.RNN(bwd_cell, return_sequences=True, return_state=False, go_backwards=True)
+        self.both_layer = tf.keras.layers.Bidirectional(self.fwd_layer, backward_layer=self.bwd_layer, merge_mode=None)
 
     @property
     def transitions(self):
-        if self.inv_mask is not None:
-            return (self.A * self.mask) + self.inv_mask
-        return self.A
+        if tf.name_scope("transitions"):
+            if self.inv_mask is not None:
+                return (self.A * self.mask) + self.inv_mask
+            return self.A
 
     def score_sentence(self, unary, tags, lengths):
         """Score a batch of sentences.
@@ -2735,13 +3030,57 @@ class CRF(tf.keras.layers.Layer):
 
         :return: torch.FloatTensor: [B]
         """
-        return crf_sequence_score(unary, tf.cast(tags, tf.int32), tf.cast(lengths, tf.int32), self.transitions)
+        unary, tags, lengths = StructuredTaggerDecoder._add_states(unary, tags, lengths)
+        return self._score_sentence(unary, tags, lengths)
+
+    def _score_sentence(self, unary, tags, lengths):
+        return crf_sequence_score(
+            unary,
+            tf.cast(tags, tf.int32),
+            tf.cast(lengths, tf.int32),
+            self.transitions
+        )
+
+    def partition(self, unary, lengths):
+        unary, _, lengths = self._add_states(unary, None, lengths)
+        return self._partition(unary, lengths)
+
+    def _partition(self, unary, lengths):
+        return crf_log_norm(unary, lengths, self.transitions)
+
+    def partition_over_time(self, unary, lengths):
+        mask = tf.sequence_mask(lengths, tf.shape(unary)[1])
+        alphas = self.fwd_layer(unary, mask=mask)
+        return tf.multiply(alphas, tf.expand_dims(tf.cast(mask, dtype=alphas.dtype), -1))
+
+    def partition_backward_over_time(self, unary, lengths):
+        mask = tf.sequence_mask(lengths, tf.shape(unary)[1])
+        alphas = self.bwd_layer(unary, mask=mask)
+        return tf.multiply(tf.reverse(alphas, axis=[1]), tf.expand_dims(tf.cast(mask, dtype=alphas.dtype), -1))
+
+    def posterior(self, unary, lengths):
+        mask = tf.sequence_mask(lengths, tf.shape(unary)[1])
+        fwd, bwd = self.both_layer(unary, mask=mask)
+        joint = fwd + bwd
+        norm = tf.reduce_sum(joint, axis=[-1], keepdims=True)
+        norm = masked_fill(norm, tf.equal(norm, 0.0), 1.0)
+        conditional = joint / norm
+        return conditional
+
+    def posterior_decode(self, unary, lengths):
+        post = self.posterior(unary, lengths)
+        scores = tf.reduce_max(post, axis=-1)
+        preds = tf.argmax(post, axis=-1)
+        mask = tf.cast(tf.sequence_mask(lengths, tf.shape(unary)[1]), preds.dtype)
+        preds = masked_fill(preds, tf.equal(mask, 0), 0)
+        scores = masked_fill(scores, tf.equal(mask, 0), 0.0)
+        scores = tf.reduce_sum(scores, axis=[1])
+        return preds, scores
 
     def call(self, inputs, training=False):
-
         unary, lengths = inputs
         if training:
-            return crf_log_norm(unary, lengths, self.transitions)
+            return self.partition(unary, lengths)
         else:
             return self.decode(unary, lengths)
 
@@ -2754,19 +3093,13 @@ class CRF(tf.keras.layers.Layer):
         :return: List[torch.LongTensor]: [B] the paths
         :return: torch.FloatTensor: [B] the path score
         """
-        bsz = tf.shape(unary)[0]
-        lsz = self.num_tags
-        np_gos = np.full((1, 1, lsz), -1e4, dtype=np.float32)
-        np_gos[:, :, Offsets.GO] = 0
-        gos = tf.constant(np_gos)
-
-        start = tf.tile(gos, [bsz, 1, 1])
-        start = tf.nn.log_softmax(start, axis=-1)
-
-        probv = tf.concat([start, unary], axis=1)
-
-        viterbi, path_scores = crf_decode(probv, self.transitions, lengths + 1)
-        return tf.identity(viterbi[:, 1:], name="best"), path_scores
+        unary, _, lengths = self._add_states(unary, None, lengths)
+        viterbi, path_scores = crf_decode(unary, self.transitions, lengths)
+        # We want to mask out the EOS so remove 1 from the length so it get covered.
+        # The GO will be selected off later
+        mask = tf.sequence_mask(lengths - 1, tf.shape(viterbi)[1])
+        viterbi = tf.multiply(viterbi, tf.cast(mask, viterbi.dtype))
+        return tf.identity(viterbi[:, 1:-1], name="bast"), path_scores
 
     def neg_log_loss(self, unary, tags, lengths):
         """Neg Log Loss with a Batched CRF.
@@ -2777,11 +3110,12 @@ class CRF(tf.keras.layers.Layer):
 
         :return: Tensor of shape `[B]`
         """
+        unary, tags, lengths = self._add_states(unary, tags, lengths)
         lengths = tf.cast(lengths, tf.int32)
+        fwd_score = self._partition(unary, lengths)
         max_length = tf.reduce_max(lengths)
-        fwd_score = self((unary, lengths), training=True)
         tags = tags[:, :max_length]
-        gold_score = self.score_sentence(unary, tags, lengths)
+        gold_score = self._score_sentence(unary, tags, lengths)
         log_likelihood = gold_score - fwd_score
         return -tf.reduce_mean(log_likelihood)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import os
+import sys
+
+_utils = os.path.join(os.path.dirname(__file__), "utils")
+
+if _utils not in sys.path:
+    sys.path.append(_utils)

--- a/tests/test_constrined_decode_pytorch.py
+++ b/tests/test_constrined_decode_pytorch.py
@@ -1,0 +1,490 @@
+import os
+import math
+import json
+from operator import itemgetter
+import pytest
+import numpy as np
+from mock import patch, MagicMock
+
+torch = pytest.importorskip("torch")
+from eight_mile.utils import Offsets
+from eight_mile.pytorch.layers import (
+    ConstrainedGreedyTaggerDecoder,
+    Viterbi,
+    ViterbiLogSoftmaxNorm,
+    transition_mask,
+    script_viterbi,
+    ViterbiBatchSize1,
+    vec_log_sum_exp,
+)
+from tagger_decode_utils import (
+    explicit_log_sum_exp,
+    explicit_sum,
+    explicit_score_gold,
+    explicit_forward,
+    explicit_backward,
+    explicit_posterior,
+    explicit_posterior_decode,
+    explicit_trellises_to_dense,
+    explicit_trellis_to_dense,
+    explicit_nll,
+    explicit_viterbi,
+    build_trans,
+    build_emission,
+)
+
+
+@pytest.fixture
+def generate_batch():
+    """Generate a batch of data.
+
+    Creates lengths such that at least one half of the batch is the maximum
+    length.
+
+    :returns: unary [B, T, H], tags [T, B], lengths [B]
+    """
+    B = np.random.randint(5, 11)
+    T = np.random.randint(15, 21)
+    H = np.random.randint(22, 41)
+    B = 2
+    T = 3
+    H = 4
+    scores = torch.rand(B, T, H)
+    tags = torch.randint(1, H, (B, T))
+    lengths = torch.randint(1, T, (B,))
+    lengths[torch.randint(0, B, (B // 2,))] = T
+    lengths = torch.Tensor([1, 3]).to(torch.long)
+    for s, l in zip(scores, lengths):
+        s[l:] = 0
+    return scores.transpose(0, 1), tags.transpose(0, 1), lengths
+
+
+@pytest.fixture
+def generate_examples_and_batch():
+    """A good test for these systems are do they produce the same results for a
+    batch of data as when you feed the example in one by one.
+
+    This function generates two single examples and then batches them together.
+    """
+    T = np.random.randint(15, 21)
+    H = np.random.randint(22, 41)
+    diff = np.random.randint(1, T // 2)
+
+    item1 = torch.rand(T, 1, H)
+    tags1 = torch.randint(1, H, (T, 1))
+    lengths1 = torch.tensor([T])
+
+    item2 = torch.rand(T - diff, 1, H)
+    tags2 = torch.randint(1, H, (T - diff, 1))
+    lengths2 = torch.tensor([T - diff])
+
+    packed_input = torch.zeros(T, 2, H)
+    packed_tags = torch.zeros(T, 2, dtype=torch.long)
+    packed_input[:, 0, :] = item1.squeeze(1)
+    packed_input[: T - diff, 1, :] = item2.squeeze(1)
+    packed_tags[:, 0] = tags1.squeeze(1)
+    packed_tags[: T - diff, 1] = tags2.squeeze(1)
+    lengths = torch.cat([lengths1, lengths2], dim=0)
+    return item1, tags1, lengths1, item2, tags2, lengths2, packed_input, packed_tags, lengths
+
+
+# def test_score_sentence(generate_batch):
+#     unary, tags, lengths = generate_batch
+#     h = unary.size(2)
+#     crf = CRF(h, batch_first=False)
+#     trans = torch.rand(h, h)
+#     crf.transitions_p.data = trans.unsqueeze(0)
+#     sentence_score = crf.score_sentence(unary, tags, lengths)
+
+#     new_trans = build_trans(trans)
+#     unary = unary.transpose(0, 1)
+#     tags = tags.transpose(0, 1)
+#     scores = []
+#     for u, t, l in zip(unary, tags, lengths):
+#         emiss = build_emission(u[:l])
+#         golds = t[:l].tolist()
+#         scores.append(explicit_score_gold(emiss, new_trans, golds, Offsets.GO, Offsets.EOS))
+#     gold_scores = np.array(scores)
+#     np.testing.assert_allclose(sentence_score.detach().numpy(), gold_scores, rtol=1e-6)
+
+
+# def test_score_sentence_batch_stable(generate_examples_and_batch):
+#     i1, t1, l1, i2, t2, l2, i, t, l = generate_examples_and_batch
+#     h = i1.size(2)
+#     crf = CRF(h, batch_first=False)
+#     crf.transitions_p.data = torch.rand(1, h, h)
+#     score1 = crf.score_sentence(i1, t1, l1)
+#     score2 = crf.score_sentence(i2, t2, l2)
+#     one_x_one = torch.cat([score1, score2], dim=0)
+#     batched = crf.score_sentence(i, t, l)
+#     np.testing.assert_allclose(one_x_one.detach().numpy(), batched.detach().numpy())
+
+
+# def test_score_sentence_shape(generate_batch):
+#     unary, tags, lengths = generate_batch
+#     h = unary.size(2)
+#     crf = CRF(h, batch_first=False)
+#     score = crf.score_sentence(unary, tags, lengths)
+#     assert score.shape == torch.Size([unary.size(1)])
+
+
+# def test_neg_log_loss(generate_batch):
+#    unary, tags, lengths = generate_batch
+#    h = unary.size(2)
+#    crf = CRF(h, batch_first=False)
+#    trans = torch.rand(h, h)
+#    crf.transitions_p.data = trans.unsqueeze(0)
+#    nll = crf.neg_log_loss(unary, tags, lengths)
+
+#    new_trans = build_trans(trans)
+#    unary = unary.transpose(0, 1)
+#    tags = tags.transpose(0, 1)
+#    scores = []
+#    for u, t, l in zip(unary, tags, lengths):
+#        emiss = build_emission(u[:l])
+#        golds = t[:l].tolist()
+#        scores.append(explicit_nll(emiss, new_trans, golds, Offsets.GO, Offsets.EOS))
+#    gold_scores = np.mean(np.array(scores))
+#    np.testing.assert_allclose(nll.detach().numpy(), gold_scores, rtol=1e-6)
+
+
+# def test_neg_log_loss_batch_stable(generate_examples_and_batch):
+#    i1, t1, l1, i2, t2, l2, i, t, l = generate_examples_and_batch
+#    h = i1.size(2)
+#    crf = CRF(h, batch_first=False)
+#    crf.transitions_p.data = torch.rand(1, h, h)
+#    nll1 = crf.neg_log_loss(i1, t1, l1)
+#    nll2 = crf.neg_log_loss(i2, t2, l2)
+#    one_x_one = (nll1 + nll2) / 2
+#    batched = crf.neg_log_loss(i, t, l)
+#    np.testing.assert_allclose(one_x_one.detach().numpy(), batched.detach().numpy())
+
+
+def test_forward(generate_batch):
+    unary, _, lengths = generate_batch
+    h = unary.size(2)
+    trans = torch.rand(h, h).bernoulli().to(torch.bool)
+    crf = ConstrainedGreedyTaggerDecoder(h, trans.unsqueeze(0), batch_first=False)
+    forward = crf.partition(unary, lengths)
+
+    new_trans = build_trans(crf.transitions.data.squeeze(0))
+    unary = unary.transpose(0, 1)
+    scores = []
+    for u, l in zip(unary, lengths):
+        emiss = build_emission(u[:l])
+        scores.append(explicit_forward(emiss, new_trans, Offsets.GO, Offsets.EOS, explicit_sum)[0])
+    gold_scores = np.array(scores)
+    np.testing.assert_allclose(forward.detach().numpy(), gold_scores, rtol=1e-6)
+
+
+def test_forward_over_time(generate_batch):
+    unary, _, lengths = generate_batch
+    h = unary.size(2)
+    trans = torch.rand(h, h).bernoulli().to(torch.bool)
+    crf = ConstrainedGreedyTaggerDecoder(h, trans.unsqueeze(0), batch_first=False)
+    forward = crf.partition_over_time(unary, lengths).transpose(0, 1)
+
+    new_trans = build_trans(crf.transitions.data.squeeze(0))
+    unary = unary.transpose(0, 1)
+    scores = []
+    for u, l in zip(unary, lengths):
+        emiss = build_emission(u[:l])
+        scores.append(explicit_forward(emiss, new_trans, Offsets.GO, Offsets.EOS, explicit_sum)[1])
+    for fwd, gold, l in zip(forward, scores, lengths):
+        fwd = fwd[:l, :]
+        np.testing.assert_allclose(fwd.detach().numpy(), explicit_trellises_to_dense(gold), rtol=1e-6)
+
+
+def test_backward_over_time(generate_batch):
+    unary, _, lengths = generate_batch
+    h = unary.size(2)
+    trans = torch.rand(h, h).bernoulli().to(torch.bool)
+    crf = ConstrainedGreedyTaggerDecoder(h, trans.unsqueeze(0), batch_first=False)
+    backward = crf.partition_backward_over_time(unary, lengths).transpose(0, 1)
+
+    new_trans = build_trans(crf.transitions.data.squeeze(0))
+    unary = unary.transpose(0, 1)
+    scores = []
+    for u, l in zip(unary, lengths):
+        emiss = build_emission(u[:l])
+        scores.append(explicit_backward(emiss, new_trans, Offsets.GO, Offsets.EOS, explicit_sum)[1])
+    for bwd, gold, l in zip(backward, scores, lengths):
+        bwd = bwd[:l, :]
+        np.testing.assert_allclose(bwd.detach().numpy(), explicit_trellises_to_dense(gold), rtol=1e-6)
+
+
+# def test_posterior(generate_batch):
+#     unary, _, lengths = generate_batch
+#     h = unary.size(2)
+#     crf = CRF(h, batch_first=False)
+#     trans = torch.rand(h, h)
+#     crf.transitions_p.data = trans.unsqueeze(0)
+#     posterior = crf.posterior(unary, lengths).transpose(0, 1)
+
+#     new_trans = build_trans(trans)
+#     unary = unary.transpose(0, 1)
+#     scores = []
+#     for u, l in zip(unary, lengths):
+#         emiss = build_emission(u[:l])
+#         scores.append(explicit_posterior(emiss, new_trans, Offsets.GO, Offsets.EOS))
+#     for post, gold, l in zip(posterior, scores, lengths):
+#         post = post[:l, :]
+#         np.testing.assert_allclose(post.detach().numpy(), explicit_trellises_to_dense(gold), rtol=1e-6)
+
+
+# def test_posterior_decode(generate_batch):
+#     unary, _, lengths = generate_batch
+#     h = unary.size(2)
+#     crf = CRF(h, batch_first=False)
+#     trans = torch.rand(h, h)
+#     crf.transitions_p.data = trans.unsqueeze(0)
+#     paths, scores = crf.posterior_decode(unary, lengths)
+#     paths = paths.transpose(0, 1)
+
+#     new_trans = build_trans(trans)
+#     unary = unary.transpose(0, 1)
+#     gold_paths = []
+#     gold_scores = []
+#     for u, l in zip(unary, lengths):
+#         emiss = build_emission(u[:l])
+#         p, s = explicit_posterior_decode(emiss, new_trans, Offsets.GO, Offsets.EOS)
+#         gold_paths.append(p)
+#         gold_scores.append(s)
+#     for p, g, l in zip(paths, gold_paths, lengths):
+#         p = p[:l]
+#         np.testing.assert_allclose(p.detach().numpy(), np.array(g), rtol=1e-6)
+#     np.testing.assert_allclose(scores.detach().numpy(), np.array(gold_scores), rtol=1e-6)
+
+
+# def test_forward_batch_stable(generate_examples_and_batch):
+#     i1, _, l1, i2, _, l2, i, _, l = generate_examples_and_batch
+#     h = i1.size(2)
+#     crf = CRF(h, batch_first=False)
+#     crf.transitions_p.data = torch.rand(1, h, h)
+#     fw1 = crf.forward((i1, l1))
+#     fw2 = crf.forward((i2, l2))
+#     one_x_one = torch.cat([fw1, fw2], dim=0)
+#     batched = crf.forward((i, l))
+#     np.testing.assert_allclose(one_x_one.detach().numpy(), batched.detach().numpy())
+
+
+# def test_forward_shape(generate_batch):
+#     unary, _, lengths = generate_batch
+#     h = unary.size(2)
+#     crf = CRF(h, batch_first=False)
+#     fwd = crf.forward((unary, lengths))
+#     assert fwd.shape == torch.Size([unary.size(1)])
+
+
+# def test_decode_batch_stable(generate_examples_and_batch):
+#    i1, _, l1, i2, _, l2, i, _, l = generate_examples_and_batch
+#    h = i1.size(2)
+#    crf = CRF(h, batch_first=False)
+#    crf.transitions_p.data = torch.rand(1, h, h)
+#    p1, s1 = crf.decode(i1, l1)
+#    p2, s2 = crf.decode(i2, l2)
+#    pad = torch.zeros(p1.size(0) - p2.size(0), 1, dtype=torch.long)
+#    one_x_one_p = torch.cat([p1, torch.cat([p2, pad], dim=0)], dim=1)
+#    one_x_one_s = torch.cat([s1, s2], dim=0)
+#    batched_p, batched_s =  crf.decode(i, l)
+#    np.testing.assert_allclose(one_x_one_s.detach().numpy(), batched_s.detach().numpy())
+#    for p1, p2 in zip(one_x_one_p, batched_p):
+#        np.testing.assert_allclose(p1.detach().numpy(), p2.detach().numpy())
+
+
+# def test_decode_shape_crf(generate_batch):
+#     unary, _, lengths = generate_batch
+#     h = unary.size(2)
+#     crf = CRF(h, batch_first=False)
+#     paths, scores = crf.decode(unary, lengths)
+#     assert scores.shape == torch.Size([unary.size(1)])
+#     assert paths.shape == torch.Size([unary.size(0), unary.size(1)])
+
+
+# def test_mask_is_applied():
+#     h = np.random.randint(22, 41)
+#     loc = np.random.randint(h)
+#     constraint = torch.zeros(h, h, dtype=torch.uint8)
+#     constraint[Offsets.GO, loc] = 1
+#     crf = CRF(h, constraint_mask=constraint)
+#     t = crf.transitions.detach().numpy()
+#     assert t[0, Offsets.GO, loc] == -1e4
+
+
+# def test_mask_not_applied():
+#     h = np.random.randint(22, 41)
+#     crf = CRF(h)
+#     t = crf.transitions.detach().numpy()
+#     assert t[0, Offsets.GO, np.random.randint(h)] != -1e4
+
+
+# def test_mask_flips():
+#     h = np.random.randint(22, 41)
+#     mask = (np.random.rand(h, h) < 0.5).astype(np.uint8)
+#     with patch("eight_mile.pytorch.layers.transition_mask_np") as mask_mock:
+#         mask_mock.return_value = mask
+#         pyt_mask = transition_mask(None, None, None, None, None)
+#     mask2 = pyt_mask.numpy()
+#     assert (mask & mask2).sum() == 0
+#     assert (mask | mask2).sum() == h * h
+
+
+# def test_mask_same_after_update(generate_batch):
+#     from torch.optim import SGD
+
+#     unary, tags, lengths = generate_batch
+#     h = unary.size(2)
+#     constraint = torch.rand(h, h) < 0.5
+#     crf = CRF(h, constraint_mask=constraint, batch_first=False)
+#     opt = SGD(crf.parameters(), lr=10)
+#     m1 = crf.constraint_mask.numpy()
+#     t1 = crf.transitions_p.detach().clone().numpy()
+#     l = crf.neg_log_loss(unary, tags, lengths)
+#     l = torch.mean(l)
+#     l.backward()
+#     opt.step()
+#     m2 = crf.constraint_mask.numpy()
+#     t2 = crf.transitions_p.detach().numpy()
+#     np.testing.assert_allclose(m1, m2)
+#     with pytest.raises(AssertionError):
+#         np.testing.assert_allclose(t1, t2)
+
+
+# def test_viterbi(generate_batch):
+#     unary, _, lengths = generate_batch
+#     h = unary.size(2)
+#     trans = torch.rand(h, h)
+#     pyt_path, pyt_scores = Viterbi(Offsets.GO, Offsets.EOS)(unary, trans.unsqueeze(0), lengths)
+
+#     new_trans = build_trans(trans)
+#     unary = unary.transpose(0, 1)
+#     paths = []
+#     scores = []
+#     for u, l in zip(unary, lengths):
+#         emiss = build_emission(u[:l])
+#         p, s = explicit_viterbi(emiss, new_trans, Offsets.GO, Offsets.EOS)
+#         scores.append(s)
+#         paths.append(p)
+#     gold_scores = np.array(scores)
+#     np.testing.assert_allclose(pyt_scores.detach().numpy(), gold_scores, rtol=1e-6)
+#     pyt_path = pyt_path.transpose(0, 1)
+#     for pp, l, p in zip(pyt_path, lengths, paths):
+#         assert pp[:l].tolist() == p
+
+
+# def test_viterbi_score_equals_sentence_score(generate_batch):
+#     """Test that the scores from viterbi decoding are the same scores that you get when looking up those returned paths."""
+#     unary, _, lengths = generate_batch
+#     h = unary.size(2)
+#     trans = torch.rand(h, h)
+#     crf = CRF(h)
+
+#     p, viterbi_scores = Viterbi(Offsets.GO, Offsets.EOS)(unary, crf.transitions, lengths)
+#     gold_scores = crf.score_sentence(unary, p, lengths)
+#     np.testing.assert_allclose(viterbi_scores.detach().numpy(), gold_scores.detach().numpy())
+
+
+# def test_viterbi_script(generate_batch):
+#     unary, _, lengths = generate_batch
+#     h = unary.size(2)
+#     trans = torch.rand(h, h)
+
+#     # pyt_path, pyt_scores = ViterbiBatchSize1(Offsets.GO, Offsets.EOS)(unary, trans.unsqueeze(0), lengths)
+
+#     new_trans = build_trans(trans)
+#     batch_first_unary = unary.transpose(0, 1)
+#     for u, l in zip(batch_first_unary, lengths):
+#         emiss = build_emission(u[:l])
+#         p, s = explicit_viterbi(emiss, new_trans, Offsets.GO, Offsets.EOS)
+#         ps, ss = script_viterbi(u[:l], trans, Offsets.GO, Offsets.EOS)
+
+#         np.testing.assert_allclose(ps.numpy().tolist(), p, rtol=1e-6)
+#         np.testing.assert_allclose(ss.item(), s, rtol=1e-6)
+
+
+# def test_viterbi_batch_stable(generate_examples_and_batch):
+#     i1, _, l1, i2, _, l2, i, _, l = generate_examples_and_batch
+#     h = i1.size(2)
+#     trans = torch.rand(1, h, h)
+#     p1, s1 = Viterbi(Offsets.GO, Offsets.EOS)(i1, trans, l1)
+#     p2, s2 = Viterbi(Offsets.GO, Offsets.EOS)(i2, trans, l2)
+#     pad = torch.zeros(p1.size(0) - p2.size(0), 1, dtype=torch.long)
+#     one_x_one_p = torch.cat([p1, torch.cat([p2, pad], dim=0)], dim=1)
+#     one_x_one_s = torch.cat([s1, s2], dim=0)
+#     batched_p, batched_s = Viterbi(Offsets.GO, Offsets.EOS)(i, trans, l)
+#     np.testing.assert_allclose(one_x_one_s.detach().numpy(), batched_s.detach().numpy())
+#     np.testing.assert_allclose(one_x_one_p.detach().numpy(), batched_p.detach().numpy())
+
+
+# def test_viterbi_degenerates_to_argmax(generate_batch):
+#     scores, _, l = generate_batch
+#     h = scores.size(2)
+#     # Then transitions are all zeros then it just greedily selects the best
+#     # state at that given emission. This is the same as doing argmax.
+#     trans = torch.zeros((1, h, h))
+#     viterbi = Viterbi(Offsets.GO, Offsets.EOS)
+#     p, s = viterbi(scores, trans, l)
+#     s_gold, p_gold = torch.max(scores, 2)
+#     # Mask out the argmax results from past the lengths
+#     for i, sl in enumerate(l):
+#         s_gold[sl:, i] = 0
+#         p_gold[sl:, i] = 0
+#     s_gold = torch.sum(s_gold, 0)
+#     np.testing.assert_allclose(p.detach().numpy(), p_gold.detach().numpy())
+#     np.testing.assert_allclose(s.detach().numpy(), s_gold.detach().numpy())
+
+
+# def test_decode_shape(generate_batch):
+#     unary, _, lengths = generate_batch
+#     h = unary.size(2)
+#     trans = torch.rand(1, h, h)
+#     viterbi = Viterbi(Offsets.GO, Offsets.EOS)
+#     paths, scores = viterbi(unary, trans, lengths)
+#     assert scores.shape == torch.Size([unary.size(1)])
+#     assert paths.shape == torch.Size([unary.size(0), unary.size(1)])
+
+
+# def test_vec_log_sum_exp():
+#     vec = torch.rand(1, np.random.randint(5, 31))
+#     ours = vec_log_sum_exp(vec, 1).squeeze()
+#     xs = {}
+#     for i in range(vec.size(1)):
+#         xs[i] = vec[0, i].item()
+#     gold = explicit_log_sum_exp(xs)
+#     np.testing.assert_allclose(ours, gold, rtol=1e-6)
+
+
+# def test_vec_log_sum_exp_zeros():
+#     l = np.random.randint(1, 21)
+#     in_ = torch.zeros(1, l)
+#     lse = vec_log_sum_exp(in_, 1).squeeze()
+#     np.testing.assert_allclose(lse.detach().numpy(), math.log(l))
+
+
+# def test_vec_log_sum_exp_ones():
+#     l = np.random.randint(1, 21)
+#     in_ = torch.ones(1, l)
+#     lse = vec_log_sum_exp(in_, 1).squeeze()
+#     np.testing.assert_allclose(lse.detach().numpy(), math.log(l * math.e))
+
+
+# def test_vec_log_sum_exp_shape():
+#     dim = torch.randint(0, 3, (1,)).item()
+#     shape = torch.randint(1, 21, (3,))
+#     in_ = torch.rand(*shape)
+#     out = vec_log_sum_exp(in_, dim)
+#     shape[dim] = 1
+#     for i in range(len(shape)):
+#         assert out.size(i) == shape[i]
+
+
+# def test_vec_log_sum_exp_batch_stable():
+#     h = np.random.randint(22, 41)
+#     i1 = torch.rand(1, h, h)
+#     i2 = torch.rand(1, h, h)
+#     i = torch.cat([i1, i2], dim=0)
+#     lse1 = vec_log_sum_exp(i1, 2)
+#     lse2 = vec_log_sum_exp(i2, 2)
+#     one_x_one = torch.cat([lse1, lse2], dim=0)
+#     lse = vec_log_sum_exp(i, 2)
+#     np.testing.assert_allclose(one_x_one.numpy(), lse.numpy())

--- a/tests/test_crf_tensorflow.py
+++ b/tests/test_crf_tensorflow.py
@@ -10,6 +10,20 @@ from baseline.model import create_tagger_model, load_tagger_model
 from baseline.embeddings import load_embeddings
 from baseline.utils import transition_mask as np_transition_mask
 from baseline.tf.tfy import transition_mask
+from crf_utils import (
+    explicit_log_sum_exp,
+    explicit_score_gold,
+    explicit_forward,
+    explicit_backward,
+    explicit_posterior,
+    explicit_posterior_decode,
+    explicit_trellises_to_dense,
+    explicit_trellis_to_dense,
+    explicit_nll,
+    explicit_viterbi,
+    build_trans,
+    build_emission,
+)
 
 
 HSZ = 100
@@ -19,6 +33,9 @@ E = "<EOS>"
 P = "<PAD>"
 SPAN_TYPE = "IOB2"
 LOC = os.path.dirname(os.path.realpath(__file__))
+
+
+
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_crf_tf2.py
+++ b/tests/test_crf_tf2.py
@@ -1,0 +1,460 @@
+import pytest
+import numpy as np
+from eight_mile.utils import get_version, Offsets
+
+tf = pytest.importorskip("tensorflow")
+pytestmark = pytest.mark.skipif(get_version(tf) < 2, reason="TF1.X")
+from eight_mile.tf.layers import (
+    CRF,
+    StructuredTaggerDecoder,
+    get_shape_as_list,
+)
+from tagger_decode_utils import (
+    explicit_log_sum_exp,
+    explicit_score_gold,
+    explicit_forward,
+    explicit_backward,
+    explicit_posterior,
+    explicit_posterior_decode,
+    explicit_trellises_to_dense,
+    explicit_trellis_to_dense,
+    explicit_nll,
+    explicit_viterbi,
+    build_trans as make_trans,
+    build_emission as make_emission,
+    generate_batch as make_batch,
+    generate_examples_and_batch as make_examples_and_batch,
+)
+
+
+@pytest.fixture
+def generate_batch():
+    scores, tags, lengths = make_batch()
+    scores = tf.convert_to_tensor(scores)
+    tags = tf.convert_to_tensor(tags)
+    lengths = tf.convert_to_tensor(lengths, dtype=tf.int32)
+    return scores, tags, lengths
+
+
+@pytest.fixture
+def generate_examples_and_batch():
+    i1, t1, l1, i2, t2, l2, items, ts, lengths = map(tf.convert_to_tensor, make_examples_and_batch())
+    t1 = tf.cast(t1, tf.int32)
+    t2 = tf.cast(t2, tf.int32)
+    ts = tf.cast(ts, tf.int32)
+    l1 = tf.cast(l1, tf.int32)
+    l2 = tf.cast(l2, tf.int32)
+    lengths = tf.cast(lengths, tf.int32)
+    return i1, t1, l1, i2, t2, l2, items, ts, lengths
+
+
+def make_crf(unary, zero_trans = False):
+    h = get_shape_as_list(unary)[-1]
+    crf = CRF(h)
+    crf.build(unary.shape)
+    if not zero_trans:
+        trans = tf.random.uniform((h, h))
+        # Assign to the variable so the updated value get used by the fwd/bwd layers
+        crf.A.assign(trans)
+    return crf, crf.A
+
+
+def build_trans(trans):
+    # The code that consumes this transition dict use (to, from) like pyt while the tf uses (from, to) so transpose so the numbers work
+    return make_trans(np.transpose(trans.numpy()))
+
+def build_emission(emission):
+    return make_emission(emission.numpy())
+
+
+def test_score_sentence(generate_batch):
+    unary, tags, lengths = generate_batch
+    crf, trans = make_crf(unary)
+
+    score = crf.score_sentence(unary, tags, lengths)
+
+    new_trans = build_trans(trans)
+    tags = tags.numpy()
+    scores = []
+    for u, t, l in zip(unary, tags, lengths):
+        emiss = build_emission(u[:l])
+        golds = t[:l].tolist()
+        scores.append(explicit_score_gold(emiss, new_trans, golds, Offsets.GO, Offsets.EOS))
+    gold_scores = np.array(scores)
+    np.testing.assert_allclose(score.numpy(), gold_scores, rtol=1e-6)
+
+
+def test_score_sentence_batch_stable(generate_examples_and_batch):
+    i1, t1, l1, i2, t2, l2, i, t, l = generate_examples_and_batch
+    crf, _ = make_crf(i)
+
+    score1 = crf.score_sentence(i1, t1, l1)
+    score2 = crf.score_sentence(i2, t2, l2)
+    one_x_one = tf.concat([score1, score2], axis=0)
+
+    batched = crf.score_sentence(i, t, l)
+
+    np.testing.assert_allclose(one_x_one.numpy(), batched.numpy(), rtol=1e-6)
+
+
+def test_score_sentence_shape(generate_batch):
+    unary, tags, lengths = generate_batch
+    b, *_, h = get_shape_as_list(unary)
+    crf = CRF(h)
+    crf.build(unary.shape)
+    score = crf.score_sentence(unary, tags, lengths)
+    assert score.shape == b
+
+
+def test_neg_log_loss(generate_batch):
+    unary, tags, lengths = generate_batch
+    crf, trans = make_crf(unary)
+
+    nll = crf.neg_log_loss(unary, tags, lengths)
+
+    new_trans = build_trans(trans)
+    tags = tags.numpy()
+    scores = []
+    for u, t, l in zip(unary, tags, lengths):
+        golds = t[:l].tolist()
+        emiss = build_emission(u[:l])
+        scores.append(explicit_nll(emiss, new_trans, golds, Offsets.GO, Offsets.EOS))
+    gold_scores = np.mean(np.array(scores))
+    np.testing.assert_allclose(nll.numpy(), gold_scores, rtol=1e-6)
+
+
+def test_neg_log_loss_batch_stable(generate_examples_and_batch):
+   i1, t1, l1, i2, t2, l2, i, t, l = generate_examples_and_batch
+   crf, _ = make_crf(i)
+
+   nll1 = crf.neg_log_loss(i1, t1, l1)
+   nll2 = crf.neg_log_loss(i2, t2, l2)
+   one_x_one = (nll1 + nll2) / 2
+
+   batched = crf.neg_log_loss(i, t, l)
+
+   np.testing.assert_allclose(one_x_one.numpy(), batched.numpy())
+
+
+def test_forward(generate_batch):
+    unary, _, lengths = generate_batch
+    crf, trans = make_crf(unary)
+
+    fwd = crf.partition(unary, lengths)
+
+    new_trans = build_trans(trans)
+    scores = []
+    for u, l in zip(unary, lengths):
+        emiss = build_emission(u[:l])
+        scores.append(explicit_forward(emiss, new_trans, Offsets.GO, Offsets.EOS)[0])
+    gold_scores = np.array(scores)
+    np.testing.assert_allclose(fwd.numpy(), gold_scores, rtol=1e-6)
+
+
+def test_forward_batch_stable(generate_examples_and_batch):
+    i1, _, l1, i2, _, l2, i, _, l = generate_examples_and_batch
+    crf, trans = make_crf(i)
+
+    fwd1 = crf.partition(i1, l1)
+    fwd2 = crf.partition(i2, l2)
+    one_x_one = tf.concat([fwd1, fwd2], axis=0)
+
+    batched = crf.partition(i, l)
+
+    np.testing.assert_allclose(one_x_one.numpy(), batched.numpy(), rtol=1e-6)
+
+
+def test_forward_batch_stable(generate_examples_and_batch):
+    i1, _, l1, i2, _, l2, i, _, l = generate_examples_and_batch
+    crf, _ = make_crf(i)
+
+    fw1 = crf.partition(i1, l1)
+    fw2 = crf.partition(i2, l2)
+    one_x_one = tf.concat([fw1, fw2], axis=0)
+    batched = crf.partition(i, l)
+    np.testing.assert_allclose(one_x_one.numpy(), batched.numpy())
+
+
+def test_forward_shape(generate_batch):
+    unary, _, lengths = generate_batch
+    crf, trans = make_crf(unary)
+    fwd = crf.partition(unary, lengths)
+    assert fwd.shape == get_shape_as_list(unary)[0]
+
+
+def test_forward_over_time(generate_batch):
+    unary, _, lengths = generate_batch
+    crf, trans = make_crf(unary)
+
+    fwd = crf.partition_over_time(unary, lengths)
+
+    new_trans = build_trans(trans)
+    scores = []
+    for u, l in zip(unary, lengths):
+        emiss = build_emission(u[:l])
+        scores.append(explicit_forward(emiss, new_trans, Offsets.GO, Offsets.EOS)[1])
+    for f, g, l in zip(fwd, scores, lengths):
+        f = f[:l, :]
+        np.testing.assert_allclose(f.numpy(), explicit_trellises_to_dense(g), rtol=1e-6)
+
+
+def test_forward_over_time_batch_stable(generate_examples_and_batch):
+    i1, t1, l1, i2, t2, l2, i, t, l = generate_examples_and_batch
+    crf, _ = make_crf(i)
+
+    f1 = crf.partition_over_time(i1, l1)
+    f2 = crf.partition_over_time(i2, l2)
+
+    batched = crf.partition_over_time(i, l)
+
+    _, t, h = get_shape_as_list(f1)
+    one_x_one = np.zeros((2, t, h))
+    one_x_one[0, :t] = tf.squeeze(f1, 0).numpy()
+    one_x_one[1, :get_shape_as_list(f2)[1]] = tf.squeeze(f2, 0).numpy()
+
+    np.testing.assert_allclose(one_x_one, batched.numpy(), rtol=1e-6)
+
+
+def test_backward_over_time(generate_batch):
+    unary, _, lengths = generate_batch
+    crf, trans = make_crf(unary)
+
+    bwd = crf.partition_backward_over_time(unary, lengths)
+
+    new_trans = build_trans(trans)
+    scores = []
+    for u, l in zip(unary, lengths):
+        emiss = build_emission(u[:l])
+        scores.append(explicit_backward(emiss, new_trans, Offsets.GO, Offsets.EOS)[1])
+    for b, g, l in zip(bwd, scores, lengths):
+        b = b[:l, :]
+        np.testing.assert_allclose(b.numpy(), explicit_trellises_to_dense(g), rtol=1e-6)
+
+
+def test_backward_over_time_batch_stable(generate_examples_and_batch):
+    i1, t1, l1, i2, t2, l2, i, t, l = generate_examples_and_batch
+    crf, _ = make_crf(i)
+
+    f1 = crf.partition_backward_over_time(i1, l1)
+    f2 = crf.partition_backward_over_time(i2, l2)
+
+    batched = crf.partition_backward_over_time(i, l)
+
+    _, t, h = get_shape_as_list(f1)
+    one_x_one = np.zeros((2, t, h))
+    one_x_one[0, :t] = tf.squeeze(f1, 0).numpy()
+    one_x_one[1, :get_shape_as_list(f2)[1]] = tf.squeeze(f2, 0).numpy()
+
+    np.testing.assert_allclose(one_x_one, batched.numpy(), rtol=1e-6)
+
+
+def test_posterior(generate_batch):
+    unary, _, lengths = generate_batch
+    crf, trans = make_crf(unary)
+
+    posterior = crf.posterior(unary, lengths)
+
+    new_trans = build_trans(trans)
+    scores = []
+    for u, l in zip(unary, lengths):
+        emiss = build_emission(u[:l])
+        scores.append(explicit_posterior(emiss, new_trans, Offsets.GO, Offsets.EOS))
+    for p, g, l in zip(posterior, scores, lengths):
+        p = p[:l, :]
+        np.testing.assert_allclose(p.numpy(), explicit_trellises_to_dense(g), rtol=1e-6)
+
+
+def test_posterior_batch_stable(generate_examples_and_batch):
+    i1, t1, l1, i2, t2, l2, i, t, l = generate_examples_and_batch
+    crf, _ = make_crf(i)
+
+    p1 = crf.posterior(i1, l1)
+    p2 = crf.posterior(i2, l2)
+
+    batched = crf.posterior(i, l)
+
+    _, t, h = get_shape_as_list(p1)
+    t2 = get_shape_as_list(p2)[1]
+    one_x_one = np.zeros((2, t, h))
+    one_x_one[0, :t] = tf.squeeze(p1, 0).numpy()
+    one_x_one[1, :t2] = tf.squeeze(p2, 0).numpy()
+
+    np.testing.assert_allclose(batched.numpy(), one_x_one, rtol=1e-6)
+
+
+def test_posterior_decode(generate_batch):
+    unary, _, lengths = generate_batch
+    crf, trans = make_crf(unary)
+
+    paths, scores = crf.posterior_decode(unary, lengths)
+
+    new_trans = build_trans(trans)
+    gold_paths = []
+    gold_scores = []
+    for u, l in zip(unary, lengths):
+        emiss = build_emission(u[:l])
+        p, s = explicit_posterior_decode(emiss, new_trans, Offsets.GO, Offsets.EOS)
+        gold_paths.append(p)
+        gold_scores.append(s)
+    for p, g, l in zip(paths, gold_paths, lengths):
+        p = p[:l]
+        np.testing.assert_allclose(p.numpy(), np.array(g), rtol=1e-6)
+    np.testing.assert_allclose(scores.numpy(), np.array(gold_scores), rtol=1e-6)
+
+
+def test_posterior_decode_batch_stable(generate_examples_and_batch):
+    i1, t1, l1, i2, t2, l2, i, t, l = generate_examples_and_batch
+    crf, _ = make_crf(i)
+
+    p1, s1 = crf.posterior_decode(i1, l1)
+    p2, s2 = crf.posterior_decode(i2, l2)
+
+    batched_p, batched_s = crf.posterior_decode(i, l)
+
+    one_x_one_s = tf.concat([s1, s2], axis=0)
+
+    _, t = get_shape_as_list(p1)
+    t2 = get_shape_as_list(p2)[1]
+    one_x_one_p = np.zeros((2, t), dtype=np.int32)
+    one_x_one_p[0, :t] = tf.squeeze(p1, 0).numpy()
+    one_x_one_p[1, :t2] = tf.squeeze(p2, 0).numpy()
+
+    np.testing.assert_allclose(batched_s.numpy(), one_x_one_s.numpy(), rtol=1e-6)
+    np.testing.assert_allclose(batched_p.numpy(), one_x_one_p, rtol=1e-6)
+
+
+def test_decode(generate_batch):
+    unary, _, lengths = generate_batch
+    crf, trans = make_crf(unary)
+
+    path, scores = crf.decode(unary, lengths)
+
+    new_trans = build_trans(trans)
+    gold_paths = []
+    gold_scores = []
+    for u, l in zip(unary, lengths):
+        emiss = build_emission(u[:l])
+        p, s = explicit_viterbi(emiss, new_trans, Offsets.GO, Offsets.EOS)
+        gold_scores.append(s)
+        gold_paths.append(p)
+    gold_scores = np.array(scores)
+    np.testing.assert_allclose(scores.numpy(), gold_scores, rtol=1e-6)
+    for p, g, l in zip(path, gold_paths, lengths):
+        assert p[:l].numpy().tolist() == g
+
+
+def test_decode_batch_stable(generate_examples_and_batch):
+    i1, _, l1, i2, _, l2, i, _, l = generate_examples_and_batch
+    crf, _ = make_crf(i)
+
+    p1, s1 = crf.decode(i1, l1)
+    p2, s2 = crf.decode(i2, l2)
+
+    batched_p, batched_s = crf.decode(i, l)
+
+    one_x_one_s = tf.concat([s1, s2], axis=0)
+
+    _, t = get_shape_as_list(p1)
+    t2 = get_shape_as_list(p2)[1]
+    one_x_one_p = np.zeros((2, t), dtype=np.int32)
+    one_x_one_p[0, :t] = tf.squeeze(p1, 0).numpy()
+    one_x_one_p[1, :t2] = tf.squeeze(p2, 0).numpy()
+
+    np.testing.assert_allclose(one_x_one_p, batched_p.numpy(), rtol=1e-6)
+    np.testing.assert_allclose(one_x_one_s.numpy(), batched_s.numpy(), rtol=1e-6)
+
+
+def test_decode_shape(generate_batch):
+    unary, _, lengths = generate_batch
+    crf, trans = make_crf(unary)
+
+    paths, scores = crf.decode(unary, lengths)
+
+    b, t, *_ = get_shape_as_list(unary)
+    assert scores.shape == (b,)
+    assert paths.shape == (b, t)
+
+
+def test_viterbi_scores_equal_score_sentence(generate_batch):
+    unary, _, lengths = generate_batch
+    crf, trans = make_crf(unary)
+
+    p, viterbi_scores = crf.decode(unary, lengths)
+    gold_scores = crf.score_sentence(unary, p, lengths)
+
+    np.testing.assert_allclose(viterbi_scores.numpy(), gold_scores.numpy(), rtol=1e-6)
+
+
+def test_viterbi_degrates_to_argmax(generate_batch):
+    unary, _, lengths = generate_batch
+
+    crf, trans = make_crf(unary, zero_trans=True)
+
+    path, score = crf.decode(unary, lengths)
+
+    gold_path = tf.argmax(unary, axis=-1).numpy()
+    gold_score = tf.reduce_max(unary, axis=-1).numpy()
+
+    for i, l in enumerate(lengths):
+        gold_path[i, l:] = 0
+        gold_score[i, l:] = 0
+
+    gold_score = np.sum(gold_score, 1)
+
+    np.testing.assert_allclose(path.numpy(), gold_path)
+    np.testing.assert_allclose(score.numpy(), gold_score, rtol=1e-6)
+
+
+def test_add_states_to_tags():
+    B = np.random.randint(5, 11)
+    T = np.random.randint(12, 22)
+    H = np.random.randint(23, 45)
+    lengths = np.random.randint(1, T, size=(B,)).astype(np.int32)
+    lengths[np.random.randint(0, B, size=(B // 2,))] = T
+
+    tags = np.random.randint(1, H, size=(B, T))
+
+    for t, l in zip(tags, lengths):
+        t[l:] = 0
+
+    g_tags = []
+    for t, l in zip(tags, lengths):
+        g_tags.append(np.array([Offsets.GO] + t[:l].tolist() + [Offsets.EOS]))
+
+    gold_tags = np.zeros((B, T + 2), dtype=np.int32)
+
+    for i, g in enumerate(g_tags):
+        gold_tags[i, :len(g)] = g
+
+    tags = StructuredTaggerDecoder._add_states_to_tags(tags, lengths)
+
+    np.testing.assert_allclose(tags.numpy(), gold_tags)
+
+
+def test_add_states_to_unary():
+    B = np.random.randint(5, 11)
+    T = np.random.randint(12, 22)
+    H = np.random.randint(23, 45)
+    lengths = np.random.randint(1, T, size=(B,)).astype(np.int32)
+    lengths[np.random.randint(0, B, size=(B // 2,))] = T
+
+    unary = np.random.rand(B, T, H).astype(np.float32)
+
+    for u, l in zip(unary, lengths):
+        u[l:, :] = 0
+
+    us = []
+    start = np.full((1, H), -1e4)
+    start[:, Offsets.GO] = 0
+    end = np.full((1, H), -1e4)
+    end[:, Offsets.EOS] = 0
+    for u, l in zip(unary, lengths):
+        us.append(np.concatenate([start, u[:l], end], axis=0))
+
+    gold_unary = np.zeros((B, T + 2, H))
+    for i, g in enumerate(us):
+        gold_unary[i, :len(g), :] = g
+
+    unary = StructuredTaggerDecoder._add_states_to_unary(unary, lengths)
+
+    np.testing.assert_allclose(unary.numpy(), gold_unary)

--- a/tests/utils/tagger_decode_utils.py
+++ b/tests/utils/tagger_decode_utils.py
@@ -1,0 +1,179 @@
+import math
+from operator import itemgetter
+import numpy as np
+
+
+def generate_batch(B=None, T=None, H=None):
+    B = np.random.randint(5, 11) if B is None else B
+    T = np.random.randint(15, 21) if T is None else T
+    H = np.random.randint(22, 41) if H is None else H
+    scores = np.random.rand(B, T, H).astype(np.float32)
+    tags = np.random.randint(1, H, size=(B, T)).astype(np.int64)
+    lengths = np.random.randint(1, T, size=(B,)).astype(np.int64)
+    lengths[np.random.randint(0, B, size=(B // 2,))] = T
+    for s, t, l in zip(scores, tags, lengths):
+        s[l:] = 0
+        t[l:] = 0
+    return scores, tags, lengths
+
+
+def generate_examples_and_batch(T=None, H=None, diff=None):
+    T = np.random.randint(15, 21) if T is None else T
+    H = np.random.randint(22, 41) if H is None else H
+    diff = np.random.randint(1, T // 2) if diff is None else diff
+
+    item1 = np.random.rand(1, T, H).astype(np.float32)
+    tags1 = np.random.randint(1, H, (1, T)).astype(np.int64)
+
+    item2 = np.random.rand(1, T - diff, H).astype(np.float32)
+    tags2 = np.random.randint(1, H, (1, T - diff)).astype(np.int64)
+
+    packed_item = np.zeros((2, T, H), dtype=np.float32)
+    packed_tags = np.zeros((2, T), dtype=np.int64)
+    packed_item[0, :, :] = np.squeeze(item1, 0)
+    packed_item[1, :T - diff, :] = np.squeeze(item2, 0)
+    packed_tags[0, :] = np.squeeze(tags1, 0)
+    packed_tags[1, :T - diff] = np.squeeze(tags2, 0)
+    lengths = np.array([T, T - diff])
+    return item1, tags1, np.array([T]), item2, tags2, np.array([T - diff]), packed_item, packed_tags, lengths
+
+
+def explicit_log_sum_exp(xs):
+    """Log Sum Exp on a dict of values."""
+    max_x = max(xs.values())
+    total = 0
+    for x in xs.values():
+        total += math.exp(x - max_x)
+    return max_x + math.log(total)
+
+
+def explicit_sum(xs):
+    return sum(xs.values())
+
+
+def explicit_score_gold(emiss, trans, golds, start, end):
+    score = 0
+    for e, g in zip(emiss, golds):
+        score += e[g]
+    for i in range(len(golds)):
+        from_ = start if i == 0 else golds[i - 1]
+        to = golds[i]
+        score += trans[(from_, to)]
+    score += trans[(golds[-1], end)]
+    return score
+
+
+def explicit_forward(emiss, trans, start, end, reduction=explicit_log_sum_exp):
+    """Best path through a lattice on the log semiring with explicit looping."""
+    trellises = []
+    trellis = dict.fromkeys(emiss[0].keys(), -1e4)
+    trellis[start] = 0
+
+    for e in emiss:
+        new_trellis = {}
+        for next_state in trellis:
+            score = {}
+            for prev_state in trellis:
+                score[prev_state] = trellis[prev_state] + e[next_state] + trans[(prev_state, next_state)]
+            new_trellis[next_state] = reduction(score)
+        trellis = new_trellis
+        trellises.append(trellis)
+    trellis = {state: trellis[state] + trans[(state, end)] for state in trellis}
+    return reduction(trellis), trellises
+
+
+def explicit_backward(emiss, trans, start, end, reduction=explicit_log_sum_exp):
+    new_trans = {(j, i): v for (i, j), v in trans.items()}
+    scores, states = explicit_forward(emiss[::-1], new_trans, end, start, reduction)
+    return scores, states[::-1]
+
+
+def explicit_posterior(emiss, trans, start, end, reduction=explicit_log_sum_exp):
+    fwd = explicit_forward(emiss, trans, start, end, reduction)[1]
+    bwd = explicit_backward(emiss, trans, start, end, reduction)[1]
+    joint = []
+    for f, b in zip(fwd, bwd):
+        joint.append({s: f[s] + b[s] for s in range(len(f))})
+    conditional = [{s: j[s] / sum(j.values()) for s in j} for j in joint]
+    return conditional
+
+
+def explicit_posterior_decode(emiss, trans, start, end, reduction=explicit_log_sum_exp):
+    posteriors = explicit_posterior(emiss, trans, start, end, reduction)
+    scores, tags = [], []
+    for posterior in posteriors:
+        tag, score = max(posterior.items(), key=itemgetter(1))
+        scores.append(score)
+        tags.append(tag)
+    return tags, sum(scores)
+
+
+def explicit_trellises_to_dense(trellises):
+    return np.stack([explicit_trellis_to_dense(t) for t in trellises])
+
+def explicit_trellis_to_dense(trellis):
+    return np.array([trellis[s] for s in range(len(trellis))])
+
+
+def explicit_nll(emiss, trans, golds, start, end, reduction=explicit_log_sum_exp):
+    f = explicit_forward(emiss, trans, start, end, reduction)[0]
+    g = explicit_score_gold(emiss, trans, golds, start, end)
+    return f - g
+
+
+def explicit_viterbi(emiss, trans, start, end):
+    """Best path through a lattice on the viterbi semiring with explicit looping."""
+    backpointers = []
+    trellis = dict.fromkeys(emiss[0].keys(), -1e4)
+    trellis[start] = 0
+
+    for e in emiss:
+        new_trellis = {}
+        backpointer = {}
+        for next_state in trellis:
+            score = {}
+            for prev_state in trellis:
+                score[prev_state] = trellis[prev_state] + e[next_state] + trans[(prev_state, next_state)]
+            new_trellis[next_state] = max(score.values())
+            backpointer[next_state] = max(score, key=lambda x: score[x])  # argmax
+        trellis = new_trellis
+        backpointers.append(backpointer)
+    for state in trellis:
+        trellis[state] += trans[(state, end)]
+    score = max(trellis.values())
+    state = max(trellis, key=lambda x: trellis[x])
+    states = [state]
+    for t in reversed(range(0, len(emiss))):
+        states.append(backpointers[t][states[-1]])
+    return list(reversed(states[:-1])), score
+
+
+def build_trans(t):
+    """Convert the transition tensor to a dict.
+
+    :param t: `torch.FloatTensor` [H, H]: transition scores in the
+        form [to, from]
+
+    :returns: `dict` transition scores in the form [from, to]
+    """
+    trans = {}
+    for i in range(t.shape[0]):
+        for j in range(t.shape[0]):
+            trans[(i, j)] = t[j, i].item()
+    return trans
+
+
+def build_emission(emission):
+    """Convert the emission scores into a list of dicts
+
+    :param emission: `torch.FloatTensor` [T, H]: emission scores
+
+    :returns: `List[dict]`
+    """
+    es = []
+    for emiss in emission:
+        e_ = {}
+        for i in range(emiss.shape[0]):
+            e_[i] = emiss[i].item()
+        es.append(e_)
+    return es


### PR DESCRIPTION
This PR updates the API for the tagger decoders. There is still some more work to do but I wanted to get comments on it earlier rather than later.

 * It creates a separation between taggers that do structured prediction vs locally normalized models.
 * It adds to the decoder API to:
    * get normalization factor at each timestep
    * get the normalization factor going backwards
    * Get the posterior distribution from the taggers
    * Decode based on the posterior
 * It adds a lot of tests
    * Adds tf2 tests for the tagger decoders
    * Adds more batch stability tests to the pytorch decoder
    * Add tests that compare the computed values between the tf/pyt version and explicit python code
 * It also sets the `EOS` tag at the end of the unary/tags for tensorflow so that we don't output illegal tags at the end of the sequence (`B-X` at the end, etc.)

This doesn't touch the main path though the code (the partition function and the viterbi decoder) so I don't think is should a big burden to merge.

There are still a few things to do before merging.

- [ ] Add the partition functions to the tensorflow `ConstrainedGreedyTaggerDecoder`
- [ ] Add pytorch tests for the constrained decoder taggers
- [ ] Add test for tf1
- [ ] Add tensorflow tests for the constrained decoder taggers
- [ ] Add pytorch tests for normal greedy decoder (score sentence, etc)
- [ ] Add tensorflow tests for normal greedy decoder (score sentence, etc)