### PR TITLE
fix windowed ra: specify squeeze axis

### DIFF
--- a/layers/eight_mile/pytorch/layers.py
+++ b/layers/eight_mile/pytorch/layers.py
@@ -2752,7 +2752,7 @@ class SeqScaledWindowedRelativeAttention(SequenceSequenceRelativeAttention):
         rpr_value = rpr_value.unsqueeze(0).unsqueeze(0).unsqueeze(0)  # [1, 1, 1, W, d_k]
         updated_values = torch.matmul(a, value)  # [B, H, T, 1, d_k]
         update_rpr_values = torch.matmul(a, rpr_value)  # [B, H, T, 1, d_k]
-        return (updated_values + update_rpr_values).squeeze()  # [B, H, T, d_k]
+        return (updated_values + update_rpr_values).squeeze(3)  # [B, H, T, d_k]
 
 
 class SeqBahdanauAttention(SequenceSequenceAttention):

--- a/layers/eight_mile/tf/layers.py
+++ b/layers/eight_mile/tf/layers.py
@@ -2311,7 +2311,7 @@ class SeqScaledWindowedRelativeAttention(SequenceSequenceRelativeAttention):
         rpr_value = tf.expand_dims(tf.expand_dims(tf.expand_dims(rpr_value, 0), 0), 0)  # [1, 1, 1, W, d_k]
         updated_values = tf.matmul(a, value)  # [B, H, T, 1, d_k]
         update_rpr_values = tf.matmul(a, rpr_value)  # [B, H, T, 1, d_k]
-        return tf.squeeze(updated_values + update_rpr_values)  # [B, H, T, d_k]
+        return tf.squeeze(updated_values + update_rpr_values, axis=3)  # [B, H, T, d_k]
 
 
 class SeqDotProductAttention(SequenceSequenceAttention):


### PR DESCRIPTION
Need to specify the squeeze axis, otherwise it'll break when batchsize or num_heads is 1. 