### PR TITLE
feat: a utility to write out a conll file from a list of sentences

### DIFF
--- a/layers/eight_mile/utils.py
+++ b/layers/eight_mile/utils.py
@@ -11,7 +11,7 @@ from itertools import chain
 from binascii import hexlify
 from functools import partial
 from collections import Counter
-from typing import List, Tuple, Union, Optional, Dict, Any, Set, Pattern
+from typing import List, Tuple, Union, Optional, Dict, Any, Set, Pattern, TextIO
 from functools import partial, update_wrapper, wraps
 import numpy as np
 from six.moves.urllib.request import urlretrieve
@@ -857,6 +857,13 @@ def read_conll(f, doc_pattern=None, delim=None, metadata=False, allow_comments=F
                 f, delim=delim, allow_comments=allow_comments, comment_pattern=comment_pattern
             ):
                 yield x
+
+
+@export
+@str_file(wf="w")
+def write_conll(wf: Union[str, TextIO], sentences: List[List[List[str]]], delim: Optional[str] = None) -> None:
+    delim = " " if delim is None else delim
+    wf.write("\n\n".join(["\n".join([delim.join(row) for row in sentence]) for sentence in sentences]) + "\n\n")
 
 
 @export

--- a/tests/test_conll.py
+++ b/tests/test_conll.py
@@ -11,6 +11,7 @@ from eight_mile.utils import (
     read_conll_sentences,
     read_conll_sentences_md,
     convert_conll_file,
+    write_conll,
 )
 
 
@@ -186,3 +187,22 @@ def test_read_write_with_delim_none():
     convert_conll_file(in_, out_, lambda x: x, delim=None)
     out_.seek(0)
     assert out_.read().strip("\n") == data.strip("\n")
+
+
+def test_write_conll():
+    data = read_conll(TEST_FILE)
+    out_ = StringIO()
+    write_conll(out_, data, delim=" ")
+    out_.seek(0)
+    with open(TEST_FILE) as gold:
+        assert out_.read().strip("\n") == gold.read().strip("\n")
+
+
+def test_write_conll_with_delims():
+    delim = random.choice(["~~", "|", "\t"])
+    data = read_conll(TEST_FILE)
+    out_ = StringIO()
+    write_conll(out_, data, delim=delim)
+    out_.seek(0)
+    with open(TEST_FILE) as gold:
+        assert out_.read().strip("\n") == gold.read().strip("\n").replace(" ", delim)


### PR DESCRIPTION
This isn't as extensive as the utilties for reading in conll files which support things like documents and meta data. This just writes out a list of
conll sentneces to a file in one shot. It is a pretty simple function but I found my self writing it in a lot of scripts so reusing in here
makes sense.