### PR TITLE
fix double clipping issue in pretrain discrim

### DIFF
--- a/api-examples/pretrain-discrim.py
+++ b/api-examples/pretrain-discrim.py
@@ -358,7 +358,6 @@ def train():
             logits = gen_model({'x': noised_x}, None)[0]
             gen_loss_step = gen_loss_fn(logits.transpose(0, 1).contiguous(), labels)
             avg_gen_loss.update(gen_loss_step.item())
-            torch.nn.utils.clip_grad_norm_(gen_model.parameters(), args.clip)
             # Re-read labels from device, this clears the masked <PAD>
             labels = y.to(args.device)
 


### PR DESCRIPTION
when i first wrote it, used a separate optim
for generator and discrim.  this was missed in
refactoring, but seems to be an issue in pytorch
1.5