### PR TITLE
fix: valid length when bpe hits the mxlen

### DIFF
--- a/baseline/vectorizers.py
+++ b/baseline/vectorizers.py
@@ -467,6 +467,7 @@ class BPEVectorizer1D(AbstractVectorizer):
                 i -= len(self.emit_end_toks)
                 for j, x in enumerate(self.emit_end_toks):
                     vec1d[i + j] = vocab.get(x)
+                i = self.mxlen - 1
                 break
             vec1d[i] = atom
         valid_length = i + 1


### PR DESCRIPTION
When bpe vectorizer hits the `mxlen`, the `valid_length` should always be `mxlen`. 