### PR TITLE
Fix/convert model

### DIFF
--- a/api-examples/response-selection.py
+++ b/api-examples/response-selection.py
@@ -1,0 +1,102 @@
+import argparse
+import os
+from transformer_utils import *
+from baseline.pytorch.lm import TransformerLanguageModel
+from baseline.progress import create_progress_bar
+from baseline.utils import str2bool
+from torch.utils.data import DataLoader
+import logging
+logger = logging.getLogger("baseline")
+
+
+parser = argparse.ArgumentParser("Load a dual-encoder model (conveRT) and do response selection on testing data")
+parser.add_argument("--d_model", type=int, default=512, help="Model dimension (and embedding dsz)")
+parser.add_argument("--d_ff", type=int, default=2048, help="FFN dimension")
+parser.add_argument("--d_k", type=int, default=None, help="Dimension per head.  Use if num_heads=1 to reduce dims")
+parser.add_argument("--num_heads", type=int, default=8, help="Number of heads")
+parser.add_argument("--num_ft_workers", type=int, default=4, help="Number train workers")
+parser.add_argument("--num_test_workers", type=int, default=2, help="Number valid workers")
+parser.add_argument("--num_layers", type=int, default=6, help="Number of layers")
+parser.add_argument("--nctx", type=int, default=64, help="Max context length (for both encoder and decoder)")
+parser.add_argument("--embed_type", type=str, default='positional',
+                    help="register label of the embeddings, so far support positional or learned-positional")
+parser.add_argument("--stacking_layers", type=int, nargs='+', default=[1024, 1024, 1024])
+parser.add_argument('--rpr_k', help='Relative attention positional sizes pass 0 if you dont want relative attention',
+                    type=int, default=[3, 5, 48, 48, 48, 48], nargs='+')
+parser.add_argument("--reduction_d_k", type=int, default=64, help="Dimensions of Key and Query in the single headed"
+                                                                  "reduction layers")
+parser.add_argument("--ckpt", type=str, help="path to the model checkpoint")
+parser.add_argument("--test_file", type=str, help="path to the testing data")
+parser.add_argument("--subword_model_file", type=str, required=True)
+parser.add_argument("--subword_vocab_file", type=str, required=True)
+parser.add_argument("--recall_k", type=int, default=100, help="select the response from how many candidates")
+parser.add_argument("--recall_top", type=int, default=1, help="whether the correct response is ranked top x")
+parser.add_argument("--device", type=str,
+                    default="cuda" if torch.cuda.is_available() else "cpu",
+                    help="Device (cuda or cpu)")
+args = parser.parse_args()
+
+reader = MultiFileDatasetReader(args.nctx, args.subword_model_file, args.subword_vocab_file, '*.txt', 'ntp')
+vocab = reader.build_vocab()
+
+preproc_data = baseline.embeddings.load_embeddings('x', dsz=args.d_model, known_vocab=vocab['x'], embed_type=args.embed_type)
+vocabs = preproc_data['vocab']
+embeddings = preproc_data['embeddings']
+logger.info("Loaded embeddings")
+
+test_set = reader.load(args.test_file, vocabs)
+ind2tok = {ind: tok for tok, ind in vocabs.items()}
+
+# use other samples in a batch as negative samples. Don't shuffle to compare with conveRT benchmarks
+test_loader = DataLoader(test_set, batch_size=args.recall_k, num_workers=args.num_test_workers)
+logger.info("Loaded datasets")
+
+model = create_model(embeddings,
+                     model_type='dual-encoder',
+                     d_model=args.d_model,
+                     d_ff=args.d_ff,
+                     num_heads=args.num_heads,
+                     num_layers=args.num_layers,
+                     stacking_layers=args.stacking_layers,
+                     dropout=0.,
+                     rpr_k=args.rpr_k,
+                     d_k=args.d_k,
+                     reduction_d_k=args.reduction_d_k,
+                     ff_pdrop=0.,
+                     logger=logger)
+
+if os.path.isdir(args.ckpt):
+    checkpoint = find_latest_checkpoint(args.ckpt)
+    logger.warning("Found latest checkpoint %s", checkpoint)
+else:
+    checkpoint = args.ckpt
+model.load_state_dict(torch.load(checkpoint, map_location=torch.device('cpu')))
+model.to(args.device)
+
+numerator = 0
+denominator = 0
+model.eval()
+pg = create_progress_bar(len(test_loader)//args.recall_k)
+for batch in test_loader:
+    if batch[0].shape[0] != args.recall_k:
+        break
+    with torch.no_grad():
+        x, y = batch
+        inputs = x.to(args.device)
+        targets = y.to(args.device)
+        query = model.encode_query(inputs).unsqueeze(1)  # [B, 1, H]
+        response = model.encode_response(targets).unsqueeze(0)  # [1, B, H]
+        all_score = nn.CosineSimilarity(dim=-1)(query, response).to('cpu')
+
+        _, indices = torch.topk(all_score, args.recall_top, dim=1)
+        correct = (indices == torch.arange(args.recall_k).unsqueeze(1).expand(-1, args.recall_top)).sum()
+        numerator += correct
+        print(f"Selected {correct} correct responses out of {args.recall_k}")
+        denominator += args.recall_k
+    pg.update()
+pg.done()
+acc = float(numerator)/denominator
+
+print(f"{args.recall_top}@{args.recall_k} acc: {acc}")
+with open('./results.txt', 'a') as wf:
+    wf.write(f"Checkpoint: {checkpoint}; {args.recall_top}@{args.recall_k} accuracy: {acc}\n")

--- a/baseline/pytorch/embeddings.py
+++ b/baseline/pytorch/embeddings.py
@@ -208,11 +208,15 @@ def _identity(x):
     return x
 
 
-def _mean_pool(_, embeddings):
+def _mean_pool(inputs, embeddings):
+    mask = (inputs != 0)
+    embeddings = embeddings * mask.unsqueeze(-1)
     return torch.mean(embeddings, 1, False)
 
 
-def _max_pool(_, embeddings):
+def _max_pool(inputs, embeddings):
+    mask = (inputs != 0)
+    embeddings = embeddings * mask.unsqueeze(-1)
     return torch.max(embeddings, 1, False)[0]
 
 
@@ -233,8 +237,10 @@ class TransformerLMPooledEmbeddingsModel(TransformerLMEmbeddingsModel):
             self.pooling_op = self._cls_pool
 
     def _sqrt_length_pool(self, inputs, embeddings):
-        lengths = (inputs != 0).sum(1)
+        mask = (inputs != 0)
+        lengths = mask.sum(1)
         sqrt_length = lengths.float().sqrt().unsqueeze(1)
+        embeddings = embeddings * mask.unsqueeze(-1)
         embeddings = embeddings.sum(1) / sqrt_length
         return embeddings
 

--- a/layers/eight_mile/pytorch/layers.py
+++ b/layers/eight_mile/pytorch/layers.py
@@ -1634,6 +1634,7 @@ class EmbeddingsStack(nn.Module):
         for k, v in zip(self.keys(), self.embeddings):
             yield k, v
 
+
 class DenseStack(nn.Module):
     """A stack of one or more hidden layers
     """
@@ -1642,9 +1643,11 @@ class DenseStack(nn.Module):
         self,
         insz: int,
         hsz: Union[int, List[int]],
-        activation: str = "relu",
+        activation: Union[str, List[str]] = "relu",
         pdrop_value: float = 0.5,
         init=None,
+        skip_connect=False,
+        layer_norm=False,
         **kwargs,
     ):
         """Stack 1 or more hidden layers, optionally (forming an MLP)
@@ -1654,15 +1657,28 @@ class DenseStack(nn.Module):
         :param activation: The name of the activation function to use
         :param pdrop_value: The dropout probability
         :param init: The initializer
+        :param skip_connect: whether use skip connection when insz is equal to outsz for a layer
+        :param layer_norm: whether use layer norm in each layer
 
         """
         super().__init__()
         hszs = listify(hsz)
         self.output_dim = hsz[-1]
+        activations = listify(activation)
+        if len(activations) == 1:
+            activations = activations * len(hszs)
+        if len(activations) != len(hszs):
+            raise ValueError("Number of activations must match number of hidden sizes in a stack!")
         current = insz
         layer_stack = []
-        for hsz in hszs:
-            layer_stack.append(WithDropout(Dense(current, hsz, activation=activation), pdrop_value))
+        for hsz, activation in zip(hszs, activations):
+            if skip_connect and current == hsz:
+                layer = SkipConnection(current, activation)
+            else:
+                layer = Dense(current, hsz, activation)
+            if layer_norm:
+                layer = nn.Sequential(layer, nn.LayerNorm(hsz, eps=1e-6))
+            layer_stack.append(WithDropout(layer, pdrop_value))
             current = hsz
         self.layer_stack = nn.Sequential(*layer_stack)
         self.requires_length = False
@@ -1677,10 +1693,7 @@ class DenseStack(nn.Module):
 
         :return: The final layer
         """
-        x = inputs
-        for layer in self.layer_stack:
-            x = layer(x)
-        return x
+        return self.layer_stack(inputs)
 
 
 class VectorSequenceAttention(nn.Module):
@@ -3331,3 +3344,62 @@ class Average(object):
     def __str__(self):
         fmtstr = '{name} {val' + self.fmt + '} ({avg' + self.fmt + '})'
         return fmtstr.format(**self.__dict__)
+
+
+class SingleHeadReduction(nn.Module):
+    """
+    Implementation of the "self_attention_head" layer from the conveRT paper (https://arxiv.org/pdf/1911.03688.pdf)
+    """
+    def __init__(
+            self, d_model: int, dropout: float = 0.0, scale: bool = True, d_k: Optional[int] = None
+    ):
+        """
+        :param d_model: The model hidden size
+        :param dropout (``float``): The amount of dropout to use
+        :param scale: should we scale the dot product attention
+        :param d_k: The low-order project per head.  This is normally `d_model // num_heads` unless set explicitly
+        """
+        super().__init__()
+        self.d_model = d_model
+        if d_k is None:
+            self.d_k = d_model
+        else:
+            self.d_k = d_k
+        self.w_Q = Dense(d_model, self.d_k)
+        self.w_K = Dense(d_model, self.d_k)
+        if scale:
+            self.attn_fn = SeqScaledDotProductAttention(dropout)
+        else:
+            self.attn_fn = SeqDotProductAttention(dropout)
+        self.attn = None
+
+    def forward(self, qkvm: Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]) -> torch.Tensor:
+        """According to conveRT model's graph, they project token encodings to lower-dimensional query and key in single
+        head, use them to calculate the attention score matrix that has dim [B, T, T], then sum over the query dim to
+        get a tensor with [B, 1, T] (meaning the amount of attentions each token gets from all other tokens), scale it
+        by sqrt of sequence lengths, then use it as the weight to weighted sum the token encoding to get the sentence
+        encoding. we implement it in an equivalent way that can best make use of the eight_mile codes: do the matrix
+        multiply with value first, then sum over the query dimension.
+        :param query: a query for alignment. Can come from self in case of self-attn or decoder in case of E/D
+        :param key: a set of keys from encoder or self
+        :param value: a set of values from encoder or self
+        :param mask: masking (for destination) to prevent seeing what we shouldnt
+        :return: sentence-level encoding with dim [B, d_model]
+        """
+        query, key, value, mask = qkvm
+        batchsz = query.size(0)
+        seq_mask = mask.squeeze()  # [B, T]
+        seq_lengths = seq_mask.sum(dim=1)
+
+        # (B, H, T, D), still have num_heads = 1 to use the attention function defined in eight_miles
+        query = self.w_Q(query).view(batchsz, -1, 1, self.d_k).transpose(1, 2)
+        key = self.w_K(key).view(batchsz, -1, 1, self.d_k).transpose(1, 2)
+        value = value.view(batchsz, -1, 1, self.d_model).transpose(1, 2)
+        x = self.attn_fn((query, key, value, mask))  # [B, 1, T, D]
+        self.attn = self.attn_fn.attn
+
+        x = x.squeeze(1)  # [B, T, D]
+        x = x * seq_mask.unsqueeze(-1)
+        x = x.sum(dim=1)  # [B, D]
+        x = x * seq_lengths.float().sqrt().unsqueeze(-1)
+        return x

--- a/layers/eight_mile/pytorch/layers.py
+++ b/layers/eight_mile/pytorch/layers.py
@@ -1671,13 +1671,15 @@ class DenseStack(nn.Module):
             raise ValueError("Number of activations must match number of hidden sizes in a stack!")
         current = insz
         layer_stack = []
+        if layer_norm:
+            layer_norm_eps = kwargs.get('layer_norm_eps', 1e-6)
         for hsz, activation in zip(hszs, activations):
             if skip_connect and current == hsz:
                 layer = SkipConnection(current, activation)
             else:
                 layer = Dense(current, hsz, activation)
             if layer_norm:
-                layer = nn.Sequential(layer, nn.LayerNorm(hsz, eps=1e-6))
+                layer = nn.Sequential(layer, nn.LayerNorm(hsz, eps=layer_norm_eps))
             layer_stack.append(WithDropout(layer, pdrop_value))
             current = hsz
         self.layer_stack = nn.Sequential(*layer_stack)


### PR DESCRIPTION
Changes based on our discussion:
- Add skip connection and layer norm as options to DenseStack; activation can be a list. For both pytorch and tf. 
- Move `create_model` to `transformer_utils.py`. Keep the name since it also creates seq2seq model.
- Put `SingleHeadReduction` in eight mile layers, considering it's a fancy pooling and might be useful somewhere else. 
- `response-selection.py` only works for dual-encoder model right now for simplicity. 

Changes slightly different from our discussion:
- Keep `TwoHeadConcat` in `transformer_utils.py` since it's very specific to dual-encoder model. 
- Add a customized module `ConveRTFFN` to still implement the convert graph. Looking at it again, I think the convert graph does make some sense, though not compatible with the DenseStack we want. E.g. the reason of layer norms at both beginning and end is because the `final` layer doesn't have either activation or layer norm. And the "projecting skip-connection" adds two unnormalized tensor before going into the final layer norm. I don't want to make much changes to the model structure since I've been experimenting on it. 