### PR TITLE
Fix/tlm ser

### DIFF
--- a/api-examples/generate-mlm.py
+++ b/api-examples/generate-mlm.py
@@ -6,6 +6,7 @@ import glob
 from argparse import ArgumentParser
 import baseline
 #from eight_mile.pytorch.layers import EmbeddingsStack
+from eight_mile.pytorch.serialize import tlm_load_state_dict
 from baseline.pytorch.lm import TransformerMaskedLanguageModel
 from baseline.utils import str2bool, read_json, Offsets, revlut
 from baseline.vectorizers import Token1DVectorizer, BPEVectorizer1D
@@ -67,7 +68,8 @@ def create_model(embeddings, d_model, d_ff, num_heads, num_layers, rpr_k, d_k, c
                                                   rpr_k=rpr_k,
                                                   d_k=d_k,
                                                   src_keys=['x'], tgt_key='x')
-    model.load_state_dict(torch.load(checkpoint_name))
+    tlm_load_state_dict(model, checkpoint_name)
+    #model.load_state_dict(torch.load(checkpoint_name))
     model.eval()
     print(model)
     return model

--- a/layers/eight_mile/pytorch/serialize.py
+++ b/layers/eight_mile/pytorch/serialize.py
@@ -82,6 +82,28 @@ def convert_transformers_keys(num_layers: int, d: Dict, replace_layer_map: Dict 
     return m
 
 
+def tlm_load_state_dict(module: nn.Module, checkpoint_file: str):
+    """
+
+    :param tlm: Safely loads the state dict for a transformer encoder
+    :param checkpoint_file: The file name
+    :return: None
+    """
+    from_str = 'transformer'
+    to_str = 'generator'
+    if hasattr(module, 'transformer'):
+        from_str = 'generator'
+        to_str = 'transformer'
+    ckpt_dict = torch.load(checkpoint_file)
+    renamed = {}
+    for k, v in ckpt_dict.items():
+        renamed[k.replace('generator', 'transformer')] = v
+    unmatch = module.load_state_dict(renamed, strict=False)
+    if unmatch.missing_keys or len(unmatch.unexpected_keys) > 2:
+        print("Warning: Embedding doesn't match with the checkpoint being loaded.")
+        print(f"missing keys: {unmatch.missing_keys}\n unexpected keys: {unmatch.unexpected_keys}")
+
+
 def to_weight_array(pytorch_layer: nn.Module, name: str) -> Dict:
     """Convert a {`LayerNorm`, `Linear`, `layers.Dense`} to `weights` and `bias` arrays
 


### PR DESCRIPTION
When we load TLMs, we have to make sure we have the right keys in the checkpoint.  This utility function checks what we have and makes sure it gets what it needs from the checkpoint by renaming keys as appropriate