### PR TITLE
move mlm masking up, TF record support in pretrain

### DIFF
--- a/api-examples/pretrain-tlm-tf.py
+++ b/api-examples/pretrain-tlm-tf.py
@@ -66,6 +66,7 @@ def decode_json(example):
 def get_dataset(directory, file_type, num_parallel_reads=1):
     """Get a dataset as a tf.data.Dataset.  Input can be a bucket or a local file
 
+
     :param directory: Either a bucket or a file
     :param file_type: Currently supports "json" files or "tfrecords"
     :param num_parallel_reads: The number of parallel reads
@@ -74,6 +75,7 @@ def get_dataset(directory, file_type, num_parallel_reads=1):
     pattern = os.path.join(directory, f'*.{file_type}')
     files = tf.io.gfile.glob(pattern)
     logger.debug(files)
+
     if file_type == 'json':
         ds = tf.data.TextLineDataset(files, num_parallel_reads=num_parallel_reads)
         return ds.map(decode_json)


### PR DESCRIPTION
Previously we supported reading JSON in and using `py_function` to execute it, but this wont work
if we are targeting TPUs:

https://github.com/tensorflow/tensorflow/issues/38762

Also note that the previous version used a 3rd party library to write the TF records, which worked
quite well, but in the process of debugging the pretraining issues, it was easier to just move the official version.  
Now the `preproc-tlm` program will try to import `tensorflow`, and if its not present, it will continue execution, but `tensorflow` is required to write the records