### PR TITLE
add a MEAD_HUB_MODULES global and persist to state

### DIFF
--- a/baseline/model.py
+++ b/baseline/model.py
@@ -130,6 +130,9 @@ def create_lang_model(embeddings, **kwargs):
 def load_model_for(activity, filename, **kwargs):
     # Sniff state to see if we need to import things
     state = read_json('{}.state'.format(filename))
+    if 'hub_modules' in state:
+        for hub_module in state['hub_modules']:
+            import_user_module(hub_module)
     # There won't be a module for pytorch (there is no state file to load).
     if 'module' in state:
         import_user_module(state['module'])

--- a/baseline/services.py
+++ b/baseline/services.py
@@ -120,7 +120,6 @@ class Service(object):
 
         model_basename = find_model_basename(directory)
         vocabs = load_vocabs(directory)
-        vectorizers = load_vectorizers(directory)
 
         be = normalize_backend(kwargs.get('backend', 'tf'))
 
@@ -135,6 +134,7 @@ class Service(object):
                 version=kwargs.get('version'),
                 remote_type=kwargs.get('remote_type'),
             )
+            vectorizers = load_vectorizers(directory)
             return cls(vocabs, vectorizers, model, preproc)
 
         # Currently nothing to do here
@@ -146,6 +146,7 @@ class Service(object):
         except:
             pass
         model = load_model_for(cls.task_name(), model_basename, **kwargs)
+        vectorizers = load_vectorizers(directory)
         return cls(vocabs, vectorizers, model, 'client')
 
     @staticmethod

--- a/baseline/tf/classify/model.py
+++ b/baseline/tf/classify/model.py
@@ -15,6 +15,7 @@ from baseline.utils import (
     read_json,
     write_json,
     MAGIC_VARS,
+    MEAD_HUB_MODULES
 )
 from baseline.model import ClassifierModel, register_model
 from baseline.tf.tfy import (
@@ -90,6 +91,7 @@ class ClassifierModelBase(tf.keras.Model, ClassifierModel):
             'module': self.__class__.__module__,
             'class': self.__class__.__name__,
             'embeddings': embeddings_info,
+            'hub_modules': MEAD_HUB_MODULES
         })
 
     def save(self, basename, **kwargs):

--- a/baseline/tf/embeddings.py
+++ b/baseline/tf/embeddings.py
@@ -4,6 +4,7 @@ from eight_mile.tf.embeddings import *
 from eight_mile.tf.serialize import load_tlm_npz
 from eight_mile.utils import read_json
 from baseline.vectorizers import load_bert_vocab
+from baseline.utils import MEAD_HUB_MODULES
 import tensorflow as tf
 
 
@@ -80,6 +81,7 @@ class TensorFlowEmbeddingsMixin(tf.keras.layers.Layer):
         config['vsz'] = int(self.get_vsz())
         config['module'] = self.__class__.__module__
         config['class'] = self.__class__.__name__
+        config['mead_hub_modules'] = MEAD_HUB_MODULES
         config.update(self._state)
         return config
 

--- a/baseline/tf/lm/training/eager.py
+++ b/baseline/tf/lm/training/eager.py
@@ -24,7 +24,7 @@ def loss_with_state(model, h, x, y):
 
 def loss_without_state(model, x, y):
     # Model will produce a null hidden state
-    logits = model(x)[0]
+    logits = model(x, None)[0]
     vsz = model.embeddings[model.tgt_key].get_vsz()
     targets = tf.reshape(y, [-1])
     bt_x_v = tf.nn.log_softmax(tf.reshape(logits, [-1, vsz]), axis=-1)

--- a/baseline/utils.py
+++ b/baseline/utils.py
@@ -29,18 +29,22 @@ logger = logging.getLogger('baseline')
 # These are inputs to models that shouldn't be saved out
 MAGIC_VARS = ['sess', 'tgt', 'y', 'lengths', 'gpus']
 MAGIC_VARS = ['sess', 'tgt', 'y', 'lengths']
-
-
+MEAD_HUB_MODULES = []
+DEFAULT_DATA_CACHE = os.path.expanduser('~/.bl-data')
 export = exporter(__all__)
 
 
 export(str2bool)
+
+@export
 @export
 def import_user_module(module_name: str, data_download_cache: Optional[str] = None):
     """Load a module that is in the python path
     :param model_name: (``str``) - the name of the module
     :return:
     """
+    if not data_download_cache and os.path.exists(DEFAULT_DATA_CACHE):
+        data_download_cache = DEFAULT_DATA_CACHE
     if data_download_cache:
         if module_name.startswith("hub:") or module_name.startswith("http"):
             if module_name.startswith("hub:"):
@@ -53,6 +57,7 @@ def import_user_module(module_name: str, data_download_cache: Optional[str] = No
                 if addons_literal != "addons":
                     raise Exception("We only support downloading addons right now")
                 module_name = f"http://raw.githubusercontent.com/mead-ml/hub/master/{version}/addons/{rest}"
+                MEAD_HUB_MODULES.append(module_name)
             module_name = AddonDownloader(module_name, data_download_cache, cache_ignore=True).download()
 
     # TODO: get rid of this!

--- a/docs/addons.md
+++ b/docs/addons.md
@@ -34,25 +34,16 @@ Only one issue remains -- how to know where to find user code.  Obviously we sho
 
 The answer is actually quite simple -- we tell MEAD what additional modules to import from the mead config.  Unlike previous versions where you needed some canonical file named something like `classify_rnf.py` (indicating this is a `classify` task handler named `rnf`), lets imagine we have a whole user-defined library of things living in a file called `userlib.py`.  We can simply tell mead, load `userlib.py`, and as long as we have a classifier registered to `rnf`, we can tell mead to use `model_type: rnf` as we did previously.
 
-### A Simple Example
+### Addons and mead-hub
 
-- [Here is a model](../python/addons/rnf_pyt.py) we want to train.  Its based off: https://github.com/bloomberg/cnn-rnf but I have rewritten it in PyTorch as a simple single class inheriting from `ClassifierModelBase` (just to remove some boilerplate code).
+Addons that live on mead-hub (or any other URL) can be downloaded and used for training automatically.  They are downloaded
+into the user's data-cache, which defaults to `~/.bl-data` and an entry will be recorded in the data-cache index which
+is located inside the data-cache in a file called `data-cache.json`.  The addons will be automatically added to the user's
+import path for training.  For example, the example [demolib module](https://github.com/mead-ml/hub/blob/master/v1/addons/demolib.py)
+can be referenced from the mead config as `hub:v1:addons:demolib` as in [this example](../mead/config/sst2-demolib.yml).
 
-Its defined as a simple class with a decorator that will register the class with Baseline.  The decorator tells Baseline that this class is going to handle any training instantion where the `model_type` given is 'rnf'.
+The library will download this path into the cache, usually at `~/.bl-data/addons/demolib.py` and it will add it to a field called `hub_modules`
+in the model (for TensorFlow, in PyTorch the entire module is persisted already). 
 
-- [Here is the config](../python/mead/config/sst2-rnf-pyt.yml) that can be used in MEAD to run train this model
-  - There are two points of interest
-    1. the `model_type` is defined as 'rnf'
-    2. the `modules` section (a list), tells us python modules to load into MEAD
+When we go to reload the model for inference, the module will automaticall be re-added to the data-cache if its not present ni the model.
 
-- Now all I have to do is call `mead-train` (trainer.py)
-
-```
-python trainer.py --config config/sst2-rnf-pyt.yml
-```
-
-We can put our code in any python module that we wish -- for instance, we might have library of registered hooks for training, models and readers.  We can just tell mead about the library in the `modules` section, and then through proper decoration, they become available for training.  Here is an example of a module that customizes several aspects of training:
-  - https://github.com/dpressel/baseline/blob/feature/v1/python/addons/demolib.py
-And here is the corresponding YAML to run this in mead:
-
-  - https://github.com/dpressel/baseline/blob/feature/v1/python/mead/config/sst2-demolib.yml


### PR DESCRIPTION
this modification adds a MEAD_HUB_MODULES variable into
baseline.utils and whenever a module is downloaded, it adds
the module.  When the state is recorded for embeddings or for
models, this is persisted, and when the model rehydrates,
it first downloads any hub modules that are persisted and not stored.

In PyTorch, this is not currently required as the full model is
persisted to the pytorch serialized state