### PR TITLE
fix: use checkout@v2 so we can rerun falied jobs

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -21,7 +21,7 @@ jobs:
         - 1.15.0
     container: tensorflow/tensorflow:${{matrix.tf-version}}-py3
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Install Baseline
       run: |
         cd layers
@@ -41,7 +41,7 @@ jobs:
         - 2.0.0
     container: tensorflow/tensorflow:${{matrix.tf-version}}-py3
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Install Baseline
       run: |
         cd layers
@@ -62,7 +62,7 @@ jobs:
         - 2.1.0
     container: tensorflow/tensorflow:${{matrix.tf-version}}-py3
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Install Baseline
       run: |
         cd layers
@@ -84,7 +84,7 @@ jobs:
         - 1.4-cuda10.1-cudnn7-runtime
     container: pytorch/pytorch:${{matrix.pyt-version}}
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Install Baseline
       run: |
         cd layers


### PR DESCRIPTION
There was a bug in v1 of the checkout action where re-running an action that was triggered by a PR would cause the checkout step of the new action to fail. This updates to v2 to where they fixed that bug