### PR TITLE
fix: exporting for constrained decoding pyt models

### DIFF
--- a/mead/pytorch/exporters.py
+++ b/mead/pytorch/exporters.py
@@ -3,7 +3,12 @@ import logging
 import torch
 import torch.nn as nn
 import baseline as bl
-from eight_mile.pytorch.layers import CRF, ViterbiBatchSize1
+from eight_mile.pytorch.layers import (
+    CRF,
+    ViterbiBatchSize1,
+    TaggerGreedyDecoder,
+    ViterbiLogSoftmaxNormBatchSize1
+)
 from baseline.utils import (
     exporter,
     Offsets,
@@ -190,4 +195,9 @@ class TaggerPytorchONNXExporter(PytorchONNXExporter):
             if isinstance(model.decoder, CRF):
                 model.decoder.viterbi = ViterbiBatchSize1(model.decoder.viterbi.start_idx,
                                                           model.decoder.viterbi.end_idx)
+            elif isinstance(model.decoder, TaggerGreedyDecoder):
+                model.decoder.viterbi = ViterbiLogSoftmaxNormBatchSize1(
+                    model.decoder.viterbi.start_idx,
+                    model.decoder.viterbi.end_idx
+                )
         return model


### PR DESCRIPTION
Models using only constrained decoding (no CRF) weren't getting their
Viterbi module swapped out for a batch size 1 version. This casued them
to error when exporting.

This PR fixes that.

_note_ ONNX doesn't support the `F.log_softmax` op so I just did
`torch.log(F.softmax(x, dim=-1))`. I haven't noticed a difference yet.