### PR TITLE
Fix/bert ft onnx

### DIFF
--- a/baseline/pytorch/embeddings.py
+++ b/baseline/pytorch/embeddings.py
@@ -239,7 +239,12 @@ class TransformerLMPooledEmbeddingsModel(TransformerLMEmbeddingsModel):
         return embeddings
 
     def _cls_pool(self, inputs, tensor):
-        pooled = tensor[inputs == self.cls_index]
+        # Would prefer
+        # tensor[inputs == self.cls_index]
+        # but ONNX export fails
+        B = tensor.shape[0]
+        mask = (inputs == self.cls_index).unsqueeze(-1).expand_as(tensor)
+        pooled = tensor.masked_select(mask).view(B, -1)
         return pooled
 
     def get_output(self, inputs, z):

--- a/mead/pytorch/exporters.py
+++ b/mead/pytorch/exporters.py
@@ -57,10 +57,12 @@ def create_fake_data(shapes, vectorizers, order, min_=0, max_=50,):
 
 def create_data_dict(vocabs, vectorizers, transpose=False, min_=0, max_=50, default_size=100):
     data = {}
+    lengths = None
     for k, v in vectorizers.items():
-        data[k], lengths = vectorizers[k].run(FAKE_SENTENCE.split(), vocabs[k])
+        data[k], feature_length = vectorizers[k].run(FAKE_SENTENCE.split(), vocabs[k])
         data[k] = torch.LongTensor(data[k]).unsqueeze(0)
-        lengths = [lengths]
+        if not lengths:
+            lengths = [feature_length]
         # TODO: use the vectorizers, thats their job!!
         # data[k][0][0] = 101
 

--- a/mead/pytorch/exporters.py
+++ b/mead/pytorch/exporters.py
@@ -56,6 +56,8 @@ def create_data_dict(shapes, vectorizers, transpose=False, min_=0, max_=50, defa
     for k, v in vectorizers.items():
         dims = [d if d >= 0 else default_size for d in v.get_dims()]
         data[k] = torch.randint(min_, max_, [1, *dims])
+        # TODO: use the vectorizers, thats their job!!
+        # data[k][0][0] = 101
 
     lengths = torch.LongTensor([data[list(data.keys())[0]].shape[1]])
 


### PR DESCRIPTION
We were doing a boolean array indexing to find the `[CLS]` index which isnt supported by ONNX and causes and invalid model to be generated.

Also, we were using fake random number data to generate the tensors which means that tokens like `[CLS]` where unlikely to be generated.  The fix for this is to stop generating numbers and use fake sentence and run them through the vectorizers