### PR TITLE
update mead-layers to be same as mead-baseline

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ def main():
         install_requires=[
             'numpy',
             'six',
-            'mead-layers',
+            'mead-layers=={}'.format(About.VERSION),
         ],
         extras_require={
             'test': ['pytest', 'mock', 'contextdecorator', 'pytest-forked'],


### PR DESCRIPTION
we currently maintain the same version and repository between baseline and layers and things change quickly.  Currently it is possible that we fix an issue in the layers and that the install requirements are satisfied with the old dep when we try and update `mead-baseline`.

this change forces a dependency on `mead-layers` that matches the version of `mead-baseline`