### PR TITLE
fix: make sure the result from the conv1d is the same shape coming out

### DIFF
--- a/layers/eight_mile/pytorch/layers.py
+++ b/layers/eight_mile/pytorch/layers.py
@@ -315,8 +315,8 @@ class Conv1DSame(nn.Module):
         :param bias: Is bias on?
         """
         super().__init__()
-        start_pad = kernel_size // 2
-        end_pad = start_pad - 1 if kernel_size % 2 == 0 else start_pad
+        end_pad = kernel_size // 2
+        start_pad = end_pad - 1 if kernel_size % 2 == 0 else end_pad
         self.conv = nn.Sequential(
             nn.ConstantPad1d((start_pad, end_pad), 0.),
             nn.Conv1d(in_channels, out_channels, kernel_size, bias=bias)
@@ -519,11 +519,13 @@ class ParallelConv(nn.Module):
 
         self.output_dim = sum(outsz_filts)
         for i, fsz in enumerate(filtsz):
-            end_pad = fsz // 2
-            start_pad = end_pad - 1 if fsz % 2 == 0 else end_pad
+            if fsz % 2 == 0:
+                conv = Conv1DSame(insz, outsz_filts[i], fsz)
+            else:
+                pad = fsz // 2
+                conv = nn.Conv1d(insz, outsz_filts[i], fsz, padding=pad)
             conv = nn.Sequential(
-                nn.ConstantPad1d((start_pad, end_pad), 0.0),
-                nn.Conv1d(insz, outsz_filts[i], fsz),
+                conv,
                 get_activation(activation)
             )
             convs.append(conv)

--- a/layers/eight_mile/pytorch/layers.py
+++ b/layers/eight_mile/pytorch/layers.py
@@ -519,8 +519,13 @@ class ParallelConv(nn.Module):
 
         self.output_dim = sum(outsz_filts)
         for i, fsz in enumerate(filtsz):
-            pad = fsz // 2
-            conv = nn.Sequential(nn.Conv1d(insz, outsz_filts[i], fsz, padding=pad), get_activation(activation))
+            end_pad = fsz // 2
+            start_pad = end_pad - 1 if fsz % 2 == 0 else end_pad
+            conv = nn.Sequential(
+                nn.ConstantPad1d((start_pad, end_pad), 0.0),
+                nn.Conv1d(insz, outsz_filts[i], fsz),
+                get_activation(activation)
+            )
             convs.append(conv)
             # Add the module so its managed correctly
         self.convs = nn.ModuleList(convs)


### PR DESCRIPTION
This PR makes the output size of conv1d's that have even filter sizes the same shape as the input. It does this by padding one less on the front end to match tensorflow.

Tested by training a tensorflow model, converting it into a pytorch model by extracting weights from the checkpoint and comparing the results (both full prediction results as well as internal activation values) between the models. They match. Also tested in cases where the input time dimension was even and when it was odd