### PR TITLE
option to mlm masking preserve non [MASK] x in y

### DIFF
--- a/api-examples/pretrain_paired_pytorch.py
+++ b/api-examples/pretrain_paired_pytorch.py
@@ -13,7 +13,6 @@ from eight_mile.pytorch.layers import save_checkpoint, init_distributed
 from eight_mile.pytorch.optz import *
 from transformer_utils import (
     MultiFileDatasetReader,
-    on_demand_mlm_masking,
     get_lr_decay,
     PairedModel,
     TripletLoss,

--- a/layers/eight_mile/utils.py
+++ b/layers/eight_mile/utils.py
@@ -1602,7 +1602,7 @@ def to_numpy(x):
 
 
 @export
-def mlm_masking(inputs, mask_value, vocab_size, ignore_prefix, ignore_suffix):
+def mlm_masking(inputs, mask_value, vocab_size, ignore_prefix, ignore_suffix, pad_y=True):
     labels = np.copy(inputs)
     masked_indices = np.random.binomial(size=len(inputs), n=1, p=0.15)
     masked_indices[np.random.randint(1, len(inputs)-1)] = 1
@@ -1611,7 +1611,8 @@ def mlm_masking(inputs, mask_value, vocab_size, ignore_prefix, ignore_suffix):
     if ignore_suffix:
         masked_indices[-1] = 0
     # Anything not masked is 0 so no loss
-    labels[masked_indices == 0] = 0
+    if pad_y:
+        labels[masked_indices == 0] = 0
     # Of the masked items, mask 80% of them with [MASK]
     indices_replaced = np.random.binomial(size=len(inputs), n=1, p=0.8)
     indices_replaced = indices_replaced & masked_indices


### PR DESCRIPTION
this alternative to BERT-style MLM might be preferred when the
architecture is a seq2seq and needs to learn to generate
the whole result not just the missing 15%