### PR TITLE
fix: set pyt models to eval mode when calling predict

### DIFF
--- a/baseline/pytorch/classify/model.py
+++ b/baseline/pytorch/classify/model.py
@@ -112,6 +112,7 @@ class ClassifierModelBase(nn.Module, ClassifierModel):
         return probs
 
     def predict(self, batch_dict: Dict[str, TensorDef], raw: bool = False, dense: bool = False, **kwargs):
+        self.eval()
         probs = self.predict_batch(batch_dict, **kwargs)
         if raw and not dense:
             logger.warning(

--- a/baseline/pytorch/lm/model.py
+++ b/baseline/pytorch/lm/model.py
@@ -78,6 +78,7 @@ class LanguageModelBase(nn.Module, LanguageModel):
         """
 
     def predict(self, batch_dict, **kwargs):
+        self.eval()
         numpy_to_tensor = bool(kwargs.get('numpy_to_tensor', True))
         batch_dict = self.make_input(batch_dict, numpy_to_tensor=numpy_to_tensor)
         hidden = batch_dict.get('h')

--- a/baseline/pytorch/tagger/model.py
+++ b/baseline/pytorch/tagger/model.py
@@ -145,6 +145,7 @@ class TaggerModelBase(nn.Module, TaggerModel):
         * *numpy_to_tensor* (``bool``) Should we convert input from numpy to `torch.Tensor` Defaults to `True`
         :return: A batch-sized tensor of predictions
         """
+        self.eval()
         numpy_to_tensor = bool(kwargs.get('numpy_to_tensor', True))
         inputs, perm_idx = self.make_input(batch_dict, perm=True, numpy_to_tensor=numpy_to_tensor)
         outputs = self(inputs)


### PR DESCRIPTION
Currently when we load a pytorch model with a baseline service and call the predict method it often runs in training
mode where drop is turned on which is not what we want at test time. This PR updates the predict method of the tagger,
classifier, and lm to match the predict of the seq2seq model where it is always turned on.

Is there were we want to fix the problem? If someone wanted to do some sort of ensambling of different "draws" of the
model by running multiple times with dropout on they could because we would keep turning it off. The other option is
to set the model to eval mode in the the service, this would me something that would be done based on checking the
backend value