### PR TITLE
this updates the snips example to work

### DIFF
--- a/mead/config/datasets.json
+++ b/mead/config/datasets.json
@@ -30,6 +30,13 @@
     "label": "AG"
   },
   {
+    "train_file": "train.conll",
+    "valid_file": "dev.conll",
+    "test_file": "test.conll",
+    "download": "https://www.dropbox.com/s/w5okrel68d8x4n4/snips.tar.gz?dl=1",
+    "label": "snips-conll"
+  },
+  {
     "train_file": "trec.nodev.utf8",
     "valid_file": "trec.dev.utf8",
     "test_file": "trec.test.utf8",

--- a/mead/config/snips.json
+++ b/mead/config/snips.json
@@ -8,7 +8,7 @@
     {
       "name": "word",
       "vectorizer": {
-        "type": "token1d",
+        "type": "dict1d",
         "transform": "baseline.lowercase"
       },
       "embeddings": {
@@ -18,7 +18,7 @@
     {
       "name": "senna",
       "vectorizer": {
-        "type": "token1d",
+        "type": "dict1d",
         "transform": "baseline.lowercase"
       },
       "embeddings": {
@@ -28,19 +28,20 @@
     {
       "name": "char",
       "vectorizer": {
-        "type": "char2d"
+        "type": "dict2d"
       },
       "embeddings": { "dsz": 30, "wsz": 30, "type": "char-conv" }
     }
   ],
   "preproc": {
   },
-  "backend": "pytorch",
-  "dataset": "snips",
-  "loader": {
-    "reader_type": "parallel",
-    "data_suffix": "in",
-    "tag_suffix": "out"
+  "dataset": "snips-conll",
+  "reader": {
+    "type": "default",
+    "named_fields": {
+      "0": "text",
+      "-1": "y"
+    }
   },
   "model": {
     "model_type": "default",


### PR DESCRIPTION
it phases out the reader that was for token1d info
which hasnt been maintained and switched it to be
like the others.  it depends on a new dataset called
`snips-conll`

fixes #597 