### PR TITLE
feat: allow for setting the max size of n grams in bleu calculations

### DIFF
--- a/baseline/pytorch/seq2seq/train.py
+++ b/baseline/pytorch/seq2seq/train.py
@@ -29,6 +29,7 @@ class Seq2SeqTrainerPyTorch(Trainer):
         self._predict = model.predict
         self.tgt_rlut = kwargs['tgt_rlut']
         self.gpus = kwargs.get('gpus', 1)
+        self.bleu_n_grams = int(kwargs.get("bleu_n_grams", 4))
 
         if self.gpus > 0:
             self.crit = model.create_loss().cuda()
@@ -84,7 +85,7 @@ class Seq2SeqTrainerPyTorch(Trainer):
             golds.extend(convert_seq2seq_golds(tgt.cpu().numpy(), tgt_lens, self.tgt_rlut))
 
         metrics = self.calc_metrics(total_loss, total_toks)
-        metrics['bleu'] = bleu(preds, golds)[0]
+        metrics['bleu'] = bleu(preds, golds, self.bleu_n_grams)[0]
         self.report(
             self.valid_epochs, metrics, start,
             phase, 'EPOCH', reporting_fns
@@ -103,7 +104,7 @@ class Seq2SeqTrainerPyTorch(Trainer):
             pred = [p[0] for p in self._predict(batch_dict, numpy_to_tensor=False, **kwargs)]
             preds.extend(convert_seq2seq_preds(pred, self.tgt_rlut))
             golds.extend(convert_seq2seq_golds(tgt, tgt_lens, self.tgt_rlut))
-        metrics = {'bleu': bleu(preds, golds)[0]}
+        metrics = {'bleu': bleu(preds, golds, self.bleu_n_grams)[0]}
         self.report(
             0, metrics, start, 'Test', 'EPOCH', reporting_fns
         )

--- a/baseline/tf/seq2seq/training/distributed.py
+++ b/baseline/tf/seq2seq/training/distributed.py
@@ -56,6 +56,7 @@ class Seq2SeqTrainerDistributedTf(Trainer):
                                                              max_to_keep=5)
         devices = ['/device:GPU:{}'.format(i) for i in range(self.gpus)]
         self.strategy = tf.distribute.MirroredStrategy(devices)
+        self.bleu_n_grams = int(kwargs.get("bleu_n_grams", 4))
 
     def checkpoint(self):
         """This method saves a checkpoint
@@ -167,7 +168,7 @@ class Seq2SeqTrainerDistributedTf(Trainer):
             top_preds = self.model.predict(features, **kwargs)
             preds.extend(convert_seq2seq_preds(top_preds[:, 0, :], self.tgt_rlut))
             golds.extend(convert_seq2seq_golds(tgt, tgt_lens, self.tgt_rlut))
-        metrics = {'bleu': bleu(preds, golds)[0]}
+        metrics = {'bleu': bleu(preds, golds, self.bleu_n_grams)[0]}
         self.report(
             0, metrics, start, 'Test', 'EPOCH', reporting_fns
         )

--- a/baseline/tf/seq2seq/training/utils.py
+++ b/baseline/tf/seq2seq/training/utils.py
@@ -103,6 +103,7 @@ class Seq2SeqTrainerTf(Trainer):
         self.model.sess.run(tables)
         self.model.sess.run(tf.compat.v1.global_variables_initializer())
         self.model.set_saver(tf.compat.v1.train.Saver())
+        self.bleu_n_grams = int(kwargs.get("bleu_n_grams", 4))
 
         init = tf.compat.v1.global_variables_initializer()
         self.model.sess.run(init)
@@ -215,7 +216,7 @@ class Seq2SeqTrainerTf(Trainer):
             pred = [p[0] for p in self.model.predict(batch_dict)]
             preds.extend(convert_seq2seq_preds(pred, self.tgt_rlut))
             golds.extend(convert_seq2seq_golds(tgt, tgt_lens, self.tgt_rlut))
-        metrics = {'bleu': bleu(preds, golds)[0]}
+        metrics = {'bleu': bleu(preds, golds, self.bleu_n_grams)[0]}
         self.report(
             0, metrics, start, 'Test', 'EPOCH', reporting_fns
         )
@@ -262,7 +263,7 @@ class Seq2SeqTrainerTf(Trainer):
             golds.extend(convert_seq2seq_golds(batch_dict['tgt'], batch_dict['tgt_lengths'], self.tgt_rlut))
 
         metrics = self.calc_metrics(total_loss, total_toks)
-        metrics['bleu'] = bleu(preds, golds)[0]
+        metrics['bleu'] = bleu(preds, golds, self.bleu_n_grams)[0]
         self.report(
             self.valid_epochs, metrics, start,
             phase, 'EPOCH', reporting_fns


### PR DESCRIPTION
In some uses for seq2seq such as for predicting slot values in a DST task it is possible that your outputs will always has < 4 tokens. 4 is the default
size of n grams used in Bleu. When all of your outputs are < 4 then the precision for 4 grams is always zero which causes the whole bleu score to be
zero. This changes lets you set the max size of n-grams so we can use the bleu scores that pop out of baseline on these sort of datasets.

Tested on:

 Pytorch
 Tf 2 eager mode
 Tf 1 graph mode

What is SOP for testing distributed training?