### PR TITLE
Fix/ra seq2seq ex

### DIFF
--- a/api-examples/generate-mlm.py
+++ b/api-examples/generate-mlm.py
@@ -53,7 +53,7 @@ def decode_sentence(model, vectorizer, query, word2index, index2word, device, sa
         return words
 
 
-def create_model(embeddings, d_model, d_ff, num_heads, num_layers, rpr_k, d_k, checkpoint_name):
+def create_model(embeddings, d_model, d_ff, num_heads, num_layers, rpr_k, d_k, checkpoint_name, activation):
     if len(rpr_k) == 0 or rpr_k[0] < 1:
         rpr_k = None
     logger.info("Creating tied encoder decoder model")
@@ -67,6 +67,7 @@ def create_model(embeddings, d_model, d_ff, num_heads, num_layers, rpr_k, d_k, c
                                                   layers=num_layers,
                                                   rpr_k=rpr_k,
                                                   d_k=d_k,
+                                                  activation=activation,
                                                   src_keys=['x'], tgt_key='x')
     tlm_load_state_dict(model, checkpoint_name)
     #model.load_state_dict(torch.load(checkpoint_name))
@@ -94,6 +95,7 @@ def run():
                         help="register label of the embeddings, so far support positional or learned-positional")
     parser.add_argument("--subword_model_file", type=str, required=True)
     parser.add_argument("--subword_vocab_file", type=str, required=True)
+    parser.add_argument("--activation", type=str, default='relu')
     parser.add_argument('--rpr_k', help='Relative attention positional sizes pass 0 if you dont want relative attention',
                         type=int, default=[3, 5, 48, 48, 48, 48], nargs='+')
 
@@ -122,7 +124,7 @@ def run():
     embeddings = preproc_data['embeddings']
     vocab = preproc_data['vocab']
     model = create_model(embeddings, d_model=args.d_model, d_ff=args.d_ff, num_heads=args.num_heads, num_layers=args.num_layers,
-                         rpr_k=args.rpr_k, d_k=args.d_k, checkpoint_name=checkpoint)
+                         rpr_k=args.rpr_k, d_k=args.d_k, checkpoint_name=checkpoint, activation=args.activation)
     model.to(args.device)
 
     vectorizer = BPEVectorizer1D(model_file=args.subword_model_file, vocab_file=args.subword_vocab_file, mxlen=args.nctx)

--- a/api-examples/tf-train-from-scratch.py
+++ b/api-examples/tf-train-from-scratch.py
@@ -1,7 +1,9 @@
 import baseline as bl
+
+from eight_mile.tf.layers import set_tf_log_level, set_tf_eager_mode
+set_tf_eager_mode(False)
 import baseline.tf.embeddings
 import baseline.tf.classify
-from eight_mile.tf.layers import set_tf_log_level
 import time
 import tensorflow as tf
 import numpy as np
@@ -17,15 +19,6 @@ def get_logging_level(ll):
     if ll == 'info':
         return logging.INFO
     return logging.WARNING
-
-
-def get_tf_logging_level(ll):
-    ll = ll.lower()
-    if ll == 'debug':
-        return tf.logging.DEBUG
-    if ll == 'info':
-        return logging.INFO
-    return tf.logging.WARN
 
 parser = argparse.ArgumentParser(description='Train a Baseline model with TensorFlow Estimator API')
 parser.add_argument('--checkpoint_dir', help='Directory for model checkpoints', default='./checkpoints', type=str)

--- a/api-examples/transformer-paired-response.py
+++ b/api-examples/transformer-paired-response.py
@@ -42,7 +42,7 @@ def decode_sentence(model, vectorizer, query, word2index, index2word, device, ma
     return response
 
 
-def create_model(embeddings, d_model, d_ff, num_heads, num_layers, rpr_k, d_k, checkpoint_name):
+def create_model(embeddings, d_model, d_ff, num_heads, num_layers, rpr_k, d_k, activation, checkpoint_name):
     if len(rpr_k) == 0 or rpr_k[0] < 1:
         rpr_k = None
     logger.info("Creating tied encoder decoder model")
@@ -56,6 +56,7 @@ def create_model(embeddings, d_model, d_ff, num_heads, num_layers, rpr_k, d_k, c
            "decoder_type": "transformer",
            "src_lengths_key": "x_lengths",
            "d_k": d_k,
+           "activation": activation,
            "rpr_k": rpr_k}
     model = TiedEmbeddingsSeq2SeqModel(embeddings, **hps)
     model.load_state_dict(torch.load(checkpoint_name))
@@ -83,6 +84,7 @@ def run():
                         help="register label of the embeddings, so far support positional or learned-positional")
     parser.add_argument("--subword_model_file", type=str, required=True)
     parser.add_argument("--subword_vocab_file", type=str, required=True)
+    parser.add_argument("--activation", type=str, default='relu')
     parser.add_argument('--rpr_k', help='Relative attention positional sizes pass 0 if you dont want relative attention',
                         type=int, default=[3, 5, 48, 48, 48, 48], nargs='+')
 
@@ -112,7 +114,7 @@ def run():
     embeddings = preproc_data['embeddings']
 
     model = create_model(embeddings, d_model=args.d_model, d_ff=args.d_ff, num_heads=args.num_heads, num_layers=args.num_layers,
-                         rpr_k=args.rpr_k, d_k=args.d_k, checkpoint_name=checkpoint)
+                         rpr_k=args.rpr_k, d_k=args.d_k, checkpoint_name=checkpoint, activation=args.activation)
     model.to(args.device)
 
     vectorizer = BPEVectorizer1D(model_file=args.subword_model_file, vocab_file=args.subword_vocab_file, mxlen=args.nctx)

--- a/baseline/pytorch/seq2seq/decoders.py
+++ b/baseline/pytorch/seq2seq/decoders.py
@@ -250,11 +250,12 @@ class TransformerDecoderWrapper(torch.nn.Module):
         d_ff = int(kwargs.get('d_ff', 4 * hsz))
         rpr_k = kwargs.get('rpr_k')
         d_k = kwargs.get('d_k')
+        activation = kwargs.get('activation', 'relu')
         scale = bool(kwargs.get('scale', True))
 
         self.transformer_decoder = TransformerDecoderStack(num_heads, d_model=hsz, d_ff=d_ff,
                                                            pdrop=dropout, scale=scale,
-                                                           layers=layers, rpr_k=rpr_k, d_k=d_k)
+                                                           layers=layers, rpr_k=rpr_k, d_k=d_k, activation_type=activation)
 
         self.proj_to_dsz = self._identity
         self.proj_to_hsz = self._identity

--- a/baseline/pytorch/seq2seq/encoders.py
+++ b/baseline/pytorch/seq2seq/encoders.py
@@ -47,10 +47,11 @@ class TransformerEncoderWrapper(torch.nn.Module):
         d_ff = int(kwargs.get('d_ff', 4 * hsz))
         rpr_k = kwargs.get('rpr_k')
         d_k = kwargs.get('d_k')
+        activation = kwargs.get('activation', 'relu')
         scale = bool(kwargs.get('scale', True))
         self.transformer = TransformerEncoderStack(num_heads, d_model=hsz, d_ff=d_ff,
                                                    pdrop=dropout, scale=scale, layers=layers,
-                                                   rpr_k=rpr_k, d_k=d_k)
+                                                   rpr_k=rpr_k, d_k=d_k, activation=activation)
 
     def _identity(self, x):
         return x

--- a/baseline/vectorizers.py
+++ b/baseline/vectorizers.py
@@ -447,7 +447,7 @@ class BPEVectorizer1D(AbstractVectorizer):
             elif t == '<eos>':
                 yield Offsets.VALUES[Offsets.EOS]
             else:
-                subwords = self.tokenizer.apply([t])[0].split()
+                subwords = self.tokenizer.apply([self.transform_fn(t)])[0].split()
                 for x in subwords:
                     yield x
         for t in self.emit_end_toks:


### PR DESCRIPTION
Fix Transformer generation when using relative attention.  To do this we have to have a destination buffer the same size as the input.  Also fix the Transformer seq2seq to pass in activation to the encoder/decoder.  Some of the old checkpoints use `relu` and the new layer stuff uses `gelu`.

Also fixes a bug in the BPE vectorizer where it was not applying the `transform_fn`