### PR TITLE
chore: install mead-layers as dependency of mead-baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,15 @@ focus on model development, delegating the repetitive tasks to the library.
 ## Installation
 
 ### Pip
+
 Baseline can be installed as a Python package.
 
 `pip install mead-baseline`
+
+If you are using tensorflow 2 as your deep learning back end you will need to have
+`tensorflow_addons` already installed or have it get installed with mead via
+
+`pip install mead-baseline[tf2]`
 
 
 ### From the repository

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,7 @@ def main():
         install_requires=[
             'numpy',
             'six',
+            'mead-layers',
         ],
         extras_require={
             'test': ['pytest', 'mock', 'contextdecorator', 'pytest-forked'],


### PR DESCRIPTION
When installing baseline via pip we don't have access to eight mile rn