### PR TITLE
fix: don't rm when saving in-between-epoch ckpts

### DIFF
--- a/api-examples/pretrain-discrim.py
+++ b/api-examples/pretrain-discrim.py
@@ -420,22 +420,8 @@ def train():
         logger.info(metrics)
 
         if args.local_rank < 1:
-
-            # Should probably do this more often
-            gen_checkpoint_name = checkpoint_for(gen_base, epoch)
-            discrim_checkpoint_name = checkpoint_for(discrim_base, epoch)
-            logger.info("Creating checkpoint: %s", gen_checkpoint_name)
-            logger.info("Creating checkpoint: %s", discrim_checkpoint_name)
-            if args.distributed:
-                torch.save(discrim_model.module.state_dict(), discrim_checkpoint_name + '.pth')
-                torch.save(gen_model.module.state_dict(), gen_checkpoint_name + '.pth')
-
-            else:
-                torch.save(discrim_model.state_dict(), discrim_checkpoint_name + '.pth')
-                torch.save(gen_model.state_dict(), gen_checkpoint_name + '.pth')
-
-            rm_old_checkpoints(gen_base, epoch)
-            rm_old_checkpoints(discrim_base, epoch)
+            save_checkpoint(discrim_model, discrim_base, epoch, tick_type='epoch', save_npz=True)
+            save_checkpoint(gen_model, gen_base, epoch, tick_type='epoch', save_npz=True)
 
 
 if __name__ == "__main__":

--- a/layers/eight_mile/pytorch/layers.py
+++ b/layers/eight_mile/pytorch/layers.py
@@ -3336,8 +3336,8 @@ def rm_old_checkpoints(base_path, current_epoch, last_n=10):
 
 
 
-def save_checkpoint(model: torch.nn.Module, model_base: str, count: int, tick_type: str = 'epoch'):
-
+def save_checkpoint(model: torch.nn.Module, model_base: str, count: int, tick_type: str = 'epoch', save_npz: bool = False):
+    from eight_mile.pytorch.serialize import save_tlm_npz
     checkpoint_name = checkpoint_for(model_base, count, tick_type=tick_type)
     # Its possible due to how its called that we might save the same checkpoint twice if we dont check first
     if os.path.exists(checkpoint_name):
@@ -3345,11 +3345,15 @@ def save_checkpoint(model: torch.nn.Module, model_base: str, count: int, tick_ty
         return
     logger.info("Creating checkpoint: %s", checkpoint_name)
     if hasattr(model, 'module'):
-        torch.save(model.module.state_dict(), checkpoint_name)
+        torch.save(model.module.state_dict(), checkpoint_name+'.pth')
+        if save_npz:
+            save_tlm_npz(model.module, checkpoint_name+'.npz')
     else:
-        torch.save(model.state_dict(), checkpoint_name)
-
-    rm_old_checkpoints(model_base, count)
+        torch.save(model.state_dict(), checkpoint_name+'.pth')
+        if save_npz:
+            save_tlm_npz(model, checkpoint_name+'.npz')
+    if tick_type == 'epoch':
+        rm_old_checkpoints(model_base, count)
 
 
 def init_distributed(local_rank):


### PR DESCRIPTION
There's a bug in saving ckpts: when saving a ckpt in between epochs, the `checkpoint-epoch-*` will be removed. This PR fixes it and clean up the saving ckpt after each epoch. 