### PR TITLE
chore: mead can order hours and minutes if need be

### DIFF
--- a/mead/utils.py
+++ b/mead/utils.py
@@ -17,7 +17,18 @@ export = exporter(__all__)
 logger = logging.getLogger('mead')
 
 
-KNOWN_FMTS = ['%Y%m%d', '%Y-%m-%d', '%Y/%m/%d', '%Y', '%Y%m', '%Y-%m', '%Y/%m', '%Y%m%d_%H%M', '%Y-%m-%d_%H-%M', '%Y/%m/%d_%M/%H']
+KNOWN_DATE_FMTS = [
+    '%Y%m%d',
+    '%Y-%m-%d',
+    '%Y/%m/%d',
+    '%Y',
+    '%Y%m',
+    '%Y-%m',
+    '%Y/%m',
+    '%Y%m%d_%H%M',
+    '%Y-%m-%d_%H-%M',
+    '%Y/%m/%d_%M/%H'
+]
 
 
 @export
@@ -79,8 +90,8 @@ def read_config_file_or_json(config, name=''):
     raise Exception('Expected {} config file or a JSON object.'.format(name))
 
 
-def parse_date(s, known_fmts: List[str] = KNOWN_FMTS):
-    for fmt in KNOWN_FMTS:
+def parse_date(s, known_fmts: List[str] = KNOWN_DATE_FMTS):
+    for fmt in known_fmts:
         try:
             dt = datetime.strptime(s, fmt)
             return dt

--- a/mead/utils.py
+++ b/mead/utils.py
@@ -4,6 +4,7 @@ import shutil
 import logging
 import logging.config
 import hashlib
+from typing import List
 from datetime import datetime
 import argparse
 from copy import deepcopy
@@ -14,6 +15,9 @@ from baseline.utils import exporter, str2bool, read_config_file, write_json, get
 __all__ = []
 export = exporter(__all__)
 logger = logging.getLogger('mead')
+
+
+KNOWN_FMTS = ['%Y%m%d', '%Y-%m-%d', '%Y/%m/%d', '%Y', '%Y%m', '%Y-%m', '%Y/%m', '%Y%m%d_%H%M', '%Y-%m-%d_%H-%M', '%Y/%m/%d_%M/%H']
 
 
 @export
@@ -75,8 +79,7 @@ def read_config_file_or_json(config, name=''):
     raise Exception('Expected {} config file or a JSON object.'.format(name))
 
 
-def parse_date(s):
-    KNOWN_FMTS = ['%Y%m%d', '%Y-%m-%d', '%Y/%m/%d', '%Y', '%Y%m', '%Y-%m', '%Y/%m']
+def parse_date(s, known_fmts: List[str] = KNOWN_FMTS):
     for fmt in KNOWN_FMTS:
         try:
             dt = datetime.strptime(s, fmt)

--- a/tests/test_mead_utils.py
+++ b/tests/test_mead_utils.py
@@ -399,6 +399,20 @@ def test_dataset_formats():
         pass
 
 
+def test_dataset_formats_with_hours():
+    keys = {
+        '1:20200312': 2,
+        '1:20200312_0545': 3,
+    }
+    assert get_dataset_from_key('1', keys) == 3
+    keys['1:20200312_0435'] = 4
+    assert get_dataset_from_key('1', keys) == 3
+    keys['1:20200313'] = 5
+    assert get_dataset_from_key('1', keys) == 5
+    keys['1:2020-03-13_23-12'] = 6
+    assert get_dataset_from_key('1', keys) == 6
+
+
 def test_dataset_hard_match():
     """Test that we only match datasets that are exact match % date, ignore ones that have extra before or after."""
     keys = {


### PR DESCRIPTION
This PR lets the mead dataset finder parse datasets that have hour and minute time stamps too. When there is a date with no hour/minutes then the datetime for those defaults to 00 and 00 which means that a new one with the hours/minutes would be returned because it is later in time which seems like the right behavior