### PR TITLE
fixes #602 and parallel conv features

### DIFF
--- a/baseline/tf/lm/training/eager.py
+++ b/baseline/tf/lm/training/eager.py
@@ -13,7 +13,7 @@ from baseline.tf.lm.training.utils import to_tensors, SHUF_BUF_SZ, NUM_PREFETCH
 
 def loss_with_state(model, h, x, y):
     logits, h_out = model(x, h)
-    vsz = model.embeddings[model.tgt_key].get_vsz()
+    vsz = model.vsz
     targets = tf.reshape(y, [-1])
     bt_x_v = tf.nn.log_softmax(tf.reshape(logits, [-1, vsz]), axis=-1)
     one_hots = tf.one_hot(targets, vsz)
@@ -25,7 +25,7 @@ def loss_with_state(model, h, x, y):
 def loss_without_state(model, x, y):
     # Model will produce a null hidden state
     logits = model(x, None)[0]
-    vsz = model.embeddings[model.tgt_key].get_vsz()
+    vsz = model.vsz
     targets = tf.reshape(y, [-1])
     bt_x_v = tf.nn.log_softmax(tf.reshape(logits, [-1, vsz]), axis=-1)
     one_hots = tf.one_hot(targets, vsz)

--- a/layers/eight_mile/pytorch/layers.py
+++ b/layers/eight_mile/pytorch/layers.py
@@ -573,8 +573,8 @@ class Highway(nn.Module):
         :param input: Input tensor
         :return: output tensor
         """
-        proj_result = nn.functional.relu(self.proj(input))
-        proj_gate = nn.functional.sigmoid(self.transform(input))
+        proj_result = torch.relu(self.proj(input))
+        proj_gate = torch.sigmoid(self.transform(input))
         gated = (proj_gate * proj_result) + ((1 - proj_gate) * input)
         return gated
 

--- a/mead/config/ptb-kim-adam.yml
+++ b/mead/config/ptb-kim-adam.yml
@@ -1,0 +1,55 @@
+basedir: ptb-med
+task: lm
+backend: tensorflow
+dataset: ptb
+unif: 0.05
+preproc:
+  mxwlen: 50
+features:
+- name: x
+  vectorizer:
+    type: token1d
+  embeddings:
+    dsz: 512
+
+- name: xch
+  vectorizer:
+    type: char2d
+    mxwlen: 50
+  embeddings:
+    dsz: 16
+    type: "char-conv"
+    filtsz:
+    - [1, 32]
+    - [2, 32]
+    - [3, 64]
+    - [4, 128]
+    - [5, 256]
+    - [6, 512]
+    - [7, 1024]
+    gating: highway
+    num_gates: 2
+    cmotsz: 30
+
+reader:
+  reader_type: default
+  tgt_key: x
+  src_keys: xch
+  nbptt: 35
+
+model:
+  model_type: default
+  hsz: 512
+  skip_conn: 1
+  projsz: 512
+  layers: 1
+  pdrop: 0.5
+
+train:
+  epochs: 25
+  optim: adam
+  eta: 0.001
+  nsteps: 100
+  clip: 1.0
+  batchsz: 20
+ 


### PR DESCRIPTION
- adds a `vsz` field on LMs so they dont need to track
self.embeddings[tgt_key]
- adds an `embeddings` arg to `init_output` so
weight-tying still works
- fixes the TensorFlow impl of CharConvEmbeddings when there
are multiple filters specified.  This wasnt hit during
tagging because the default filters are length=3, not variable.
During testing of the Kim LM which uses multiple parallel
features, this issue was uncovered