### PR TITLE
fixes broken reload of modules on mead-hub.

### DIFF
--- a/api-examples/classify-text-onnx.py
+++ b/api-examples/classify-text-onnx.py
@@ -7,9 +7,10 @@ from baseline.utils import str2bool, read_json
 import numpy as np
 from collections import defaultdict
 import onnxruntime as ort
-from baseline.utils import unzip_files, find_model_basename, load_vectorizers, load_vocabs
+from baseline.utils import unzip_files, find_model_basename, load_vectorizers, load_vocabs, put_addons_in_path
 
-class ONNXClassifierService(object):
+
+class ONNXClassifierService:
 
     def __init__(self, vocabs=None, vectorizers=None, model=None, labels=None, lengths_key=None):
         self.vectorizers = vectorizers
@@ -125,10 +126,12 @@ parser.add_argument('--export_mapping', help='mapping between features and the f
                                                          'request, eg: token:word ner:ner. This should match with the '
                                                          '`exporter_field` definition in the mead config',
                     default=[], nargs='+')
+parser.add_argument("--addon_path", type=str, default=os.path.expanduser('~/.bl-data/addons'),
+                    help="Path or url of the dataset cache")
 args = parser.parse_args()
 
 
-
+put_addons_in_path(args.addon_path)
 if os.path.exists(args.text) and os.path.isfile(args.text):
     texts = []
     with open(args.text, 'r') as f:

--- a/api-examples/classify-text.py
+++ b/api-examples/classify-text.py
@@ -1,7 +1,7 @@
 import baseline as bl
 import argparse
 import os
-from baseline.utils import str2bool
+from baseline.utils import str2bool, put_addons_in_path
 
 parser = argparse.ArgumentParser(description='Classify text with a model')
 parser.add_argument('--model', help='The path to either the .zip file created by training or to the client bundle '
@@ -18,8 +18,12 @@ parser.add_argument('--batchsz', help='batch size when --text is a file', defaul
 parser.add_argument('--model_type', type=str, default='default')
 parser.add_argument('--modules', default=[])
 parser.add_argument('--prefer_eager', help="If running in TensorFlow, should we prefer eager model", type=str2bool, default=False)
+parser.add_argument("--addon_path", type=str, default=os.path.expanduser('~/.bl-data/addons'),
+                    help="Path or url of the dataset cache")
 
 args = parser.parse_args()
+
+put_addons_in_path(args.addon_path)
 
 if args.backend == 'tf':
     from eight_mile.tf.layers import set_tf_eager_mode

--- a/api-examples/ed-text.py
+++ b/api-examples/ed-text.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 import baseline as bl
 import argparse
 import os
-from baseline.utils import str2bool
+from baseline.utils import str2bool, put_addons_in_path
 
 parser = argparse.ArgumentParser(description='Encoder-Decoder execution')
 parser.add_argument('--model', help='An encoder-decoder model', required=True, type=str)
@@ -17,8 +17,11 @@ parser.add_argument('--device', help='device')
 parser.add_argument('--alpha', type=float, help='If set use in the gnmt length penalty.')
 parser.add_argument('--beam', type=int, default=30, help='The size of beam to use.')
 parser.add_argument('--prefer_eager', help="If running in TensorFlow, should we prefer eager model", type=str2bool)
-
+parser.add_argument("--addon_path", type=str, default=os.path.expanduser('~/.bl-data/addons'),
+                    help="Path or url of the dataset cache")
 args = parser.parse_known_args()[0]
+
+put_addons_in_path(args.addon_path)
 
 if args.backend == 'tf':
     from eight_mile.tf.layers import set_tf_eager_mode

--- a/api-examples/lm-text.py
+++ b/api-examples/lm-text.py
@@ -1,16 +1,19 @@
 import baseline as bl
 import argparse
 import os
-from baseline.utils import str2bool
+from baseline.utils import str2bool, put_addons_in_path
 parser = argparse.ArgumentParser(description='Classify text with a model')
 parser.add_argument('--model', help='A classifier model', required=True, type=str)
 parser.add_argument('--text', help='raw value', type=str)
 parser.add_argument('--device', help='device')
 parser.add_argument('--backend', help='backend', choices={'tf', 'pytorch'}, default='tf')
 parser.add_argument('--prefer_eager', help="If running in TensorFlow, should we prefer eager model", type=str2bool)
-
+parser.add_argument("--addon_path", type=str, default=os.path.expanduser('~/.bl-data/addons'),
+                    help="Path or url of the dataset cache")
 
 args = parser.parse_known_args()[0]
+
+put_addons_in_path(args.addon_path)
 
 if args.backend == 'tf':
     from eight_mile.tf.layers import set_tf_eager_mode

--- a/api-examples/tag-text-onnx.py
+++ b/api-examples/tag-text-onnx.py
@@ -4,7 +4,7 @@ import baseline as bl
 import numpy as np
 import argparse
 import os
-from baseline.utils import str2bool, read_conll, read_json, revlut
+from baseline.utils import str2bool, read_conll, read_json, revlut, put_addons_in_path
 import onnxruntime as ort
 from baseline.utils import unzip_files, find_model_basename, load_vectorizers, load_vocabs
 
@@ -124,8 +124,11 @@ parser.add_argument('--export_mapping', help='mapping between features and the f
                                                          'request, eg: token:word ner:ner. This should match with the '
                                                          '`exporter_field` definition in the mead config',
                     default=[], nargs='+')
+parser.add_argument("--addon_path", type=str, default=os.path.expanduser('~/.bl-data/addons'),
+                    help="Path or url of the dataset cache")
 args = parser.parse_args()
 
+put_addons_in_path(args.addon_path)
 
 def create_export_mapping(feature_map_strings):
     feature_map_strings = [x.strip() for x in feature_map_strings if x.strip()]

--- a/api-examples/tag-text.py
+++ b/api-examples/tag-text.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 import baseline as bl
 import argparse
 import os
-from baseline.utils import str2bool, read_conll
+from baseline.utils import str2bool, read_conll, put_addons_in_path
 
 
 parser = argparse.ArgumentParser(description='Tag text with a model')
@@ -23,8 +23,11 @@ parser.add_argument('--export_mapping', help='mapping between features and the f
                     default=[], nargs='+')
 parser.add_argument('--prefer_eager', help="If running in TensorFlow, should we prefer eager model", type=str2bool)
 parser.add_argument('--batchsz', default=64, help="How many examples to run through the model at once", type=int)
-
+parser.add_argument("--addon_path", type=str, default=os.path.expanduser('~/.bl-data/addons'),
+                    help="Path or url of the dataset cache")
 args = parser.parse_args()
+
+put_addons_in_path(args.addon_path)
 
 if args.backend == 'tf':
     from eight_mile.tf.layers import set_tf_eager_mode

--- a/baseline/utils.py
+++ b/baseline/utils.py
@@ -71,6 +71,14 @@ def import_user_module(module_name: str, data_download_cache: Optional[str] = No
     mod = importlib.import_module(module_name)
     return mod
 
+@export
+def put_addons_in_path(addons_dir: Optional[str] = None):
+    """Insert addons into the path"""
+    import sys
+    if not addons_dir:
+        addons_dir = os.path.expanduser("~/.bl-data/addons")
+    if os.path.exists(addons_dir):
+        idempotent_append(addons_dir, sys.path, 0)
 
 @export
 def normalize_backend(name: str) -> str:

--- a/docs/addons.md
+++ b/docs/addons.md
@@ -34,25 +34,17 @@ Only one issue remains -- how to know where to find user code.  Obviously we sho
 
 The answer is actually quite simple -- we tell MEAD what additional modules to import from the mead config.  Unlike previous versions where you needed some canonical file named something like `classify_rnf.py` (indicating this is a `classify` task handler named `rnf`), lets imagine we have a whole user-defined library of things living in a file called `userlib.py`.  We can simply tell mead, load `userlib.py`, and as long as we have a classifier registered to `rnf`, we can tell mead to use `model_type: rnf` as we did previously.
 
-### A Simple Example
+### Addons and mead-hub
 
-- [Here is a model](../python/addons/rnf_pyt.py) we want to train.  Its based off: https://github.com/bloomberg/cnn-rnf but I have rewritten it in PyTorch as a simple single class inheriting from `ClassifierModelBase` (just to remove some boilerplate code).
+Addons that live on mead-hub (or any other URL) can be downloaded and used for training automatically.  They are downloaded
+into the user's data-cache, which defaults to `~/.bl-data` and an entry will be recorded in the data-cache index which
+is located inside the data-cache in a file called `data-cache.json`.  The addons will be automatically added to the user's
+import path for training.  For example, the example [demolib module](https://github.com/mead-ml/hub/blob/master/v1/addons/demolib.py)
+can be referenced from the mead config as `hub:v1:addons:demolib` as in [this example](../mead/config/sst2-demolib.yml).
 
-Its defined as a simple class with a decorator that will register the class with Baseline.  The decorator tells Baseline that this class is going to handle any training instantion where the `model_type` given is 'rnf'.
+The library will download this path into the cache, usually at `~/.bl-data/addons/demolib.py`.
 
-- [Here is the config](../python/mead/config/sst2-rnf-pyt.yml) that can be used in MEAD to run train this model
-  - There are two points of interest
-    1. the `model_type` is defined as 'rnf'
-    2. the `modules` section (a list), tells us python modules to load into MEAD
+When we go to reload the model for inference, if the model was not already exported, we need the module in the path as well.
+To do this, we need to make sure to add a call to `put_addons_in_path('/path/to/.bl-data/addons')`.  This will
+place the addons at the beginning of the `sys.path` variable.
 
-- Now all I have to do is call `mead-train` (trainer.py)
-
-```
-python trainer.py --config config/sst2-rnf-pyt.yml
-```
-
-We can put our code in any python module that we wish -- for instance, we might have library of registered hooks for training, models and readers.  We can just tell mead about the library in the `modules` section, and then through proper decoration, they become available for training.  Here is an example of a module that customizes several aspects of training:
-  - https://github.com/dpressel/baseline/blob/feature/v1/python/addons/demolib.py
-And here is the corresponding YAML to run this in mead:
-
-  - https://github.com/dpressel/baseline/blob/feature/v1/python/mead/config/sst2-demolib.yml

--- a/layers/eight_mile/utils.py
+++ b/layers/eight_mile/utils.py
@@ -491,15 +491,19 @@ def ls_props(thing):
 
 
 @export
-def idempotent_append(element: Any, data: List[Any]) -> List[Any]:
+def idempotent_append(element: Any, data: List[Any], position: int=-1) -> List[Any]:
     """Append to a list if that element is not already in the list.
 
     :param element: The element to add to the list.
     :param data: `List` the list to add to.
+    :param position: An optional place to insert, defaults to the end
     :returns: `List` the list with the element in it.
     """
     if element not in data:
-        data.append(element)
+        if position < 0:
+            data.append(element)
+        else:
+            data.insert(position, element)
     return data
 
 
@@ -516,6 +520,7 @@ def parse_module_as_path(module_name):
     module_dir = os.path.realpath(os.path.expanduser(module_dir)) if module_dir else module_dir
     module_name, _ = os.path.splitext(module_name)
     return module_name, module_dir
+
 
 @export
 def fill_y(nc, yidx):


### PR DESCRIPTION
When we go to reload modules that were downloaded from mead-hub, we encounter the issues that they are not in the `sys.path`.  Since all addons from mead-hub go in the `~/.bl-data/addons` directory, we can solve this problem just by prepending to the path (we have to prepend because the CWD is usual on the front, which can cause issues if a model directory is in the path).

We have code currently in `import_user_module()` that brings in the installed `addons` path, but this is no longer the primary location where modules live.

This PR creates a function `put_addons_in_path()` and changes the API examples to make this call.
It also wouldve been possible to place this call right in `import_user_module` alongside the portion whee we add `addons`, but that feels like a bad side effect (in fact, I think we should change the current behavior of always adding this path).

This doesnt completely answer the question of what to do for inference on another machine, but presumably, the client code could do an upfront download of hub to addons to be safe.

We discussed other more complex ways of handling this via hub like keeping an index (although we already have that in `data-cache.json` and unless we store the source location in the model state, we wouldnt be able to recover it.

TBD how to handle where the training machine is different from
the inference machine