### PR TITLE
support non-directory/non-zip checkpoint names

### DIFF
--- a/baseline/pytorch/torchy.py
+++ b/baseline/pytorch/torchy.py
@@ -85,29 +85,3 @@ def append2seq(seq, modules):
 
     for i, module in enumerate(modules):
         seq.add_module('%s-%d' % (str(module).replace('.', 'dot'), i), module)
-
-
-def tensor_max(tensor):
-    return tensor.max()
-
-
-def tensor_shape(tensor):
-    return tensor.size()
-
-
-def tensor_reverse_2nd(tensor):
-    idx = torch.LongTensor([i for i in range(tensor.size(1)-1, -1, -1)])
-    return tensor.index_select(1, idx)
-
-
-def long_0_tensor_alloc(dims, dtype=None):
-    lt = long_tensor_alloc(dims)
-    lt.zero_()
-    return lt
-
-
-def long_tensor_alloc(dims, dtype=None):
-    if type(dims) == int or len(dims) == 1:
-        return torch.LongTensor(dims)
-    return torch.LongTensor(*dims)
-

--- a/baseline/services.py
+++ b/baseline/services.py
@@ -123,7 +123,7 @@ class Service:
             directory = os.path.dirname(bundle)
             basehead = os.path.basename(bundle)
         model_basename = find_model_basename(directory, basehead)
-        suffix = model_basename.split('-')[-1]
+        suffix = model_basename.split('-')[-1] + ".json"
         vocabs = load_vocabs(directory, suffix)
 
         be = normalize_backend(kwargs.get('backend', 'tf'))

--- a/baseline/services.py
+++ b/baseline/services.py
@@ -113,13 +113,18 @@ class Service:
         :returns a Service implementation
         """
         # can delegate
+        basehead = None
+
         if os.path.isdir(bundle):
             directory = bundle
-        else:
+        elif os.path.isfile(bundle):
             directory = unzip_files(bundle)
-
-        model_basename = find_model_basename(directory)
-        vocabs = load_vocabs(directory)
+        else:
+            directory = os.path.dirname(bundle)
+            basehead = os.path.basename(bundle)
+        model_basename = find_model_basename(directory, basehead)
+        suffix = model_basename.split('-')[-1]
+        vocabs = load_vocabs(directory, suffix)
 
         be = normalize_backend(kwargs.get('backend', 'tf'))
 
@@ -279,6 +284,7 @@ class ONNXClassifierService:
         # can delegate
         if os.path.isdir(bundle):
             directory = bundle
+        # Try and unzip if its a zip file
         else:
             directory = unzip_files(bundle)
 

--- a/baseline/utils.py
+++ b/baseline/utils.py
@@ -324,7 +324,7 @@ def save_vocabs(basedir, embeds_or_vocabs, name='vocabs'):
 
 
 @export
-def load_vocabs(directory):
+def load_vocabs(directory: str, suffix: Optional[str] = None):
     vocab_fnames = find_files_with_prefix(directory, 'vocabs')
     vocabs = {}
     for f in vocab_fnames:
@@ -370,16 +370,29 @@ def unzip_files(zip_path):
 
 
 @export
-def find_model_basename(directory):
-    path = os.path.join(directory, [x for x in os.listdir(directory) if 'model' in x and '-md' not in x and 'wgt' not in x and '.assets' not in x][0])
+def find_model_basename(directory, basename=None):
+    if not basename:
+        basename = [x for x in os.listdir(directory) if 'model' in x and '-md' not in x and 'wgt' not in x and '.assets' not in x][0]
+    else:
+        globname = os.path.join(directory, basename)
+        if not os.path.isfile(globname):
+            import glob
+            out = glob.glob(f'{globname}*')
+            out = [x for x in out if 'model' in x and '-md' not in x and 'wgt' not in x and '.assets' not in x][0]
+            basename = out
+    path = os.path.join(directory, basename)
     logger.info(path)
     path = path.split('.')[:-1]
     return '.'.join(path)
 
 
 @export
-def find_files_with_prefix(directory, prefix):
-    return [os.path.join(directory, x) for x in os.listdir(directory) if x.startswith(prefix)]
+def find_files_with_prefix(directory, prefix, suffix=None):
+
+    files_with_prefix = [os.path.join(directory, x) for x in os.listdir(directory) if x.startswith(prefix)]
+    if suffix:
+        files_with_prefix = [f for f in files_with_prefix if f.endswith(suffix)]
+    return files_with_prefix
 
 
 @export

--- a/baseline/utils.py
+++ b/baseline/utils.py
@@ -325,7 +325,7 @@ def save_vocabs(basedir, embeds_or_vocabs, name='vocabs'):
 
 @export
 def load_vocabs(directory: str, suffix: Optional[str] = None):
-    vocab_fnames = find_files_with_prefix(directory, 'vocabs')
+    vocab_fnames = find_files_with_prefix(directory, 'vocabs', suffix)
     vocabs = {}
     for f in vocab_fnames:
         logger.info(f)


### PR DESCRIPTION
sometimes there might be multiple pid names in
the same file. this happens when multiple runs are
done and then the user needs to load only one.

by checking the job status or even just the time
of each checkpoint written out, the user can easily
determine the PID-specific job name, but its not
currently loadable.

This change allows the user to give a longer expression
as the checkpoint name and resolves that to the full
checkpoint name, and passes this along to the suffix