### PR TITLE
fix: correctly export viterbi decoding to ONNX

### DIFF
--- a/layers/eight_mile/pytorch/layers.py
+++ b/layers/eight_mile/pytorch/layers.py
@@ -1998,8 +1998,8 @@ def script_viterbi(
     fill_value: float = -1e4
     alphas = torch.full((num_tags,), fill_value, dtype=unary.dtype, device=unary.device)
     broadcast_idx = torch.full((num_tags,), start_idx, dtype=torch.long)
-    alphas.scatter_(0, broadcast_idx, torch.zeros((num_tags,)))
-    alphas.unsqueeze_(0)
+    alphas = alphas.scatter(0, broadcast_idx, torch.zeros((num_tags,)))
+    alphas = alphas.unsqueeze(0)
     backpointers: torch.Tensor = torch.zeros(num_tags, dtype=torch.long).unsqueeze(0)
     for i in range(seq_len):
         unary_t = unary[i, :]


### PR DESCRIPTION
When you do inplace operations like this in a `@torch.jit.script`
function and export to ONNX it doesn't register the changes to the
tensor as things that happen and they get stripped out of the graph. It
means that our initial `alphas` value as all `-1e4` instead of having a
`0` in the starting index. This was causing different results between
the pytorch models and the onnx exported ones.

This PR fixes the problem by using out of place operations, tested by
running 1000 random unary, trans, lengths triple through the pytorch
version of just the viterbi decoder and the onnx version of just the
decoder. Both the resulting paths and the scores had a 100% match rate
(compared to only ~35% before the fix). I also trained a tagger on conll
and run the pytorch `.zip` and the onnx export over the test set and
they produced identical results.