### PR TITLE
fix: import fastBPE in `__setstate__` too

### DIFF
--- a/baseline/vectorizers.py
+++ b/baseline/vectorizers.py
@@ -388,6 +388,7 @@ class SavableFastBPE:
         return {'codes': self.codes, 'vocab': self.vocab}
 
     def __setstate__(self, state):
+        from fastBPE import fastBPE
         with tempfile.NamedTemporaryFile() as codes, tempfile.NamedTemporaryFile() as vocab:
             codes.write(state['codes'])
             vocab.write(state['vocab'])


### PR DESCRIPTION
When you unpickle an object that exposes a `__setstate__` that is called
first. This means the things like our `from fastBPE import fastBPE` in
the `__init__` of the `SaveableFastBPE` hasn't been called yet so we
don't have access to the fastBPE name here. This causes errors when
un-pickling (I think imports like that are scoped anyway so I think this
would have failed anyway).

This PR included a fastBPE import in the `__setstate__` call that I had
to add in order to get the vectorizer loading when using a fine-tuned
model with one of the api-example scripts.