### PR TITLE
if we reload loaded mods we can get an error

### DIFF
--- a/baseline/utils.py
+++ b/baseline/utils.py
@@ -57,6 +57,9 @@ def import_user_module(module_name: str, data_download_cache: Optional[str] = No
                 if addons_literal != "addons":
                     raise Exception("We only support downloading addons right now")
                 module_name = f"http://raw.githubusercontent.com/mead-ml/hub/master/{version}/addons/{rest}"
+                if module_name in MEAD_HUB_MODULES:
+                    logger.warning(f"Skipping previously downloaded module: {module_name}")
+                    return None
                 MEAD_HUB_MODULES.append(module_name)
             module_name = AddonDownloader(module_name, data_download_cache, cache_ignore=True).download()
 


### PR DESCRIPTION
This change allows us to specify the same addon multiple times without having to reload it.  If we dont do this we would get an error the second time.  Its also inefficient to do an HTTP GET for the same module 2x.

Typically occurs if the vectorizer and the embeddings both refer to the same addon (like elmo).