### PR TITLE
fix: surface downloaders from the top level of baseline

### DIFF
--- a/baseline/utils.py
+++ b/baseline/utils.py
@@ -25,6 +25,7 @@ import addons
 
 __all__ = []
 __all__.extend(eight_mile.utils.__all__)
+__all__.extend(eight_mile.downloads.__all__)
 logger = logging.getLogger('baseline')
 # These are inputs to models that shouldn't be saved out
 MAGIC_VARS = ['sess', 'tgt', 'y', 'lengths', 'gpus']


### PR DESCRIPTION
The downloder objects and functions weren't available with `from baseline
import DataDownloader`. This is because while they were imported in the
`baseline.utils` file it was never added to the `__all__` list. This meant
they wouldn't be included when you use `*` imports. This means that in the
baseline `__init__.py` where we import all the utils into the top level
they weren't included/accessible.

This PR fixes it by including things imported from
`eight_mile.downloads` in the `baseline.utils` `__all__` list.