### PR TITLE
fix: make bert ONNX exportable

### DIFF
--- a/baseline/services.py
+++ b/baseline/services.py
@@ -488,14 +488,17 @@ class TaggerService(Service):
         outputs = []
         for i, outcome in enumerate(predicted):
             output = []
-            for j, token in enumerate(tokens_batch[i]):
+            j = 0
+            for token in tokens_batch[i]:
                 new_token = dict()
                 new_token.update(token)
-                if self.return_labels:
-                    new_token[label_field] = outcome[j]
-                else:
-                    new_token[label_field] = self.label_vocab[outcome[j].item()]
+                label = outcome[j] if self.return_labels else self.label_vocab[outcome[j].item()]
+                while label == Offsets.VALUES[Offsets.PAD] and j < len(outcome) - 1:
+                    j += 1
+                    label = outcome[j] if self.return_labels else self.label_vocab[outcome[j].item()]
+                new_token[label_field] = label
                 output += [new_token]
+                j += 1
             outputs += [output]
         return outputs
 

--- a/baseline/vectorizers.py
+++ b/baseline/vectorizers.py
@@ -936,9 +936,14 @@ class WordpieceDict1DVectorizer(WordpieceVectorizer1D):
     def iterable(self, tokens):
         yield '[CLS]'
         for t in tokens:
-            tok = t[self.field]
-            for subtok in self.tokenizer.tokenize(tok):
-                yield subtok
+            tok = t[self.field] if isinstance(t, dict) else t
+            if tok == '<unk>':
+                yield '[UNK]'
+            elif tok == '<EOS>':
+                yield '[SEP]'
+            else:
+                for subtok in self.tokenizer.tokenize(self.transform_fn(tok)):
+                    yield subtok
         yield '[SEP]'
 
 

--- a/mead/pytorch/exporters.py
+++ b/mead/pytorch/exporters.py
@@ -83,7 +83,7 @@ class PytorchONNXExporter(Exporter):
         self.transpose = kwargs.get('transpose', False)
         self.tracing = kwargs.get('tracing', True)
         self.default_size = int(kwargs.get('default_size', 100))
-        self.onnx_opset = int(kwargs.get('onnx_opset', 11))
+        self.onnx_opset = int(kwargs.get('onnx_opset', 12))
 
     def apply_model_patches(self, model):
         return model


### PR DESCRIPTION
The `WordpieceDict1DVectorizer` didn't handle the case where the input
was just a list of tokens that same way the `Dict1DVectorizer`s did
which causes problems because the fake data was always passed in as a
list of tokens.

This updates the `.iterable` method to handle the list of tokens case.
It also updates the method to match the version in
`Wordpiece1DVectorizer`.

This also updates the way labels are read and assigned to tokens in the
`.format_output` method of the taggers. Basically the bert models were
outputing things like the `<PAD>` symbol for the subtokens and we needed
to skip those.

It also bumps the opset we use for ONNX because if you have a lengths
key that goes unused when the ONNX export traces you model then that
input is thrown away in the exported model. Then when you predict with
that key you get an error. Opset 12 will keep that input and remove the error.