### PR TITLE
Feature/save tf tlm npz

### DIFF
--- a/api-examples/pretrain-tlm-tf.py
+++ b/api-examples/pretrain-tlm-tf.py
@@ -13,6 +13,7 @@ from eight_mile.utils import Average, get_num_gpus_multiworker, read_yaml
 from eight_mile.optz import *
 from eight_mile.tf.optz import *
 from baseline.tf.lm import SET_TRAIN_FLAG, TransformerLanguageModel, TransformerMaskedLanguageModel
+from eight_mile.tf.serialize import save_tlm_npz
 import tensorflow as tf
 import json
 logger = logging.getLogger(__file__)
@@ -155,7 +156,7 @@ def train():
                         help='Relative attention positional sizes pass 0 if you dont want relative attention',
                         type=int, default=[8], nargs='+')
     parser.add_argument("--strategy", help="Training strategy, defaults to `mirror`", choices=["mirror"])
-
+    parser.add_argument("--npz", help="Should we write out NPZ files?", type=str2bool, default=False)
     args = parser.parse_args()
     SET_TRAIN_FLAG(True)
 
@@ -302,6 +303,9 @@ def train():
                     logging.info('elapsed time this epoch %d min', elapsed)
                     logging.info('elapsed step time %f steps/min', i/elapsed)
                     checkpoint_manager.save()
+                    if args.npz:
+                        npz_checkpoint = os.path.join(args.basedir, f'checkpoint-step-{steps}.npz')
+                        save_tlm_npz(model, npz_checkpoint)
 
             # How much time elapsed in minutes
             elapsed = (time.time() - start)/60

--- a/api-examples/pretrain-tlm-tf.py
+++ b/api-examples/pretrain-tlm-tf.py
@@ -163,7 +163,7 @@ def train():
     if args.basedir is None:
         args.basedir = f'lm-{args.dataset_key}-bpe-{os.getpid()}'
     logging.basicConfig(level=logging.INFO)
-
+    logger.info(f"Writing results to {args.basedir}")
     strategy = create_distribute_strategy(args.distribute, args.tpu_ep)
     num_replicas = strategy.num_replicas_in_sync
     logger.info(f"Using {num_replicas} replicas in this job.")

--- a/api-examples/pretrain-tlm.py
+++ b/api-examples/pretrain-tlm.py
@@ -168,7 +168,7 @@ def train():
     # correct it here
     steps_per_epoch = len(train_loader) // (args.batch_size*num_gpus)
     update_on = steps_per_epoch // args.saves_per_epoch
-    report_on = update_on // 10
+    report_on = max(10, update_on) // 10
     logger.info(f"Steps per epoch per GPU: {steps_per_epoch}. Saving checkpoint every {update_on} steps.")
     lr_decay = get_lr_decay(args.lr_scheduler, args.lr, steps_per_epoch, args.epochs, logger,
                             decay_steps=args.lr_decay_steps, decay_rate=args.lr_decay_rate, alpha=args.lr_alpha)

--- a/api-examples/pretrain-tlm.py
+++ b/api-examples/pretrain-tlm.py
@@ -71,7 +71,8 @@ def train():
     parser.add_argument("--warmup_steps", type=int, default=10000, help="Num warmup steps")
     parser.add_argument("--saves_per_epoch", type=int, default=100, help="The number of checkpoints to save per epoch")
     parser.add_argument("--mlm", type=str2bool, default=True, help="Use Masked Language Model (MLM) objective")
-    parser.add_argument("--preprocessed", type=str2bool, default=False, help="Has the data already been preprocessed?")
+    parser.add_argument("--preprocessed", type=str2bool, default=True, help="Has the data already been preprocessed?")
+    parser.add_argument("--preserve_vocab_indices", type=str2bool, default=False, help="Use the exact same indices stored in the subword model")
     parser.add_argument('--rpr_k',
                         help='Relative attention positional sizes pass 0 if you dont want relative attention',
                         type=int, default=[8], nargs='+')
@@ -112,6 +113,7 @@ def train():
     vocab = reader.build_vocab([args.valid_file])
     # If we are not using chars, then use 'x' for both input and output
     preproc_data = baseline.embeddings.load_embeddings('x', dsz=args.d_model, known_vocab=vocab['x'],
+                                                       preserve_vocab_indices=args.preserve_vocab_indices,
                                                        embed_type=args.embed_type)
     vocabs = preproc_data['vocab']
 

--- a/api-examples/pretrain-tlm.py
+++ b/api-examples/pretrain-tlm.py
@@ -14,6 +14,7 @@ from eight_mile.pytorch.layers import save_checkpoint, init_distributed
 from eight_mile.pytorch.optz import *
 from baseline.pytorch.lm import TransformerLanguageModel, TransformerMaskedLanguageModel
 from transformer_utils import MultiFileDatasetReader, on_demand_mlm_masking, get_lr_decay
+from eight_mile.pytorch.serialize import load_tlm_npz
 
 logger = logging.getLogger(__file__)
 
@@ -175,7 +176,11 @@ def train():
     global_step = 0
     start_epoch = 0
     if args.restart_from:
-        model.load_state_dict(torch.load(args.restart_from))
+
+        if args.restart_from.endswith('npz'):
+            load_tlm_npz(model, args.restart_from)
+        else:
+            model.load_state_dict(torch.load(args.restart_from))
         vec = args.restart_from.split("-")
 
         if args.restart_tt:

--- a/layers/eight_mile/pytorch/serialize.py
+++ b/layers/eight_mile/pytorch/serialize.py
@@ -128,8 +128,9 @@ def from_weight_array(pytorch_layer: nn.Module, d: Dict, name: str):
     """
     if isinstance(pytorch_layer, Dense):
         pytorch_layer = pytorch_layer.layer
-    pytorch_layer.weight = nn.Parameter(torch.from_numpy(d[f"{name}/weights"]), requires_grad=True)
-    pytorch_layer.bias = nn.Parameter(torch.from_numpy(d[f"{name}/bias"]), requires_grad=True)
+    device = pytorch_layer.weight.device
+    pytorch_layer.weight = nn.Parameter(torch.from_numpy(d[f"{name}/weights"]).to(device=device), requires_grad=True)
+    pytorch_layer.bias = nn.Parameter(torch.from_numpy(d[f"{name}/bias"]).to(device=device), requires_grad=True)
 
 
 def to_ffn_array(pytorch_ffn: nn.Sequential, name: str) -> Dict:
@@ -253,9 +254,10 @@ def from_embed_array(pytorch_embed: nn.Module, d: Dict, name: str):
     :param name: name of the layer
     :return: None
     """
-    pytorch_embed.embeddings.weight = torch.nn.Parameter(torch.from_numpy(d[f"{name}/weights"]), requires_grad=True)
+    device = pytorch_embed.embeddings.weight.device
+    pytorch_embed.embeddings.weight = torch.nn.Parameter(torch.from_numpy(d[f"{name}/weights"]).to(device=device), requires_grad=True)
     if hasattr(pytorch_embed, 'pos_embeddings'):
-        pytorch_embed.pos_embeddings.weight = torch.nn.Parameter(torch.from_numpy(d[f"{name}/pos_weights"]),
+        pytorch_embed.pos_embeddings.weight = torch.nn.Parameter(torch.from_numpy(d[f"{name}/pos_weights"]).to(device=device),
                                                                  requires_grad=True)
 
 

--- a/layers/eight_mile/pytorch/serialize.py
+++ b/layers/eight_mile/pytorch/serialize.py
@@ -195,8 +195,9 @@ def from_attn_array(pytorch_attn: nn.Module, d: Dict, name: str):
     from_weight_array(pytorch_attn.w_O, d, f"{name}/w_O")
 
     if hasattr(pytorch_attn, 'rpr_key'):
-        pytorch_attn.rpr_key.weight = torch.nn.Parameter(torch.from_numpy(d[f"{name}/rpr_key"]))
-        pytorch_attn.rpr_value.weight = torch.nn.Parameter(torch.from_numpy(d[f"{name}/rpr_value"]))
+        device = pytorch_attn.rpr_key.weight.device
+        pytorch_attn.rpr_key.weight = torch.nn.Parameter(torch.from_numpy(d[f"{name}/rpr_key"]).to(device=device))
+        pytorch_attn.rpr_value.weight = torch.nn.Parameter(torch.from_numpy(d[f"{name}/rpr_value"]).to(device=device))
 
 
 def to_encoder_array(pytorch_encoder: TransformerEncoder, name: str) -> Dict:

--- a/layers/eight_mile/tf/serialize.py
+++ b/layers/eight_mile/tf/serialize.py
@@ -130,7 +130,7 @@ def from_encoder_array(tf_encoder: TransformerEncoder, d: Dict, name: str):
 
 def to_embed_array(tf_embed: tf.keras.layers.Layer, name: str) -> Dict:
     """Convert positional embedding to a `weights` array, if it's learned positional embedding,
-    save the pos_weight as well.  This currently only works in eager mode
+    save the pos_weight as well.
 
     :param tf_embed: An embedding module
     :param name: A layer name
@@ -140,17 +140,17 @@ def to_embed_array(tf_embed: tf.keras.layers.Layer, name: str) -> Dict:
 
 
     if hasattr(tf_embed, 'pos'):
-        pos_weights = tf_embed.pos.numpy()
+        pos_weights = tf.keras.backend.get_value(tf_embed.pos)
         d.update({f"{name}/pos_weights": pos_weights})
 
     if hasattr(tf_embed, 'bias'):
-        bias = tf_embed.bias.numpy()
+        bias = tf.keras.backend.get_value(tf_embed.bias)
         d.update({f"{name}/bias": bias.squeeze()})
 
     # Note: we override the Keras function forcing a single value not a list
     # this function could break if we used get_weights() since we have broken that
     # however, we'd like to fix that so using the raw value feels like the lesser of 2 evils
-    weights = tf_embed.W.numpy()
+    weights = tf.keras.backend.get_value(tf_embed.W)
     d.update({f"{name}/weights": weights})
     return d
 

--- a/layers/eight_mile/tf/serialize.py
+++ b/layers/eight_mile/tf/serialize.py
@@ -6,8 +6,20 @@ from eight_mile.tf.embeddings import LookupTableEmbeddings, LearnedPositionalLoo
 import tensorflow as tf
 
 
+def to_weight_array(tf_layer: tf.keras.layers.Layer, name: str) -> Dict:
+    """Convert a {`LayerNorm`, `tf.keras.layers.Dense`} to `weights` and `bias` arrays
+
+    :param tf_layer: A layer to get weights for
+    :param name: The name of this layer to serialize
+    :return: A Dictionary containing `weights` and `bias` keys
+    """
+
+    weights, bias = tf_layer.get_weights()
+    return {f"{name}/weights": weights.T, f"{name}/bias": bias}
+
+
 def from_weight_array(tf_layer: tf.keras.layers.Layer, d: Dict, name: str):
-    """Read in {`LayerNorm`, `Linear`, `layers.Dense`} from `weights` and `bias` fields
+    """Read in {`LayerNorm`, `tf.keras.layers.Dense`} from `weights` and `bias` fields
 
     :param tf_layer: A layer to get weights for
     :param d: A Dict containing the arrays by key
@@ -17,6 +29,19 @@ def from_weight_array(tf_layer: tf.keras.layers.Layer, d: Dict, name: str):
     weights = d[f"{name}/weights"]
     bias = d[f"{name}/bias"]
     tf_layer.set_weights([weights.T, bias])
+
+
+def to_ffn_array(tf_ffn: FFN, name: str) -> Dict:
+    """Convert a `FFN` layer to a set of arrays
+
+    :param tf_ffn: An `FFN` layer for Transformers
+    :param name: The name of the layer
+    :return: A Dict containing the arrays by key
+    """
+    d = {}
+    d.update(to_weight_array(tf_ffn.expansion, f"{name}/expansion"))
+    d.update(to_weight_array(tf_ffn.squeeze, f"{name}/squeeze"))
+    return d
 
 
 def from_ffn_array(tf_ffn: FFN, d: Dict, name: str):
@@ -29,6 +54,31 @@ def from_ffn_array(tf_ffn: FFN, d: Dict, name: str):
     """
     from_weight_array(tf_ffn.expansion, d, f"{name}/expansion")
     from_weight_array(tf_ffn.squeeze, d, f"{name}/squeeze")
+
+
+def to_attn_array(tf_attn: tf.keras.layers.Layer, name: str) -> Dict:
+    """Convert a self-attention module to a set of arrays
+
+    :param tf_attn: The self-attention layer of the transformer encoder, could be MultiHeadedAttention or
+    MultiHeadedRelativeAttention
+    :param name: The name of the layer
+    :return: A Dict containing the arrays by key
+    """
+    d = {}
+
+    d.update(to_weight_array(tf_attn.w_Q, f"{name}/w_Q"))
+    d.update(to_weight_array(tf_attn.w_K, f"{name}/w_K"))
+    d.update(to_weight_array(tf_attn.w_V, f"{name}/w_V"))
+    d.update(to_weight_array(tf_attn.w_O, f"{name}/w_O"))
+
+    if hasattr(tf_attn, 'rpr_key'):
+        # Embeddings have same shape in PyTorch and TF [input_sz, output_sz]
+        rpr_key_weights = tf_attn.rpr_key.get_weights()[0]
+        rpr_value_weights = tf_attn.rpr_value.get_weights()[0]
+        d.update({f"{name}/rpr_key": rpr_key_weights})
+        d.update({f"{name}/rpr_value": rpr_value_weights})
+
+    return d
 
 
 def from_attn_array(tf_attn: tf.keras.layers.Layer, d: Dict, name: str):
@@ -49,6 +99,21 @@ def from_attn_array(tf_attn: tf.keras.layers.Layer, d: Dict, name: str):
         tf_attn.rpr_value.set_weights([d[f"{name}/rpr_value"]])
 
 
+def to_encoder_array(tf_encoder: TransformerEncoder, name: str) -> Dict:
+    """Convert a `TransformerEncoder` layer to an set of numpy arrays
+
+    :param tf_encoder: A `TransformerEncoder` layer
+    :param name: The layer name
+    :return: A Dict of arrays by key
+    """
+    d = {}
+    d.update(to_weight_array(tf_encoder.ln1, f"{name}/ln1"))
+    d.update(to_weight_array(tf_encoder.ln2, f"{name}/ln2"))
+    d.update(to_attn_array(tf_encoder.self_attn, f"{name}/attn"))
+    d.update(to_ffn_array(tf_encoder.ffn, f"{name}/ffn"))
+    return d
+
+
 def from_encoder_array(tf_encoder: TransformerEncoder, d: Dict, name: str):
     """Restore a `TransformerEncoder` layer from a set of numpy arrays
 
@@ -61,6 +126,33 @@ def from_encoder_array(tf_encoder: TransformerEncoder, d: Dict, name: str):
     from_weight_array(tf_encoder.ln2, d, f"{name}/ln2")
     from_attn_array(tf_encoder.self_attn, d, f"{name}/attn")
     from_ffn_array(tf_encoder.ffn, d, f"{name}/ffn")
+
+
+def to_embed_array(tf_embed: tf.keras.layers.Layer, name: str) -> Dict:
+    """Convert positional embedding to a `weights` array, if it's learned positional embedding,
+    save the pos_weight as well
+
+    :param tf_embed: An embedding module
+    :param name: A layer name
+    :return: A Dict containing the embedding `weights`
+    """
+    d = {}
+
+
+    weights = tf_embed.embeddings.get_weights()
+    weight_offset = 0
+    if hasattr(tf_embed, 'pos'):
+        pos_weights = weights[0]
+        d.update({f"{name}/pos_weights": pos_weights})
+        weight_offset += 1
+
+    if hasattr(tf_embed, 'bias'):
+        bias = weights[-1]
+        d.update({f"{name}/bias": bias.squeeze()})
+
+    weights = weights[weight_offset]
+    d.update({f"{name}/weights": weights})
+    return d
 
 
 def from_embed_array(tf_embed: tf.keras.layers.Layer, d: Dict, name: str, bias=None):
@@ -81,6 +173,24 @@ def from_embed_array(tf_embed: tf.keras.layers.Layer, d: Dict, name: str, bias=N
     tf_embed.set_weights(weights)
 
 
+def to_encoder_stack_array(
+    tf_encoder_stack: TransformerEncoderStack, name: str = "TransformerEncoderStack"
+) -> Dict:
+    """Convert a `TransformerEncoderStack` to a set of weigths
+
+    :param tf_encoder_stack: A transformer encoder stack
+    :param name: A name
+    :return: A Dict containing a set of weights
+    """
+    d = {}
+    if isinstance(tf_encoder_stack.ln, tf.keras.layers.LayerNormalization):
+        d.update(to_weight_array(tf_encoder_stack.ln, f"{name}/ln"))
+    for i, enc_pyt in enumerate(tf_encoder_stack.encoders):
+        d.update(to_encoder_array(enc_pyt, f"{name}/{i}"))
+    return d
+
+
+
 def from_encoder_stack_array(tf_encoder_stack: TransformerEncoderStack, d: Dict, name: str = "TransformerEncoderStack"):
     """Restore weights from a `TransformerEncoderStack`
 
@@ -93,6 +203,27 @@ def from_encoder_stack_array(tf_encoder_stack: TransformerEncoderStack, d: Dict,
         from_weight_array(tf_encoder_stack.ln, d, f"{name}/ln")
     for i, enc_tf in enumerate(tf_encoder_stack.encoders):
         from_encoder_array(enc_tf, d, f"{name}/{i}")
+
+
+def to_tlm_array(tf_tlm: tf.keras.layers.Layer, embeddings_keys: List[str] = None, name: str = "TLM") -> Dict:
+    """Convert a Transformer LM-type module to a set of weights in a Dict
+
+    :param pytorch_tlm: A Transformer LM-type module
+    :param embeddings_keys: A key to get the embeddings from, defaults to `None` in which case, gets all keys
+    :param name: A name for this TLM
+    :return: A Dict containing all the keys to restore from Embeddings and the TransformerEncoderStack
+    """
+    d = {}
+    transformer = tf_tlm.transformer if hasattr(tf_tlm, 'transformer') else tf_tlm.generator
+    d.update(to_encoder_stack_array(transformer, name=f"{name}/TransformerEncoderStack"))
+    keys_to_write = embeddings_keys if embeddings_keys else list(tf_tlm.embeddings.keys())
+
+    for embeddings_key in keys_to_write:
+        d.update(to_embed_array(tf_tlm.embeddings[embeddings_key], name=f"{name}/Embeddings/{embeddings_key}"))
+
+    if hasattr(tf_tlm.embeddings.reduction, 'ln'):
+        d.update(to_weight_array(tf_tlm.embeddings.reduction.ln, name=f"{name}/Embeddings/reduction/ln"))
+    return d
 
 
 def from_tlm_array(tf_tlm: tf.keras.layers.Layer, d: Dict, embeddings_keys: List[str] = None, name: str = "TLM"):
@@ -120,6 +251,22 @@ def from_tlm_array(tf_tlm: tf.keras.layers.Layer, d: Dict, embeddings_keys: List
             from_embed_array(tf_tlm.embeddings[embeddings_key], d, f"{name}/Embeddings/{embeddings_key}")
     if hasattr(tf_tlm.embeddings.reduction, 'ln'):
         from_weight_array(tf_tlm.embeddings.reduction.ln, d, f"{name}/Embeddings/reduction/ln")
+
+
+def save_tlm_npz(tf_tlm: tf.keras.layers.Layer, npz: str, embeddings_keys: List[str] = None, name: str = "TLM", verbose: bool = False):
+    """Save a TLM to an NPZ file
+
+    :param pytorch_tlm: A Transformer LM-type module
+    :param npz: A file to save
+    :param embeddings_keys: A key to get embeddings from.  Defaults to `None`, in which case, all embeddings are written
+    :param name: A name for this TLM
+    :param verbose: whether output
+    :return: None
+    """
+    d = to_tlm_array(tf_tlm, embeddings_keys, name)
+    if verbose:
+        print(d.keys())
+    np.savez(npz, **d)
 
 
 def load_tlm_npz(tf_tlm: tf.keras.layers.Layer, npz: str, embeddings_key: str = 'x', name: str = "TLM"):

--- a/layers/eight_mile/tf/serialize.py
+++ b/layers/eight_mile/tf/serialize.py
@@ -139,7 +139,7 @@ def to_embed_array(tf_embed: tf.keras.layers.Layer, name: str) -> Dict:
     d = {}
 
 
-    weights = tf_embed.embeddings.get_weights()
+    weights = tf_embed.get_weights()
     weight_offset = 0
     if hasattr(tf_embed, 'pos'):
         pos_weights = weights[0]
@@ -185,8 +185,8 @@ def to_encoder_stack_array(
     d = {}
     if isinstance(tf_encoder_stack.ln, tf.keras.layers.LayerNormalization):
         d.update(to_weight_array(tf_encoder_stack.ln, f"{name}/ln"))
-    for i, enc_pyt in enumerate(tf_encoder_stack.encoders):
-        d.update(to_encoder_array(enc_pyt, f"{name}/{i}"))
+    for i, enc_tf in enumerate(tf_encoder_stack.encoders):
+        d.update(to_encoder_array(enc_tf, f"{name}/{i}"))
     return d
 
 


### PR DESCRIPTION
- Add `eight_mile.tf.serialize` support for writing transformers to NPZ file
- Add support for writing NPZ checkpoints from `pretrain-tlm-tf`
- Add support for reading NPZ checkpoints from `pretrain-tlm`
- Add support for preserving the vocab order from the vectorizer in `pretrain-tlm` which matches TF way