### PR TITLE
fix: the unsort batch was clobbering things

### DIFF
--- a/layers/eight_mile/pytorch/layers.py
+++ b/layers/eight_mile/pytorch/layers.py
@@ -63,7 +63,7 @@ def unsort_batch(batch: torch.Tensor, perm_idx: torch.Tensor) -> torch.Tensor:
     diff = len(batch.shape) - len(perm_idx.shape)
     extra_dims = [1] * diff
     perm_idx = perm_idx.view([-1] + extra_dims)
-    return batch.scatter_(0, perm_idx.expand_as(batch), batch)
+    return torch.scatter(torch.zeros_like(batch), 0, perm_idx.expand_as(batch), batch)
 
 
 def infer_lengths(tensor, dim=1):


### PR DESCRIPTION
I was seeing very different results when running our seq2seq models as
batches compared to as single examples. They were very common, often a
single batch of size 10 run with a beam of size 10 have a 50% error rate
when compared to the outputs of the single example runs. In order to
narrow down where this bug was coming from I added a simple greedy decoder
to the pytorch seq2seq model. When running this decoder I was still seeing
theses errors.

A deeper look into these errors and found that the errors were often an
output was actually an output from a different element in the batch that
was getting copied over other batch elements.

The problem was the `unsort_batch` function. The main point of this
function was that RNN's in pytorch require the examples in a batch to be
in sorted order based on their lengths (descending). To handle this we
would sort the batch based on the length during the initial call to
`make_input` but we need to undo this sort when returning the values.
Otherwise the returned outputs won't be aligned to the inputs.

The actual error was that we did the unsort with the in-place version of
`.scatter_`. This was being called in-place where the output and the
input was the same tensor. Do to various ordering in the sort you could
get a situation where the value at `i` should be at `j` and the value at
`j` should be at `k`. If the value at `i` is written to `j` before the
`j` is written to `k` then that `i` value will also be written to `k`. I
fixed this by using the output of place `.scatter` and created a new
output tensor that we are scattering into.

This change seems to have mostly fixed the problem. When running batches
of size 10 I have yet to see an error. As the batches get large I see an
occasional error this seems to be an actual error where the is like a
single value that is off by one rather than a completely different
output. This occurs on about 1 example in a batch size of 64 about half
the time.