### PR TITLE
chore: test on more versions

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -4,11 +4,9 @@ on:
   push:
     branches:
     - master
-    - feature/v2
   pull_request:
     branches:
     - master
-    - feature/v2
 
 jobs:
   test-tf-1:
@@ -32,7 +30,7 @@ jobs:
       run: |
         pytest --forked
 
-  test-tf-2:
+  test-tf-2-0:
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 4
@@ -53,13 +51,15 @@ jobs:
       run: |
         pytest --forked
 
-  test-tf-2-1:
+  test-tf-2:
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 4
       matrix:
         tf-version:
         - 2.1.0
+        - 2.2.0
+        - 2.3.0
     container: tensorflow/tensorflow:${{matrix.tf-version}}-py3
     steps:
     - uses: actions/checkout@v2
@@ -81,8 +81,9 @@ jobs:
       matrix:
         pyt-version:
         - 1.3-cuda10.1-cudnn7-runtime
-        - 1.5-cuda10.1-cudnn7-runtime
         - 1.4-cuda10.1-cudnn7-runtime
+        - 1.5-cuda10.1-cudnn7-runtime
+        - 1.6.0-cuda10.1-cudnn7-runtime
     container: pytorch/pytorch:${{matrix.pyt-version}}
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -51,15 +51,13 @@ jobs:
       run: |
         pytest --forked
 
-  test-tf-2:
+  test-tf-2-1:
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 4
       matrix:
         tf-version:
         - 2.1.0
-        - 2.2.0
-        - 2.3.0
     container: tensorflow/tensorflow:${{matrix.tf-version}}-py3
     steps:
     - uses: actions/checkout@v2
@@ -69,6 +67,28 @@ jobs:
         pip install -e .
         cd ..
         pip install tensorflow_addons==0.9.1
+        pip install -e .[test,yaml]
+    - name: Unit Test Tf ${{matrix.tf-version}}
+      run: |
+        pytest --forked
+
+  test-tf-2:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        tf-version:
+        - 2.2.0
+        - 2.3.0
+    container: tensorflow/tensorflow:${{matrix.tf-version}}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install Baseline
+      run: |
+        cd layers
+        pip install -e .
+        cd ..
+        pip install tensorflow_addons
         pip install -e .[test,yaml]
     - name: Unit Test Tf ${{matrix.tf-version}}
       run: |

--- a/layers/eight_mile/pytorch/layers.py
+++ b/layers/eight_mile/pytorch/layers.py
@@ -3422,7 +3422,7 @@ class BeamSearchBase:
                 # Get the log_probs of the best scoring beams
                 log_probs = probs.view(bsz, -1).gather(1, best_idx).view(bsz, self.K)
 
-                best_beams = best_idx / V  # Get which beam it came from
+                best_beams = best_idx // V  # Get which beam it came from
                 best_idx = best_idx % V  # Get the index of the word regardless of which beam it is.
 
                 # Best Beam index is relative within the batch (only [0, K)).


### PR DESCRIPTION
This PR extends the versions of various frameworks we test on.

I had to create a new job for the newer TF models because they dropped the `-py3` suffix from their docker containers.

Also right now these all work wilth installing the latest `tensorflow_addons` but if we ever get errors about the newest version of that not supporting older tfs we will need to break the tf out into it's own job like we have for `2.0` and `2.1`

I also dropped the triggering of the action on `feature/v2` because we don't use that branch anymore