### PR TITLE
NPZ Serialization updates for TLMs and Transformer Seq2Seq Models

### DIFF
--- a/api-examples/pretrain_tlm_pytorch.py
+++ b/api-examples/pretrain_tlm_pytorch.py
@@ -179,7 +179,7 @@ def train():
     if args.restart_from:
 
         if args.restart_from.endswith('npz'):
-            load_tlm_npz(model, args.restart_from)
+            load_tlm_npz(model, args.restart_from, lm_head=True)
         else:
             model.load_state_dict(torch.load(args.restart_from))
         vec = args.restart_from.split("-")

--- a/api-examples/transformer_seq2seq_response.py
+++ b/api-examples/transformer_seq2seq_response.py
@@ -70,8 +70,7 @@ def create_model(embeddings, d_model, d_ff, num_heads, num_layers, rpr_k, d_k, a
            "rpr_k": rpr_k}
     model = TiedEmbeddingsSeq2SeqModel(embeddings, **hps)
     if checkpoint_name.endswith('npz'):
-        load_transformer_seq2seq_npz(model, checkpoint_name)
-        model.decoder.preds.weight = torch.nn.Parameter(model.decoder.tgt_embeddings.embeddings.weight)
+        load_transformer_seq2seq_npz(model, checkpoint_name, decode_head=True)
     else:
         model.load_state_dict(torch.load(checkpoint_name))
     model.eval()

--- a/layers/eight_mile/pytorch/serialize.py
+++ b/layers/eight_mile/pytorch/serialize.py
@@ -2,7 +2,7 @@ import torch
 import torch.nn as nn
 import numpy as np
 from typing import Dict, List
-from eight_mile.pytorch.layers import Dense, TransformerEncoderStack, TransformerEncoder, EmbeddingsStack
+from eight_mile.pytorch.layers import Dense, TransformerEncoderStack, TransformerEncoder, TransformerDecoderStack, TransformerDecoder, EmbeddingsStack
 from eight_mile.pytorch.embeddings import LookupTableEmbeddings, LearnedPositionalLookupTableEmbeddingsWithBias
 
 # BERT HuggingFace Tokenizers checkpoints can be converted into MEAD Baseline Transformer checkpoints
@@ -229,6 +229,39 @@ def from_encoder_array(pytorch_encoder: TransformerEncoder, d: Dict, name: str):
     from_ffn_array(pytorch_encoder.ffn, d, f"{name}/ffn")
 
 
+def from_decoder_array(pytorch_decoder: TransformerDecoder, d: Dict, name: str):
+    """Restore a `TransformerDecoder` layer from a set of numpy arrays
+
+    :param pytorch_decoder: A `TransformerDecoder` layer
+    :param d: A Dict of arrays by key
+    :param name: The layer name
+    :return: None
+    """
+    from_weight_array(pytorch_decoder.ln1, d, f"{name}/ln1")
+    from_weight_array(pytorch_decoder.ln2, d, f"{name}/ln2")
+    from_weight_array(pytorch_decoder.ln2, d, f"{name}/ln3")
+    from_attn_array(pytorch_decoder.src_attn, d, f"{name}/src_attn")
+    from_attn_array(pytorch_decoder.self_attn, d, f"{name}/self_attn")
+    from_ffn_array(pytorch_decoder.ffn, d, f"{name}/ffn")
+
+
+def to_decoder_array(pytorch_decoder: TransformerDecoder, name: str) -> Dict:
+    """Convert a `TransformerDeccoder` layer to an set of numpy arrays
+
+    :param pytorch_decoder: A `TransformerDecoder` layer
+    :param name: The layer name
+    :return: A Dict of arrays by key
+    """
+    d = {}
+    d.update(to_weight_array(pytorch_decoder.ln1, f"{name}/ln1"))
+    d.update(to_weight_array(pytorch_decoder.ln2, f"{name}/ln2"))
+    d.update(to_weight_array(pytorch_decoder.ln2, f"{name}/ln3"))
+    d.update(to_attn_array(pytorch_decoder.self_attn, f"{name}/self_attn"))
+    d.update(to_attn_array(pytorch_decoder.src_attn, f"{name}/src_attn"))
+    d.update(to_ffn_array(pytorch_decoder.ffn, f"{name}/ffn"))
+    return d
+
+
 def to_embed_array(pytorch_embed: nn.Module, name: str) -> Dict:
     """Convert positional embedding to a `weights` array, if it's learned positional embedding,
     save the pos_weight as well
@@ -299,6 +332,37 @@ def save_tlm_npz(pytorch_tlm: nn.Module, npz: str, embeddings_keys: List[str] = 
     np.savez(npz, **d)
 
 
+def save_transformer_seq2seq_npz(pytorch_seq2seq: nn.Module, npz: str, src_embeddings_keys: List[str] = None,
+                                 tgt_embedding_key: str = 'y', name: str = "Seq2Seq", verbose: bool = False):
+    """Save a Transformer seq2seq file out
+
+    The will be in pytorch_seq2seq.encoder.transformer, and the usual conversions work for that (via `to_tlm_array()`).
+    The decoder requires a new converter for the portion containing attention weights between the encoder and the decoder
+
+    :param pytorch_seq2seq: A Transformer Seq2Seq module
+    """
+    #enc = to_tlm_array(tf_seq2seq.encoder, embeddings_keys, name=f'{name}/Encoder')
+
+    enc = {}
+    transformer = pytorch_seq2seq.encoder.transformer
+    enc.update(to_encoder_stack_array(transformer, name=f"{name}/TransformerEncoderStack"))
+    enc_keys_to_write = src_embeddings_keys if src_embeddings_keys else list(pytorch_seq2seq.src_embeddings.keys())
+
+    for embeddings_key in enc_keys_to_write:
+        enc.update(to_embed_array(pytorch_seq2seq.src_embeddings[embeddings_key], name=f"{name}/SrcEmbeddings/{embeddings_key}"))
+
+    dec = {}
+    transformer_decoder = pytorch_seq2seq.decoder.transformer_decoder
+
+    dec.update(to_decoder_stack_array(transformer_decoder, name=f"{name}/TransformerDecoderStack"))
+    dec.update(to_embed_array(pytorch_seq2seq.tgt_embedding, name=f"{name}/TgtEmbedding/{tgt_embedding_key}"))
+
+    if verbose:
+        print(enc.keys())
+        print(dec.keys())
+    np.savez(npz, **enc, **dec)
+
+
 def to_encoder_stack_array(
     pytorch_encoder_stack: TransformerEncoderStack, name: str = "TransformerEncoderStack"
 ) -> Dict:
@@ -332,6 +396,39 @@ def from_encoder_stack_array(
         from_encoder_array(enc_pyt, d, f"{name}/{i}")
 
 
+def to_decoder_stack_array(
+    pytorch_decoder_stack: TransformerDecoderStack, name: str = "TransformerDecoderStack"
+) -> Dict:
+    """Convert a `TransformerDecoderStack` to a set of weights
+
+    :param pytorch_decoder_stack: A transformer decoder stack
+    :param name: A name
+    :return: A Dict containing a set of weights
+    """
+    d = {}
+    if isinstance(pytorch_decoder_stack.ln, nn.LayerNorm):
+        d.update(to_weight_array(pytorch_decoder_stack.ln, f"{name}/ln"))
+    for i, dec_pytorch in enumerate(pytorch_decoder_stack.decoders):
+        d.update(to_decoder_array(dec_pytorch, f"{name}/{i}"))
+    return d
+
+
+def from_decoder_stack_array(
+    pytorch_decoder_stack: TransformerDecoderStack, d: Dict, name: str = "TransformerDecoderStack"
+):
+    """Restore weights from a `TransformerDecoderStack`
+
+    :param pytorch_decoder_stack: A transformer decoder stack
+    :param d: A Dict containing sets of arrays
+    :param name: A name for this primitive
+    :return: None
+    """
+    if isinstance(pytorch_decoder_stack.ln, nn.LayerNorm):
+        from_weight_array(pytorch_decoder_stack.ln, d, f"{name}/ln")
+    for i, dec_pyt in enumerate(pytorch_decoder_stack.decoders):
+        from_decoder_array(dec_pyt, d, f"{name}/{i}")
+
+
 def from_tlm_array(pytorch_tlm: nn.Module, d: Dict, embeddings_keys: List[str] = None, name: str = "TLM"):
     """Restore a TLM-like model (possibly a `nn.Module` for fine-tuning)
 
@@ -359,7 +456,6 @@ def from_tlm_array(pytorch_tlm: nn.Module, d: Dict, embeddings_keys: List[str] =
         from_weight_array(pytorch_tlm.embeddings.reduction.ln, d, f"{name}/Embeddings/reduction/ln")
 
 
-
 def load_tlm_npz(pytorch_tlm: nn.Module, npz: str, embeddings_keys: List[str] = None, name: str = "TLM"):
     """Restore a TLM-like model (possibly a `nn.Module` for fine-tuning
 
@@ -374,6 +470,32 @@ def load_tlm_npz(pytorch_tlm: nn.Module, npz: str, embeddings_keys: List[str] = 
     """
     d = np.load(npz)
     from_tlm_array(pytorch_tlm, d, embeddings_keys, name)
+
+
+def load_transformer_seq2seq_npz(pytorch_seq2seq: nn.Module, npz: str, src_embeddings_keys: List[str] = None,
+                                 tgt_embedding_key: str = 'y', name: str = "Seq2Seq"):
+    """Save a Transformer seq2seq file out
+
+    The will be in pytorch_seq2seq.encoder.transformer, and the usual conversions work for that (via `to_tlm_array()`).
+    The decoder requires a new converter for the portion containing attention weights between the encoder and the decoder
+
+    :param pytorch_seq2seq: A Transformer Seq2Seq module
+    """
+
+    d = np.load(npz)
+
+    transformer = pytorch_seq2seq.encoder.transformer
+    from_encoder_stack_array(transformer, d, name=f"{name}/TransformerEncoderStack")
+
+    enc_keys_to_restore = src_embeddings_keys if src_embeddings_keys else list(pytorch_seq2seq.src_embeddings.keys())
+
+    for embeddings_key in enc_keys_to_restore:
+        from_embed_array(pytorch_seq2seq.src_embeddings[embeddings_key], d, f"{name}/SrcEmbeddings/{embeddings_key}")
+
+    transformer_decoder = pytorch_seq2seq.decoder.transformer_decoder
+
+    from_decoder_stack_array(transformer_decoder, d,  name=f"{name}/TransformerDecoderStack")
+    from_embed_array(pytorch_seq2seq.decoder.tgt_embeddings, d, name=f"{name}/TgtEmbedding/{tgt_embedding_key}")
 
 
 def load_tlm_transformers_bin(pytorch_tlm: nn.Module, bin_file: str, replace_layers=BERT_HF_LAYER_MAP, replace_embeds=BERT_HF_EMBED_MAP):

--- a/layers/eight_mile/tf/serialize.py
+++ b/layers/eight_mile/tf/serialize.py
@@ -303,6 +303,7 @@ def save_tlm_npz(tf_tlm: tf.keras.layers.Layer, npz: str, embeddings_keys: List[
         print(d.keys())
     np.savez(npz, **d)
 
+
 def save_transformer_seq2seq_npz(tf_seq2seq: tf.keras.layers.Layer, npz: str, src_embeddings_keys: List[str] = None,
                                  tgt_embedding_key: str = 'y', name: str = "Seq2Seq", verbose: bool = False):
     """Save a Transformer seq2seq file out
@@ -324,7 +325,6 @@ def save_transformer_seq2seq_npz(tf_seq2seq: tf.keras.layers.Layer, npz: str, sr
 
     dec = {}
     transformer_decoder = tf_seq2seq.decoder.transformer_decoder
-
 
     dec.update(to_decoder_stack_array(transformer_decoder, name=f"{name}/TransformerDecoderStack"))
     dec.update(to_embed_array(tf_seq2seq.tgt_embedding, name=f"{name}/TgtEmbedding/{tgt_embedding_key}"))


### PR DESCRIPTION
Includes changes to support seq2seq NPZ but also to support reloading TLMs and Seq2Seq with heads.  This makes it possible to continue to use as a LM even when switching from TF to PyTorch, e.g. for downstream fine-tuning or LM analysis