### PR TITLE
improve TB logging in both PyTorch and TF

### DIFF
--- a/baseline/pytorch/classify/train.py
+++ b/baseline/pytorch/classify/train.py
@@ -30,7 +30,7 @@ class ClassifyTrainerPyTorch(EpochReportingTrainer):
 
         if type(model) is dict:
             model = create_model_for('classify', **model)
-        super(ClassifyTrainerPyTorch, self).__init__()
+        super().__init__()
         if type(model) is dict:
             model = create_model_for('classify', **model)
         self.clip = float(kwargs.get('clip', 5))
@@ -130,6 +130,7 @@ class ClassifyTrainerPyTorch(EpochReportingTrainer):
 
             if (self.optimizer.global_step + 1) % self.nsteps == 0:
                 metrics = self.calc_metrics(self.nstep_agg, self.nstep_div)
+                metrics['lr'] = self.optimizer.current_lr
                 self.report(
                     self.optimizer.global_step + 1, metrics, self.nstep_start,
                     'Train', 'STEP', reporting_fns, self.nsteps
@@ -137,6 +138,8 @@ class ClassifyTrainerPyTorch(EpochReportingTrainer):
                 self.reset_nstep()
 
         metrics = cm.get_all_metrics()
+        metrics['lr'] = self.optimizer.current_lr
+
         metrics['avg_loss'] = epoch_loss / float(epoch_div)
         return metrics
 

--- a/baseline/pytorch/lm/train.py
+++ b/baseline/pytorch/lm/train.py
@@ -116,6 +116,8 @@ class LanguageModelTrainerPyTorch(Trainer):
             self.nstep_div += toks
             if (self.optimizer.global_step + 1) % self.nsteps == 0:
                 metrics = self.calc_metrics(self.nstep_agg, self.nstep_div)
+                metrics['lr'] = self.optimizer.current_lr
+
                 self.report(
                     self.optimizer.global_step + 1, metrics, self.nstep_start,
                     'Train', 'STEP', reporting_fns, self.nsteps
@@ -123,6 +125,8 @@ class LanguageModelTrainerPyTorch(Trainer):
                 self.reset_nstep()
 
         metrics = self.calc_metrics(epoch_loss, epoch_toks)
+        metrics['lr'] = self.optimizer.current_lr
+
         self.train_epochs += 1
         self.report(
             self.train_epochs, metrics, start,

--- a/baseline/pytorch/seq2seq/train.py
+++ b/baseline/pytorch/seq2seq/train.py
@@ -139,6 +139,7 @@ class Seq2SeqTrainerPyTorch(Trainer):
 
             if (self.optimizer.global_step + 1) % self.nsteps == 0:
                 metrics = self.calc_metrics(self.nstep_agg, self.nstep_div)
+                metrics['lr'] = self.optimizer.current_lr
                 self.report(
                     self.optimizer.global_step + 1, metrics, self.nstep_start,
                     'Train', 'STEP', reporting_fns, self.nsteps
@@ -146,6 +147,8 @@ class Seq2SeqTrainerPyTorch(Trainer):
                 self.reset_nstep()
 
         metrics = self.calc_metrics(epoch_loss, epoch_toks)
+        metrics['lr'] = self.optimizer.current_lr
+
         self.train_epochs += 1
         self.report(
             self.train_epochs, metrics, start,

--- a/baseline/pytorch/tagger/train.py
+++ b/baseline/pytorch/tagger/train.py
@@ -17,7 +17,7 @@ logger = logging.getLogger('baseline')
 class TaggerTrainerPyTorch(EpochReportingTrainer):
 
     def __init__(self, model, **kwargs):
-        super(TaggerTrainerPyTorch, self).__init__()
+        super().__init__()
         if type(model) is dict:
             model = create_model_for('tagger', **model)
         self.grad_accum = int(kwargs.get('grad_accum', 1))
@@ -152,6 +152,7 @@ class TaggerTrainerPyTorch(EpochReportingTrainer):
             self.nstep_div += bsz
             if (self.optimizer.global_step + 1) % self.nsteps == 0:
                 metrics = self.calc_metrics(self.nstep_agg, self.nstep_div)
+                metrics['lr'] = self.optimizer.current_lr
                 self.report(
                     self.optimizer.global_step + 1, metrics, self.nstep_start,
                     'Train', 'STEP', reporting_fns, self.nsteps
@@ -159,6 +160,8 @@ class TaggerTrainerPyTorch(EpochReportingTrainer):
                 self.reset_nstep()
 
         metrics = self.calc_metrics(epoch_loss, epoch_norm)
+        metrics['lr'] = self.optimizer.current_lr
+
         return metrics
 
 

--- a/layers/eight_mile/pytorch/optz.py
+++ b/layers/eight_mile/pytorch/optz.py
@@ -218,10 +218,11 @@ class OptimizerManager:
         lr = self.lr_function(self.global_step)
         for p in self.optimizer.param_groups:
             p["lr"] = lr
+
         return lr
 
 
-class EagerOptimizer(object):
+class EagerOptimizer:
     def __init__(self, loss, optimizer=None, **kwargs):
         self.loss = loss
         if optimizer:

--- a/layers/eight_mile/tf/optz.py
+++ b/layers/eight_mile/tf/optz.py
@@ -161,6 +161,7 @@ class ConstantSchedulerTensorFlow2(LearningRateScheduler, tf.keras.optimizers.sc
         super().__init__(**kwargs)
 
     def __call__(self, global_step):
+        tf.summary.scalar(name='lr', data=self.lr, step=tf.cast(global_step, tf.int64))
         return self.lr
 
     def __str__(self):
@@ -176,7 +177,9 @@ class WarmupLinearSchedulerTensorFlow2(
         super().__init__(warmup_steps=warmup_steps, **kwargs)
 
     def __call__(self, global_step):
-        return tf.minimum(1.0, global_step / float(self.warmup_steps)) * self.lr
+        new_lr = tf.minimum(1.0, global_step / float(self.warmup_steps)) * self.lr
+        tf.summary.scalar(name='warmup_lr', data=new_lr, step=tf.cast(global_step, tf.int64))
+        return new_lr
 
     def __str__(self):
         return type(self).__name__ + "()"
@@ -195,7 +198,9 @@ class CyclicLRSchedulerTensorFlow2(LearningRateScheduler, tf.keras.optimizers.sc
         cycle = tf.floor(1.0 + gs_f / (2.0 * self.decay_steps))
         x = tf.abs(gs_f / self.decay_steps - 2.0 * cycle + 1.0)
         clr = self.lr + (self.max_lr - self.lr) * tf.maximum(0.0, 1.0 - x)
-        return tf.identity(clr, name="lr")
+        new_lr = tf.identity(clr, name="lr")
+        tf.summary.scalar(name='clr_lr', data=new_lr, step=tf.cast(global_step, tf.int64))
+        return new_lr
 
     def __str__(self):
         return type(self).__name__ + "()"
@@ -207,12 +212,14 @@ class SGDRSchedulerTensorFlow2(LearningRateScheduler, tf.keras.optimizers.schedu
         self.first_decay_steps = first_decay_steps
 
     def __call__(self, global_step):
-        return tf.identity(
+        new_lr = tf.identity(
             tf.compat.v1.train.cosine_decay_restarts(
                 self.lr, global_step, first_decay_steps=self.first_decay_steps
             ),
             name="lr",
         )
+        tf.summary.scalar(name='sgdr_lr', data=new_lr, step=tf.cast(global_step, tf.int64))
+        return new_lr
 
     def __str__(self):
         return type(self).__name__ + "()"
@@ -245,7 +252,7 @@ class CompositeLRSchedulerTensorFlow2(tf.keras.optimizers.schedules.LearningRate
             return rest_tensor
 
         new_lr = tf.cond(global_step < self.warm.warmup_steps, call_warm, call_rest)
-        tf.summary.scalar(name='lr', data=new_lr, step=tf.cast(global_step, tf.int64))
+        tf.summary.scalar(name='composite_lr', data=new_lr, step=tf.cast(global_step, tf.int64))
         return new_lr
 
     def __str__(self):
@@ -256,17 +263,32 @@ class PiecewiseDecaySchedulerTensorFlow2(tf.keras.optimizers.schedules.Piecewise
     def __init__(self, boundaries, values, **kwargs):
         super().__init__(boundaries, values)
 
+    def __call__(self, global_step):
+        new_lr = super().__call__(global_step)
+        tf.summary.scalar(name='piecewise_decay_lr', data=new_lr, step=tf.cast(global_step, tf.int64))
+        return new_lr
+
 
 class InverseTimeDecaySchedulerTensorFlow2(tf.keras.optimizers.schedules.InverseTimeDecay):
     def __init__(self, decay_steps=16000, decay_rate=0.05, staircase=False, **kwargs):
         lr = kwargs.get("lr", kwargs.get("eta", 0.01))
         super().__init__(lr, decay_steps, decay_rate, staircase, kwargs.get("name"))
 
+    def __call__(self, global_step):
+        new_lr = super().__call__(global_step)
+        tf.summary.scalar(name='inv_time_decay_lr', data=new_lr, step=tf.cast(global_step, tf.int64))
+        return new_lr
+
 
 class ExponentialDecaySchedulerTensorFlow2(tf.keras.optimizers.schedules.ExponentialDecay):
     def __init__(self, decay_steps=16000, decay_rate=0.5, staircase=False, **kwargs):
         lr = kwargs.get("lr", kwargs.get("eta", 0.01))
         super().__init__(lr, decay_steps, decay_rate, staircase, kwargs.get("name"))
+
+    def __call__(self, global_step):
+        new_lr = super().__call__(global_step)
+        tf.summary.scalar(name='exponential_decay_lr', data=new_lr, step=tf.cast(global_step, tf.int64))
+        return new_lr
 
 
 class CosineDecaySchedulerTensorFlow(CosineDecayScheduler, tf.keras.optimizers.schedules.LearningRateSchedule):
@@ -278,7 +300,9 @@ class CosineDecaySchedulerTensorFlow(CosineDecayScheduler, tf.keras.optimizers.s
         global_step = tf.math.minimum(global_step, self.decay_steps)
         cosine_decay = 0.5 * (1.0 + tf.cos(3.14159265 * global_step / self.decay_steps))
         decayed = (1 - self.alpha) * cosine_decay + self.alpha
-        return self.lr * decayed
+        new_lr = self.lr * decayed
+        tf.summary.scalar(name='cosine_decay_lr', data=new_lr, step=tf.cast(global_step, tf.int64))
+        return new_lr
 
 
 if not tf.executing_eagerly():

--- a/setup.py
+++ b/setup.py
@@ -83,7 +83,7 @@ def main():
         ],
         extras_require={
             'test': ['pytest', 'mock', 'contextdecorator', 'pytest-forked'],
-            'report': ['visdom', 'tensorboardX'],
+            'report': ['visdom', 'tensorboard'],
             'yaml': ['pyyaml'],
             'tf2': ['tensorflow_addons'],
             'grpc': ['grpc'],


### PR DESCRIPTION
TensorBoard logging wasnt very informative or
helpful, and our reporting hook was still depending
on tensorboardX which is now integrated into PyTorch.

This change makes the reporting hook use PyTorch's TB
logging if it exists, and if not, fall back to use the
tf library.  This somewhat decouples it from having to
check the backend.

Additionally, adds LR logging in the metrics for PyTorch,
and for TF, where the Keras API means that this doesnt
make much sense, instead log all the LRs in each decay
LRS