### PR TITLE
make WeightTiedDense lazy via a weight property

### DIFF
--- a/api-examples/generate_mlm.py
+++ b/api-examples/generate_mlm.py
@@ -74,7 +74,7 @@ def create_model(embeddings, d_model, d_ff, num_heads, num_layers, rpr_k, d_k, c
                                                   activation=activation,
                                                   src_keys=['x'], tgt_key='x')
     if checkpoint_name.endswith('npz'):
-        load_tlm_npz(model, checkpoint_name, lm_head=True)
+        load_tlm_npz(model, checkpoint_name)
         #model.output_layer = WeightTieDense(model.embeddings['x'])
     else:
         tlm_load_state_dict(model, checkpoint_name)

--- a/api-examples/pretrain_tlm_pytorch.py
+++ b/api-examples/pretrain_tlm_pytorch.py
@@ -181,7 +181,7 @@ def train():
     if args.restart_from:
 
         if args.restart_from.endswith('npz'):
-            load_tlm_npz(model, args.restart_from, lm_head=True)
+            load_tlm_npz(model, args.restart_from)
         else:
             model.load_state_dict(torch.load(args.restart_from))
         vec = args.restart_from.split("-")

--- a/api-examples/transformer_seq2seq_response.py
+++ b/api-examples/transformer_seq2seq_response.py
@@ -70,7 +70,7 @@ def create_model(embeddings, d_model, d_ff, num_heads, num_layers, rpr_k, d_k, a
            "rpr_k": rpr_k}
     model = TiedEmbeddingsSeq2SeqModel(embeddings, **hps)
     if checkpoint_name.endswith('npz'):
-        load_transformer_seq2seq_npz(model, checkpoint_name, decode_head=True)
+        load_transformer_seq2seq_npz(model, checkpoint_name)
     else:
         model.load_state_dict(torch.load(checkpoint_name))
     model.eval()

--- a/docs/fine-tuning.md
+++ b/docs/fine-tuning.md
@@ -159,17 +159,7 @@ an NPZ and can hydrate a model from those checkpoints as well.  The checkpoints 
 checkpoint.
 
 Please note that the checkpoints that are written during pre-training or export are headless as they are typically used
-for downstream processing.  However, for models with tied embeddings (most models), it is possible to restore
-the original language model or encoder-decoder, by properly resetting the `WeightTieDense` module. 
-For Masked Language models, use:
+for downstream processing.  However, for models with tied embeddings (most models), the heads will automatically be
+restored to the tied module since `weight` is property that is tied to the other module's `.weight`
 
-```python
-load_tlm_npz(model, checkpoint_name, lm_head=True)
-```
-
-For Encoder-Decoder models, use:
-
-```python
-load_transformer_seq2seq_npz(model, checkpoint_name, decode_head=True)
-```
 

--- a/layers/eight_mile/pytorch/layers.py
+++ b/layers/eight_mile/pytorch/layers.py
@@ -714,23 +714,34 @@ class Dense(nn.Module):
 
 class WeightTieDense(nn.Module):
     """Do weight tying from the input parameter
+
+    This module never copies the weight pointer, it lazily accesses to allow the tied variable to reset its parameters
+    after initialization.  This is helpful for cases where we have LMs and are reloading them after they have been
+    initially created
     """
 
     def __init__(self, tie: nn.Module, bias=False):
         super().__init__()
         self.tie = tie
-        self.weight, self.transform = self._get_weight(tie)
+        self.transform = self._get_transform(tie)
         if bias:
-            bias = torch.nn.Parameter(torch.zeros(self.transform(self.weight).shape[0]))
+            bias = torch.nn.Parameter(torch.zeros(self.transform(self.weight.shape[0])))
         else:
             bias = None
         self.register_parameter("bias", bias)
 
-    def _get_weight(self, tie: nn.Module):
+    def _get_transform(self, tie: nn.Module):
         emb = getattr(tie, "embeddings", None)
         if emb is not None:
-            return getattr(emb, "weight"), self._identity
-        return getattr(tie, "weight"), self._transpose
+            return self._identity
+        return self._transpose
+
+    @property
+    def weight(self):
+        emb = getattr(self.tie, "embeddings", None)
+        if emb is not None:
+            return getattr(emb, "weight")
+        return getattr(self.tie, "weight")
 
     def _identity(self, x: torch.Tensor) -> torch.Tensor:
         return x

--- a/layers/eight_mile/tf/layers.py
+++ b/layers/eight_mile/tf/layers.py
@@ -1865,19 +1865,21 @@ class WeightTieDense(tf.keras.layers.Layer):
     def build(self, input_shape):
         emb = getattr(self.tied, "embedding_layer", None)
         if emb is not None:
-            self.W = getattr(emb, "W")
-            self._add_bias(self.W)
+            self._add_bias(getattr(emb, "W"))
             super().build(input_shape)
             return
         W = getattr(self.tied, "W", None)
         if W is not None:
-            self.W = W
-            self._add_bias(self.W)
+            self._add_bias(W)
             super().build(input_shape)
             return
-        self.W = getattr(self.tied, "kernel")
         self._add_bias(self.W)
         super().build()
+
+    @property
+    def W(self):
+        w = getattr(self.tied, "W", None)
+        return w if w is not None else getattr(self.tied, "kernel")
 
     def call(self, inputs):
         shape = tf.shape(inputs)


### PR DESCRIPTION
this change makes weight tying module use the
tied module's underlying weight directly instead of
copying a pointer parameter.  Previously we were using a
pointer, which causes problems when the module is
rehydrated from disk after first initialization.

This was found because the number of parameters in the
model was increasing after embeddings were reloaded,
which were tied to an LM head.  One other nice property of
deferring to the "held" module is that we dont need properties
instructing us reload the LM head, because this will happen
automatically for models with a tied head, simplifying TLM
(and TiedSeq2Seq) reloads from checkpoints

The only concern with this approach is that there is now
a function powering the `weight` which may cause a bit of latency,
though compared to the matrix multiply this is probably negligable.
Prior to this change however, there was (at a minimum) some memory
that shouldve been freeable that was still being tracked in PyTorch,
and at worst, may have been affecting the NN fine-tuning