### PR TITLE
chore: let us read the model and vocab bpe files from a remote location

### DIFF
--- a/baseline/reader.py
+++ b/baseline/reader.py
@@ -6,7 +6,7 @@ from collections import Counter
 import numpy as np
 import baseline.data
 from baseline.vectorizers import Dict1DVectorizer, GOVectorizer, Token1DVectorizer, create_vectorizer
-from baseline.utils import import_user_module, revlut, exporter, optional_params, Offsets, listify
+from baseline.utils import import_user_module, revlut, exporter, optional_params, Offsets, listify, SingleFileDownloader
 
 __all__ = []
 export = exporter(__all__)
@@ -274,6 +274,11 @@ class SeqPredictReader(object):
         self.truncate = truncate
         label_vectorizer_spec = kwargs.get('label_vectorizer', None)
         if label_vectorizer_spec:
+            cache = label_vectorizer_spec.get("data_download_cache", os.path.expanduser("~/.bl-data"))
+            if 'model_file' in label_vectorizer_spec:
+                label_vectorizer_spec['model_file'] = SingleFileDownloader(label_vectorizer_spec['model_file'], cache).download()
+            if 'vocab_file' in label_vectorizer_spec:
+                label_vectorizer_spec['vocab_file'] = SingleFileDownloader(label_vectorizer_spec['vocab_file'], cache).download()
             self.label_vectorizer = create_vectorizer(**label_vectorizer_spec)
         else:
             self.label_vectorizer = Dict1DVectorizer(fields='y', mxlen=mxlen)

--- a/mead/tasks.py
+++ b/mead/tasks.py
@@ -171,6 +171,10 @@ class Task(object):
                 vectorizer_section['file'] = vec_file
             vectorizer_section['mxlen'] = vectorizer_section.get('mxlen', self.config_params.get('preproc', {}).get('mxlen', -1))
             vectorizer_section['mxwlen'] = vectorizer_section.get('mxwlen', self.config_params.get('preproc', {}).get('mxwlen', -1))
+            if 'model_file' in vectorizer_section:
+                vectorizer_section['model_file'] = SingleFileDownloader(vectorizer_section['model_file'], self.data_download_cache).download()
+            if 'vocab_file' in vectorizer_section:
+                vectorizer_section['vocab_file'] = SingleFileDownloader(vectorizer_section['vocab_file'], self.data_download_cache).download()
             if 'transform' in vectorizer_section:
                 vectorizer_section['transform_fn'] = eval(vectorizer_section['transform'])
             vectorizer = baseline.create_vectorizer(**vectorizer_section)


### PR DESCRIPTION
This PR adds the ability to read code and vocab file for BPE vectorizers from a remote url. I did this manually instead of using `read_config_stream` because that one defaults to trying to open a file with `read_config_file` which assumes json/yaml when it isn't a remote location. This code will download the file into cache if it is a remote location and then open it from there.

If anyone has a better way to do this or things the download should happen in the BPE part lmk