### PR TITLE
get rid of error-prone py2 style supers

### DIFF
--- a/addons/reader_conllcased.py
+++ b/addons/reader_conllcased.py
@@ -12,7 +12,7 @@ class CONLLSeqMixedCaseReader(CONLLSeqReader):
 
     def __init__(self, max_sentence_length=-1, max_word_length=-1, word_trans_fn=None,
                  vec_alloc=np.zeros, vec_shape=np.shape, trim=False, extended_features=dict()):
-        super(CONLLSeqMixedCaseReader, self).__init__(max_sentence_length, max_word_length, word_trans_fn, vec_alloc, vec_shape, trim, extended_features)
+        super().__init__(max_sentence_length, max_word_length, word_trans_fn, vec_alloc, vec_shape, trim, extended_features)
         self.idx = 2 # GO=0, START=1, EOS=2
 
 

--- a/addons/reader_pandas.py
+++ b/addons/reader_pandas.py
@@ -9,7 +9,7 @@ from baseline.reader import TSVSeqLabelReader, register_reader
 @register_reader(task='classify', name='pandas')
 class PandasReader(TSVSeqLabelReader):
     def __init__(self, vectorizers, trim=False, **kwargs):
-        super(PandasReader, self).__init__(vectorizers, trim, **kwargs)
+        super().__init__(vectorizers, trim, **kwargs)
         self.label = kwargs.get('label', 'label')
         self.text = kwargs.get('text', 'text')
         self.sep = kwargs.get('sep', ',')

--- a/addons/reader_parallel_classify.py
+++ b/addons/reader_parallel_classify.py
@@ -19,7 +19,7 @@ class ParallelSeqLabelReader(SeqLabelReader):
                 }
 
     def __init__(self, vectorizers, trim=False, truncate=False, **kwargs):
-        super(ParallelSeqLabelReader, self).__init__()
+        super().__init__()
 
         self.label2index = {}
         self.vectorizers = vectorizers

--- a/addons/vec_text.py
+++ b/addons/vec_text.py
@@ -29,7 +29,7 @@ class Text1DVectorizer(Token1DVectorizer):
 @register_vectorizer(name='dict_text')
 class DictText1DVectorizer(Text1DVectorizer):
     def __init__(self, **kwargs):
-        super(DictText1DVectorizer, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.fields = listify(kwargs.get('fields', 'text'))
         self.delim = kwargs.get('token_delim', '@@')
 

--- a/api-examples/transformer_utils.py
+++ b/api-examples/transformer_utils.py
@@ -292,7 +292,7 @@ class TensorCharDatasetReader(TensorDatasetReaderBase):
     def __init__(self, nctx, chars_per_word):
         y_vectorizer = Token1DVectorizer(transform_fn=baseline.lowercase)
         x_vectorizer = Char2DVectorizer(mxwlen=chars_per_word)
-        super(TensorCharDatasetReader, self).__init__(nctx, {'x': x_vectorizer, 'y': y_vectorizer})
+        super().__init__(nctx, {'x': x_vectorizer, 'y': y_vectorizer})
         self.chars_per_word = chars_per_word
 
     def load(self, filename, vocabs):

--- a/baseline/data.py
+++ b/baseline/data.py
@@ -65,7 +65,7 @@ class ExampleDataFeed(DataFeed):
                 a full batch cannot be made, otherwise the final batch is smaller
                 than normal batches.
         """
-        super(ExampleDataFeed, self).__init__()
+        super().__init__()
 
         self.examples = examples
         self.batchsz = batchsz

--- a/baseline/pytorch/seq2seq/train.py
+++ b/baseline/pytorch/seq2seq/train.py
@@ -54,7 +54,7 @@ class Seq2SeqTrainerPyTorch(Trainer):
         return self.model.module if self.gpus > 1 else self.model
 
     def calc_metrics(self, agg, norm):
-        metrics = super(Seq2SeqTrainerPyTorch, self).calc_metrics(agg, norm)
+        metrics = super().calc_metrics(agg, norm)
         metrics['perplexity'] = np.exp(metrics['avg_loss'])
         return metrics
 

--- a/baseline/reader.py
+++ b/baseline/reader.py
@@ -265,7 +265,7 @@ class MultiFileParallelCorpusReader(ParallelCorpusReader):
 
 
 @export
-class SeqPredictReader(object):
+class SeqPredictReader:
 
     def __init__(self, vectorizers, trim=False, truncate=False, mxlen=-1, **kwargs):
         super().__init__()

--- a/baseline/remote.py
+++ b/baseline/remote.py
@@ -124,7 +124,7 @@ class RemoteModelREST(RemoteModel):
         :param return_labels: Whether the remote model returns class indices or the class labels directly. This depends
         on the `return_labels` parameter in exporters
         """
-        super(RemoteModelREST, self).__init__(
+        super().__init__(
             remote, name, signature, labels, beam, lengths_key, inputs, version, return_labels
         )
         url = urlparse(self.remote)
@@ -258,7 +258,7 @@ class RemoteModelGRPC(RemoteModel):
         :param return_labels: Whether the remote model returns class indices or the class labels directly. This depends
         on the `return_labels` parameter in exporters
         """
-        super(RemoteModelGRPC, self).__init__(
+        super().__init__(
             remote, name, signature, labels, beam, lengths_key, inputs, version, return_labels
         )
         self.predictpb = import_user_module('baseline.tensorflow_serving.apis.predict_pb2')

--- a/baseline/reporting.py
+++ b/baseline/reporting.py
@@ -57,7 +57,7 @@ class StepReportingHook(ReportingHook):
 @register_reporting(name='console')
 class ConsoleReporting(EpochReportingHook):
     def __init__(self, **kwargs):
-        super(ConsoleReporting, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     def _step(self, metrics, tick, phase, tick_type=None, **kwargs):
         """Write results to `stdout`
@@ -80,7 +80,7 @@ class ConsoleReporting(EpochReportingHook):
 @register_reporting(name='step_logging')
 class StepLoggingReporting(StepReportingHook):
     def __init__(self, **kwargs):
-        super(StepLoggingReporting, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.log = logging.getLogger('baseline')
 
     def _step(self, metrics, tick, phase, tick_type=None, **kwargs):
@@ -101,7 +101,7 @@ class StepLoggingReporting(StepReportingHook):
 @register_reporting(name='logging')
 class LoggingReporting(EpochReportingHook):
     def __init__(self, **kwargs):
-        super(LoggingReporting, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.log = logging.getLogger('baseline.reporting')
 
     def _step(self, metrics, tick, phase, tick_type=None, **kwargs):

--- a/baseline/services.py
+++ b/baseline/services.py
@@ -743,7 +743,7 @@ class EncoderDecoderService(Service):
         return 'suggest_text'
 
     def __init__(self, vocabs=None, vectorizers=None, model=None, preproc='client'):
-        super(EncoderDecoderService, self).__init__(None, None, model, preproc)
+        super().__init__(None, None, model, preproc)
         self.src_vocabs = {}
         self.tgt_vocab = None
         for k, vocab in vocabs.items():

--- a/baseline/tf/lm/training/utils.py
+++ b/baseline/tf/lm/training/utils.py
@@ -88,7 +88,7 @@ class LanguageModelTrainerTf(Trainer):
     When the latter, we will use the baseline DataFeed to read the object into the `feed_dict`
     """
     def __init__(self, model_params, **kwargs):
-        super(LanguageModelTrainerTf, self).__init__()
+        super().__init__()
         if type(model_params) is dict:
             self.model = create_model_for('lm', **model_params)
         else:
@@ -205,7 +205,7 @@ class LanguageModelTrainerTf(Trainer):
         return metrics
 
     def calc_metrics(self, agg, norm):
-        metrics = super(LanguageModelTrainerTf, self).calc_metrics(agg, norm)
+        metrics = super().calc_metrics(agg, norm)
         metrics['perplexity'] = np.exp(metrics['avg_loss'])
         return metrics
 

--- a/baseline/tf/seq2seq/model.py
+++ b/baseline/tf/seq2seq/model.py
@@ -260,7 +260,7 @@ if not tf.executing_eagerly():
     class Seq2Seq(EncoderDecoderModelBase):
 
         def __init__(self):
-            super(Seq2Seq, self).__init__()
+            super().__init__()
             self._vdrop = False
 
         @property

--- a/baseline/utils.py
+++ b/baseline/utils.py
@@ -126,7 +126,7 @@ class ColoredFormatter(logging.Formatter):
 
     def format(self, record):
         if record.levelname in self.COLORS:
-            return color(super(ColoredFormatter, self).format(record), self.COLORS[record.levelname])
+            return color(super().format(record), self.COLORS[record.levelname])
         return super().format(record)
 
 

--- a/layers/eight_mile/progress.py
+++ b/layers/eight_mile/progress.py
@@ -60,7 +60,7 @@ class ProgressBarJupyter(Progress):
     """
 
     def __init__(self, total):
-        super(ProgressBarJupyter, self).__init__()
+        super().__init__()
         from ipywidgets import FloatProgress
         from IPython.display import display
 
@@ -91,7 +91,7 @@ class ProgressBarTerminal(Progress):
     FULL = "%(bar)s %(current)d/%(total)d (%(percent)3d%%) %(remaining)d to go"
 
     def __init__(self, total, width=40, fmt=DEFAULT, symbol="="):
-        super(ProgressBarTerminal, self).__init__()
+        super().__init__()
         assert len(symbol) == 1
 
         self.total = total

--- a/layers/eight_mile/pytorch/layers.py
+++ b/layers/eight_mile/pytorch/layers.py
@@ -3660,7 +3660,7 @@ class TransformerDiscriminator(nn.Module):
 class SequenceCriterion(nn.Module):
 
     def __init__(self, LossFn=nn.NLLLoss, avg='token'):
-        super(SequenceCriterion, self).__init__()
+        super().__init__()
         if avg == 'token':
             # self.crit = LossFn(ignore_index=Offsets.PAD, reduction='elementwise-mean')
             self.crit = LossFn(ignore_index=Offsets.PAD, size_average=True)

--- a/layers/eight_mile/tf/layers.py
+++ b/layers/eight_mile/tf/layers.py
@@ -2037,7 +2037,7 @@ class ResidualBlock(tf.keras.layers.Layer):
 
 class SkipConnection(ResidualBlock):
     def __init__(self, input_size: int, activation: str = "relu"):
-        super(SkipConnection, self).__init__(tf.keras.layers.Dense(input_size, activation=activation))
+        super().__init__(tf.keras.layers.Dense(input_size, activation=activation))
 
 
 class TimeDistributedProjection(tf.keras.layers.Layer):

--- a/mead/config/ontonotes.json
+++ b/mead/config/ontonotes.json
@@ -1,7 +1,7 @@
 {
   "task": "tagger",
   "batchsz": 9,
-  "conll_output": "conllresults.conll",
+  "conll_output": "ontonotes-results.conll",
   "unif": 0.1,
   "features": [
     {

--- a/mead/exporters.py
+++ b/mead/exporters.py
@@ -9,7 +9,7 @@ export = exporter(__all__)
 class Exporter(object):
 
     def __init__(self, task, **kwargs):
-        super(Exporter, self).__init__()
+        super().__init__()
         self.task = task
 
     @classmethod

--- a/mead/tasks.py
+++ b/mead/tasks.py
@@ -54,7 +54,7 @@ def merge_reporting_with_settings(reporting, settings):
     return reporting_hooks, reporting
 
 
-class Backend(object):
+class Backend:
     """Simple object to represent a deep-learning framework backend"""
     def __init__(self, name=None, params=None, exporter=None):
         """Initialize the backend, optional with constructor args
@@ -81,7 +81,10 @@ class Backend(object):
         import_user_module('baseline.{}.embeddings'.format(self.name))
         import_user_module('mead.{}.exporters'.format(self.name))
         if task_name is not None:
-            import_user_module('{}.{}'.format(base_pkg_name, task_name))
+            try:
+                import_user_module(f'{base_pkg_name}.{task_name}')
+            except:
+                logger.warning(f"No module found [{base_pkg_name}.{task_name}]")
         self.transition_mask = mod.transition_mask
 
 
@@ -109,7 +112,7 @@ def assert_unique_feature_names(names: List[str]) -> None:
 
 
 @export
-class Task(object):
+class Task:
     """Basic building block for a task of NLP problems, e.g. `tagger`, `classify`, etc.
     """
 
@@ -492,7 +495,7 @@ class Task(object):
 class ClassifierTask(Task):
 
     def __init__(self, mead_settings_config, **kwargs):
-        super(ClassifierTask, self).__init__(mead_settings_config, **kwargs)
+        super().__init__(mead_settings_config, **kwargs)
 
     @classmethod
     def task_name(cls):
@@ -505,7 +508,7 @@ class ClassifierTask(Task):
         return backend
 
     def _setup_task(self, **kwargs):
-        super(ClassifierTask, self)._setup_task(**kwargs)
+        super()._setup_task(**kwargs)
         if self.config_params.get('preproc', {}).get('clean', False) is True:
             self.config_params.get('preproc', {})['clean_fn'] = baseline.TSVSeqLabelReader.do_clean
             logger.info('Clean')
@@ -584,7 +587,7 @@ class ClassifierTask(Task):
 class TaggerTask(Task):
 
     def __init__(self, mead_settings_config, **kwargs):
-        super(TaggerTask, self).__init__(mead_settings_config, **kwargs)
+        super().__init__(mead_settings_config, **kwargs)
 
     @classmethod
     def task_name(cls):
@@ -707,7 +710,7 @@ class TaggerTask(Task):
 class EncoderDecoderTask(Task):
 
     def __init__(self, mead_settings_config, **kwargs):
-        super(EncoderDecoderTask, self).__init__(mead_settings_config, **kwargs)
+        super().__init__(mead_settings_config, **kwargs)
 
     @classmethod
     def task_name(cls):

--- a/mead/tf/exporters.py
+++ b/mead/tf/exporters.py
@@ -36,7 +36,7 @@ def get_tf_index_from_unzipped(dir_path):
 class TensorFlowExporter(Exporter):
 
     def __init__(self, task, **kwargs):
-        super(TensorFlowExporter, self).__init__(task, **kwargs)
+        super().__init__(task, **kwargs)
 
     def _run(self, basename, output_dir, project=None, name=None, model_version=None, **kwargs):
         basename = get_tf_index_from_unzipped(basename)
@@ -114,7 +114,7 @@ class TensorFlowExporter(Exporter):
 class ClassifyTensorFlowExporter(TensorFlowExporter):
 
     def __init__(self, task, **kwargs):
-        super(ClassifyTensorFlowExporter, self).__init__(task, **kwargs)
+        super().__init__(task, **kwargs)
         self.return_labels = kwargs.get('return_labels', True)
 
     def _create_model(self, sess, basename, **kwargs):
@@ -160,7 +160,7 @@ class ClassifyTensorFlowExporter(TensorFlowExporter):
 class TaggerTensorFlowExporter(TensorFlowExporter):
 
     def __init__(self, task, **kwargs):
-        super(TaggerTensorFlowExporter, self).__init__(task, **kwargs)
+        super().__init__(task, **kwargs)
         self.return_labels = kwargs.get('return_labels', False)  # keep default behavior
 
     def _create_model(self, sess, basename, **kwargs):
@@ -230,7 +230,7 @@ class Seq2SeqTensorFlowExporter(TensorFlowExporter):
     TARGET_EMBED_KEY = 'tgt'
 
     def __init__(self, task, **kwargs):
-        super(Seq2SeqTensorFlowExporter, self).__init__(task, **kwargs)
+        super().__init__(task, **kwargs)
         self.return_labels = kwargs.get('return_labels', False)
 
     def _create_model(self, sess, basename, **kwargs):

--- a/mead/tf/preproc_exporters.py
+++ b/mead/tf/preproc_exporters.py
@@ -146,7 +146,7 @@ class ClassifyTensorFlowPreProcExporter(ClassifyTensorFlowExporter):
         return 'server'
 
     def __init__(self, task, **kwargs):
-        super(ClassifyTensorFlowPreProcExporter, self).__init__(task, **kwargs)
+        super().__init__(task, **kwargs)
         self.feature_exporter_field_map = kwargs.get('feature_exporter_field_map', {'tokens': 'text'})
         self.return_labels = kwargs.get('return_labels', False)
 
@@ -188,7 +188,7 @@ class TaggerTensorFlowPreProcExporter(TaggerTensorFlowExporter):
         return 'server'
 
     def __init__(self, task, **kwargs):
-        super(TaggerTensorFlowPreProcExporter, self).__init__(task, **kwargs)
+        super().__init__(task, **kwargs)
         self.feature_exporter_field_map = kwargs.get('feature_exporter_field_map', {'tokens': 'text'})
         self.return_labels = kwargs.get('return_labels', False)
 

--- a/mead/tf/preprocessors.py
+++ b/mead/tf/preprocessors.py
@@ -14,7 +14,7 @@ class TensorFlowPreprocessor(Preprocessor):
     """
 
     def __init__(self, feature, vectorizer, index, vocab, **kwargs):
-        super(TensorFlowPreprocessor, self).__init__(feature, vectorizer, index, vocab, **kwargs)
+        super().__init__(feature, vectorizer, index, vocab, **kwargs)
         self.FIELD_NAME = kwargs.get('FIELD_NAME', 'tokens')
         self.upchars = tf.constant([chr(i) for i in range(65, 91)])
         self.lchars = tf.constant([chr(i) for i in range(97, 123)])
@@ -122,11 +122,11 @@ class Char2DPreprocessor(TensorFlowPreprocessor):
 @register_preprocessor(name='dict1d')
 class Dict1DPreprocessor(Token1DPreprocessor):
     def __init__(self, feature, vectorizer, index, vocab, **kwargs):
-        super(Dict1DPreprocessor, self).__init__(feature, vectorizer, index, vocab, **kwargs)
+        super().__init__(feature, vectorizer, index, vocab, **kwargs)
 
 
 @export
 @register_preprocessor(name='dict2d')
 class Dict2DPreprocessor(Char2DPreprocessor):
     def __init__(self, feature, vectorizer, index, vocab, **kwargs):
-        super(Dict2DPreprocessor, self).__init__(feature, vectorizer, index, vocab, **kwargs)
+        super().__init__(feature, vectorizer, index, vocab, **kwargs)


### PR DESCRIPTION
also, allow task modules to be loaded without requiring
a sub-package for each task (with a warning)