### PR TITLE
update the ONNX tagger

### DIFF
--- a/mead/exporters.py
+++ b/mead/exporters.py
@@ -25,7 +25,8 @@ class Exporter(object):
             output_dir,
             project=project,
             name=name,
-            model_version=model_version
+            model_version=model_version,
+            **kwargs
         )
         if model_version is None:
             try:

--- a/mead/pytorch/exporters.py
+++ b/mead/pytorch/exporters.py
@@ -153,9 +153,8 @@ class TaggerPytorchONNXExporter(PytorchONNXExporter):
         self.sig_name = 'tag_text'
 
     def apply_model_patches(self, model):
-        if hasattr(model, 'layers'):
-            if hasattr(model.layers, 'decoder_model'):
-                if isinstance(model.layers.decoder_model, CRF):
-                    model.layers.decoder_model.viterbi = ViterbiBatchSize1(model.layers.decoder_model.viterbi.start_idx,
-                                                                           model.layers.decoder_model.viterbi.end_idx)
+        if hasattr(model, 'decoder'):
+            if isinstance(model.decoder, CRF):
+                model.decoder.viterbi = ViterbiBatchSize1(model.decoder.viterbi.start_idx,
+                                                          model.decoder.viterbi.end_idx)
         return model


### PR DESCRIPTION
This fixes the tagger monkey patching which was broken when the sub-layers were eliminated from the models.  It also adds documentation on how to export ONNX models and run them using the API examples