### PR TITLE
Feature/single head attention

### DIFF
--- a/api-examples/pretrain_tlm_pytorch.py
+++ b/api-examples/pretrain_tlm_pytorch.py
@@ -73,6 +73,9 @@ def train():
     parser.add_argument('--rpr_k',
                         help='Relative attention positional sizes pass 0 if you dont want relative attention',
                         type=int, default=[8], nargs='+')
+    parser.add_argument('--rpr_value_on', type=str2bool, default=True,
+                        help="In relative attention, whether add positional correction to values in addition to the "
+                             "correction to attention matrix")
     parser.add_argument("--windowed_ra", type=str2bool, default=False, help="whether prevent attention beyond rpr_k")
     parser.add_argument("--device", type=str,
                         default="cuda" if torch.cuda.is_available() else "cpu",
@@ -162,6 +165,7 @@ def train():
                        rpr_k=rpr_k,
                        d_k=args.d_k,
                        windowed_ra=args.windowed_ra,
+                       rpr_value_on=args.rpr_value_on,
                        src_keys=['x'], tgt_key='x')
     model.to(args.device)
     loss_function = model.create_loss()

--- a/api-examples/pretrain_tlm_tf.py
+++ b/api-examples/pretrain_tlm_tf.py
@@ -345,11 +345,11 @@ def train():
                     return
 
                 if (i + 1) % report_on == 0:
-                    logging.info(avg_loss)
+                    logger.info(avg_loss)
                 if (i + 1) % update_on == 0:
                     elapsed = (time.time() - start)/60
-                    logging.info('elapsed time this epoch %d min', elapsed)
-                    logging.info('elapsed step time %f steps/min', i/elapsed)
+                    logger.info('elapsed time this epoch %d min', elapsed)
+                    logger.info('elapsed step time %f steps/min', i/elapsed)
                     checkpoint_manager.save()
                     if args.npz:
                         steps = optimizer.global_step.numpy()

--- a/api-examples/pretrain_tlm_tf.py
+++ b/api-examples/pretrain_tlm_tf.py
@@ -177,6 +177,9 @@ def train():
     parser.add_argument('--rpr_k',
                         help='Relative attention positional sizes pass 0 if you dont want relative attention',
                         type=int, default=[8], nargs='+')
+    parser.add_argument('--rpr_value_on', type=str2bool, default=True,
+                        help="In relative attention, whether add positional correction to values in addition to the "
+                             "correction to attention matrix")
     parser.add_argument('--windowed_ra', type=str2bool, default=False, help="whether prevent attention beyond rpr_k")
     parser.add_argument("--strategy", help="Training strategy, defaults to `mirror`", choices=["mirror"])
     parser.add_argument("--npz", help="Should we write out NPZ files?", type=str2bool, default=False)
@@ -257,6 +260,7 @@ def train():
                        rpr_k=rpr_k,
                        d_k=args.d_k,
                        windowed_ra=args.windowed_ra,
+                       rpr_value_on=args.rpr_value_on,
                        src_keys=['x'], tgt_key='x')
 
     loss_function = Loss(vocab_size, args.nctx)

--- a/baseline/pytorch/embeddings.py
+++ b/baseline/pytorch/embeddings.py
@@ -143,11 +143,12 @@ class TransformerLMEmbeddings(PyTorchEmbeddings):
         layer_norm_eps = kwargs.get('layer_norm_eps', 1e-12)
         activation = kwargs.get('activation', 'gelu')
         windowed_ra = kwargs.get('windowed_ra', False)
+        rpr_value_on = kwargs.get('rpr_value_on', True)
         self.transformer = TransformerEncoderStack(num_heads, d_model=self.d_model, pdrop=pdrop, scale=True,
                                                    layers=num_layers, d_ff=d_ff, rpr_k=rpr_k, d_k=d_k,
                                                    activation=activation, ffn_pdrop=ff_pdrop,
                                                    layer_norms_after=layer_norms_after, layer_norm_eps=layer_norm_eps,
-                                                   windowed_ra=windowed_ra)
+                                                   windowed_ra=windowed_ra, rpr_value_on=rpr_value_on)
         self.mlm = kwargs.get('mlm', False)
         self.finetune = kwargs.get('finetune', True)
 

--- a/baseline/pytorch/lm/model.py
+++ b/baseline/pytorch/lm/model.py
@@ -201,10 +201,12 @@ class TransformerLanguageModel(AbstractGeneratorLanguageModel):
         layer_norm_eps = kwargs.get('layer_norm_eps', 1e-12)
         layer_norms_after = kwargs.get('layer_norms_after', False)
         windowed_ra = kwargs.get('windowed_ra', False)
+        rpr_value_on = kwargs.get('rpr_value_on', True)
         return TransformerEncoderStack(num_heads, d_model=d_model, pdrop=pdrop, scale=scale,
                                        layers=layers, d_ff=d_ff, rpr_k=rpr_k, d_k=d_k,
                                        activation=activation, layer_norm_eps=layer_norm_eps,
-                                       layer_norms_after=layer_norms_after, windowed_ra=windowed_ra)
+                                       layer_norms_after=layer_norms_after, windowed_ra=windowed_ra,
+                                       rpr_value_on=rpr_value_on)
 
     def create_layers(self, embeddings, **kwargs):
         super().create_layers(embeddings, **kwargs)

--- a/baseline/tf/embeddings.py
+++ b/baseline/tf/embeddings.py
@@ -228,10 +228,12 @@ class TransformerLMEmbeddings(TensorFlowEmbeddings):
         layer_norm_eps = kwargs.get('layer_norm_eps', 1e-12)
         activation = kwargs.get('activation', 'gelu')
         windowed_ra = kwargs.get('windowed_ra', False)
+        rpr_value_on = kwargs.get('rpr_value_on', True)
         self.transformer = TransformerEncoderStack(num_heads, d_model=self.d_model, pdrop=pdrop, scale=True,
                                                    layers=num_layers, d_ff=d_ff, rpr_k=rpr_k, d_k=d_k,
                                                    activation=activation, layer_norms_after=layer_norms_after,
-                                                   layer_norm_eps=layer_norm_eps, windowed_ra=windowed_ra)
+                                                   layer_norm_eps=layer_norm_eps, windowed_ra=windowed_ra,
+                                                   rpr_value_on=rpr_value_on)
         self.mlm = kwargs.get('mlm', False)
         self.finetune = kwargs.get('finetune', True)
 

--- a/baseline/tf/lm/model.py
+++ b/baseline/tf/lm/model.py
@@ -402,10 +402,12 @@ class TransformerLanguageModel(AbstractGeneratorModel):
         layer_norm_eps = kwargs.get('layer_norm_eps', 1e-12)
         layer_norms_after = kwargs.get('layer_norms_after', False)
         windowed_ra = kwargs.get('windowed_ra', False)
+        rpr_value_on = kwargs.get('rpr_value_on', True)
         return TransformerEncoderStack(num_heads, d_model=d_model, pdrop=pdrop, scale=scale,
                                        layers=layers, d_ff=d_ff, rpr_k=rpr_k, d_k=d_k,
                                        activation=activation, layer_norm_eps=layer_norm_eps,
-                                       layer_norms_after=layer_norms_after, windowed_ra=windowed_ra)
+                                       layer_norms_after=layer_norms_after, windowed_ra=windowed_ra,
+                                       rpr_value_on=rpr_value_on)
 
     def create_mask(self, bth):
         max_seqlen = get_shape_as_list(bth)[1]

--- a/layers/eight_mile/pytorch/layers.py
+++ b/layers/eight_mile/pytorch/layers.py
@@ -2681,10 +2681,13 @@ class SequenceSequenceRelativeAttention(nn.Module):
         """
         B, H, T, D = value.shape
         updated_values = torch.matmul(a, value)
-        a = a.view(B * H, T, T).transpose(0, 1)  # (T, BxH, T)
-        t = torch.matmul(a, edges_value)  # (T, BxH, D)
-        update_edge_values = t.transpose(0, 1).view(B, H, T, D)
-        return updated_values + update_edge_values
+        if edges_value is not None:
+            a = a.view(B * H, T, T).transpose(0, 1)  # (T, BxH, T)
+            t = torch.matmul(a, edges_value)  # (T, BxH, D)
+            update_edge_values = t.transpose(0, 1).view(B, H, T, D)
+            return updated_values + update_edge_values
+        else:
+            return updated_values
 
 
 class SeqScaledDotProductRelativeAttention(SequenceSequenceRelativeAttention):
@@ -2807,10 +2810,13 @@ class SeqScaledWindowedRelativeAttention(SequenceSequenceRelativeAttention):
         # a has dim [B, H, T, 1, W]
         window_sz = a.shape[-1]
         value = unfold_tensor(value, dim=2, window_sz=window_sz).transpose(-1, -2)  # [B, H, T, W, d_value]
-        rpr_value = rpr_value.unsqueeze(0).unsqueeze(0).unsqueeze(0)  # [1, 1, 1, W, d_value]
         updated_values = torch.matmul(a, value)  # [B, H, T, 1, d_value]
-        update_rpr_values = torch.matmul(a, rpr_value)  # [B, H, T, 1, d_value]
-        return (updated_values + update_rpr_values).squeeze(3)  # [B, H, T, d_value]
+        if rpr_value is not None:
+            rpr_value = rpr_value.unsqueeze(0).unsqueeze(0).unsqueeze(0)  # [1, 1, 1, W, d_value]
+            update_rpr_values = torch.matmul(a, rpr_value)  # [B, H, T, 1, d_value]
+            return (updated_values + update_rpr_values).squeeze(3)  # [B, H, T, d_value]
+        else:
+            return updated_values.squeeze(3)
 
 
 class SeqBahdanauAttention(SequenceSequenceAttention):
@@ -2934,6 +2940,7 @@ class MultiHeadedRelativeAttention(nn.Module):
         scale: bool = False,
         d_k: Optional[int] = None,
         windowed_ra: bool = False,
+        rpr_value_on: bool = True
     ):
         """Constructor for multi-headed attention
 
@@ -2962,8 +2969,10 @@ class MultiHeadedRelativeAttention(nn.Module):
         else:
             self.d_value = d_model
         self.rpr_k = rpr_k
+        self.rpr_value_on = rpr_value_on
         self.rpr_key = nn.Embedding(2 * rpr_k + 1, self.d_k)
-        self.rpr_value = nn.Embedding(2 * rpr_k + 1, self.d_value)
+        if self.rpr_value_on:
+            self.rpr_value = nn.Embedding(2 * rpr_k + 1, self.d_value)
         self.windowed_ra = windowed_ra
         self.w_Q = Dense(d_model, self.d_k * self.h)
         self.w_K = Dense(d_model, self.d_k * self.h)
@@ -2986,12 +2995,18 @@ class MultiHeadedRelativeAttention(nn.Module):
         window_len = 2 * self.rpr_k
         edges = seq.view(1, -1) - seq.view(-1, 1) + self.rpr_k
         edges = torch.clamp(edges, 0, window_len)
-        return self.rpr_key(edges), self.rpr_value(edges)
+        if self.rpr_value_on:
+            return self.rpr_key(edges), self.rpr_value(edges)
+        else:
+            return self.rpr_key(edges), None
 
     def make_windowed_rpr(self, device):
         window_len = 2 * self.rpr_k + 1
         window = torch.arange(window_len).to(device)
-        return self.rpr_key(window), self.rpr_value(window)
+        if self.rpr_value_on:
+            return self.rpr_key(window), self.rpr_value(window)
+        else:
+            return self.rpr_key(window), None
 
     def forward(self, qkvm: Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]) -> torch.Tensor:
         """Low-order projections of query, key and value into multiple heads, then attention application and dropout
@@ -3039,7 +3054,8 @@ class TransformerEncoder(nn.Module):
         ffn_pdrop: Optional[float] = 0.0,
         layer_norms_after: bool = False,
         layer_norm_eps: float = 1.0e-6,
-        windowed_ra: Optional[bool] = False
+        windowed_ra: Optional[bool] = False,
+        rpr_value_on: bool = True
     ):
         super().__init__()
         # to properly execute BERT models, we have to follow T2T and do layer norms after
@@ -3048,7 +3064,7 @@ class TransformerEncoder(nn.Module):
         self.d_ff = d_ff if d_ff is not None else 4 * d_model
         if rpr_k is not None:
             self.self_attn = MultiHeadedRelativeAttention(num_heads, d_model, rpr_k, pdrop, scale, d_k=d_k,
-                                                          windowed_ra=windowed_ra)
+                                                          windowed_ra=windowed_ra, rpr_value_on=rpr_value_on)
         else:
             self.self_attn = MultiHeadedAttention(num_heads, d_model, pdrop, scale=scale, d_k=d_k)
         self.ffn = nn.Sequential(
@@ -3154,6 +3170,7 @@ class TransformerEncoderStack(nn.Module):
         layer_norms_after: bool = False,
         layer_norm_eps: float = 1.0e-6,
         windowed_ra: Optional[bool] = False,
+        rpr_value_on: bool = True,
         **kwargs,
     ):
         super().__init__()
@@ -3169,7 +3186,7 @@ class TransformerEncoderStack(nn.Module):
                 TransformerEncoder(
                     num_heads, d_model, pdrop, scale, activation, d_ff, d_k,
                     rpr_k=rpr_k[i], ffn_pdrop=ffn_pdrop, layer_norms_after=layer_norms_after,
-                    layer_norm_eps=layer_norm_eps, windowed_ra=windowed_ra
+                    layer_norm_eps=layer_norm_eps, windowed_ra=windowed_ra, rpr_value_on=rpr_value_on
                 )
             )
 

--- a/layers/eight_mile/pytorch/serialize.py
+++ b/layers/eight_mile/pytorch/serialize.py
@@ -171,12 +171,16 @@ def to_attn_array(pytorch_attn: nn.Module, name: str) -> Dict:
     d.update(to_weight_array(pytorch_attn.w_Q, f"{name}/w_Q"))
     d.update(to_weight_array(pytorch_attn.w_K, f"{name}/w_K"))
     d.update(to_weight_array(pytorch_attn.w_V, f"{name}/w_V"))
-    d.update(to_weight_array(pytorch_attn.w_O, f"{name}/w_O"))
+
+    if hasattr(pytorch_attn, 'w_O'):
+        d.update(to_weight_array(pytorch_attn.w_O, f"{name}/w_O"))
 
     if hasattr(pytorch_attn, 'rpr_key'):
         rpr_key_weights = pytorch_attn.rpr_key.weight.cpu().detach().numpy()
-        rpr_value_weights = pytorch_attn.rpr_value.weight.cpu().detach().numpy()
         d.update({f"{name}/rpr_key": rpr_key_weights})
+
+    if hasattr(pytorch_attn, 'rpr_value'):
+        rpr_value_weights = pytorch_attn.rpr_value.weight.cpu().detach().numpy()
         d.update({f"{name}/rpr_value": rpr_value_weights})
 
     return d
@@ -192,11 +196,16 @@ def from_attn_array(pytorch_attn: nn.Module, d: Dict, name: str):
     from_weight_array(pytorch_attn.w_Q, d, f"{name}/w_Q")
     from_weight_array(pytorch_attn.w_K, d, f"{name}/w_K")
     from_weight_array(pytorch_attn.w_V, d, f"{name}/w_V")
-    from_weight_array(pytorch_attn.w_O, d, f"{name}/w_O")
+
+    if hasattr(pytorch_attn, 'w_O'):
+        from_weight_array(pytorch_attn.w_O, d, f"{name}/w_O")
 
     if hasattr(pytorch_attn, 'rpr_key'):
         device = pytorch_attn.rpr_key.weight.device
         pytorch_attn.rpr_key.weight = torch.nn.Parameter(torch.from_numpy(d[f"{name}/rpr_key"]).to(device=device))
+
+    if hasattr(pytorch_attn, 'rpr_value'):
+        device = pytorch_attn.rpr_key.weight.device
         pytorch_attn.rpr_value.weight = torch.nn.Parameter(torch.from_numpy(d[f"{name}/rpr_value"]).to(device=device))
 
 

--- a/layers/eight_mile/tf/layers.py
+++ b/layers/eight_mile/tf/layers.py
@@ -2384,7 +2384,7 @@ class MultiHeadedAttention(tf.keras.layers.Layer):
 
         self.h = num_heads
         if self.h > 1:
-            self.d_value = d_k
+            self.d_value = self.d_k
         else:
             self.d_value = d_model
         self.w_Q = tf.keras.layers.Dense(units=self.d_k * self.h, name="query_projection")
@@ -2460,7 +2460,7 @@ class MultiHeadedRelativeAttention(tf.keras.layers.Layer):
 
         self.h = num_heads
         if self.h > 1:
-            self.d_value = d_k
+            self.d_value = self.d_k
         else:
             self.d_value = d_model
         self.rpr_k = rpr_k

--- a/layers/eight_mile/tf/layers.py
+++ b/layers/eight_mile/tf/layers.py
@@ -2173,12 +2173,15 @@ class SequenceSequenceRelativeAttention(tf.keras.layers.Layer):
         """
         B, H, T, D = get_shape_as_list(value)
         updated_values = tf.matmul(a, value)
-        # (T, BxH, T)
-        a = tf.transpose(tf.reshape(a, [B * H, T, T]), [1, 0, 2])
-        t = tf.matmul(a, edges_value)  # (T, BxH, D)
-        t = tf.transpose(t, [1, 0, 2])
-        update_edge_values = tf.reshape(t, [B, H, T, D])
-        return updated_values + update_edge_values
+        if edges_value is not None:
+            # (T, BxH, T)
+            a = tf.transpose(tf.reshape(a, [B * H, T, T]), [1, 0, 2])
+            t = tf.matmul(a, edges_value)  # (T, BxH, D)
+            t = tf.transpose(t, [1, 0, 2])
+            update_edge_values = tf.reshape(t, [B, H, T, D])
+            return updated_values + update_edge_values
+        else:
+            return updated_values
 
 
 class SeqScaledDotProductRelativeAttention(SequenceSequenceRelativeAttention):
@@ -2309,11 +2312,14 @@ class SeqScaledWindowedRelativeAttention(SequenceSequenceRelativeAttention):
     def _update(self, a, value, rpr_value):
         # a has dim [B, H, T, 1, W]
         window_sz = a.shape[-1]
-        value = unfold_tensor(value, dim=2, window_sz=window_sz)  # [B, H, T, W, d_k]
-        rpr_value = tf.expand_dims(tf.expand_dims(tf.expand_dims(rpr_value, 0), 0), 0)  # [1, 1, 1, W, d_k]
-        updated_values = tf.matmul(a, value)  # [B, H, T, 1, d_k]
-        update_rpr_values = tf.matmul(a, rpr_value)  # [B, H, T, 1, d_k]
-        return tf.squeeze(updated_values + update_rpr_values, axis=3)  # [B, H, T, d_k]
+        value = unfold_tensor(value, dim=2, window_sz=window_sz)  # [B, H, T, W, d_value]
+        updated_values = tf.matmul(a, value)  # [B, H, T, 1, d_value]
+        if rpr_value is not None:
+            rpr_value = tf.expand_dims(tf.expand_dims(tf.expand_dims(rpr_value, 0), 0), 0)  # [1, 1, 1, W, d_value]
+            update_rpr_values = tf.matmul(a, rpr_value)  # [B, H, T, 1, d_value]
+            return tf.squeeze(updated_values + update_rpr_values, axis=3)  # [B, H, T, d_value]
+        else:
+            return tf.squeeze(updated_values, axis=3)
 
 
 class SeqDotProductAttention(SequenceSequenceAttention):
@@ -2377,10 +2383,15 @@ class MultiHeadedAttention(tf.keras.layers.Layer):
             self.d_k = d_k
 
         self.h = num_heads
+        if self.h > 1:
+            self.d_value = d_k
+        else:
+            self.d_value = d_model
         self.w_Q = tf.keras.layers.Dense(units=self.d_k * self.h, name="query_projection")
         self.w_K = tf.keras.layers.Dense(units=self.d_k * self.h, name="key_projection")
-        self.w_V = tf.keras.layers.Dense(units=self.d_k * self.h, name="value_projection")
-        self.w_O = tf.keras.layers.Dense(units=self.d_k * self.h, name="output_projection")
+        self.w_V = tf.keras.layers.Dense(units=self.d_value * self.h, name="value_projection")
+        if self.h > 1:  # w_O is not needed for sinlge headed attention
+            self.w_O = tf.keras.layers.Dense(units=self.d_k * self.h, name="output_projection")
         if scale:
             self.attn_fn = SeqScaledDotProductAttention(dropout)
         else:
@@ -2394,14 +2405,17 @@ class MultiHeadedAttention(tf.keras.layers.Layer):
         # (B, T, H, D) -> (B, H, T, D)
         query = tf.transpose(tf.reshape(self.w_Q(query), [batchsz, -1, self.h, self.d_k]), [0, 2, 1, 3])
         key = tf.transpose(tf.reshape(self.w_K(key), [batchsz, -1, self.h, self.d_k]), [0, 2, 1, 3])
-        value = tf.transpose(tf.reshape(self.w_V(value), [batchsz, -1, self.h, self.d_k]), [0, 2, 1, 3])
+        value = tf.transpose(tf.reshape(self.w_V(value), [batchsz, -1, self.h, self.d_value]), [0, 2, 1, 3])
         x = self.attn_fn((query, key, value, mask))
         self.attn = self.attn_fn.attn
 
         # (B, H, T, D) -> (B, T, H, D) -> (B, T, H*D)
         x = tf.transpose(x, [0, 2, 1, 3])
-        x = tf.reshape(x, [batchsz, -1, self.h * self.d_k])
-        return self.w_O(x)
+        x = tf.reshape(x, [batchsz, -1, self.h * self.d_value])
+        if self.h > 1:
+            return self.w_O(x)
+        else:
+            return x
 
 
 class MultiHeadedRelativeAttention(tf.keras.layers.Layer):
@@ -2424,6 +2438,7 @@ class MultiHeadedRelativeAttention(tf.keras.layers.Layer):
         scale: bool = False,
         d_k: Optional[int] = None,
         windowed_ra: bool = False,
+        rpr_value_on: bool = True,
         name=None,
     ):
         """Constructor for multi-headed attention
@@ -2443,15 +2458,22 @@ class MultiHeadedRelativeAttention(tf.keras.layers.Layer):
         else:
             self.d_k = d_k
 
-        self.rpr_k = rpr_k
-        self.rpr_key = tf.keras.layers.Embedding(2 * rpr_k + 1, self.d_k)
-        self.rpr_value = tf.keras.layers.Embedding(2 * rpr_k + 1, self.d_k)
-        self.windowed_ra = windowed_ra
         self.h = num_heads
+        if self.h > 1:
+            self.d_value = d_k
+        else:
+            self.d_value = d_model
+        self.rpr_k = rpr_k
+        self.rpr_value_on = rpr_value_on
+        self.rpr_key = tf.keras.layers.Embedding(2 * rpr_k + 1, self.d_k)
+        if self.rpr_value_on:
+            self.rpr_value = tf.keras.layers.Embedding(2 * rpr_k + 1, self.d_value)
+        self.windowed_ra = windowed_ra
         self.w_Q = tf.keras.layers.Dense(units=self.d_k * self.h, name="query_projection")
         self.w_K = tf.keras.layers.Dense(units=self.d_k * self.h, name="key_projection")
-        self.w_V = tf.keras.layers.Dense(units=self.d_k * self.h, name="value_projection")
-        self.w_O = tf.keras.layers.Dense(units=self.d_k * self.h, name="output_projection")
+        self.w_V = tf.keras.layers.Dense(units=self.d_value * self.h, name="value_projection")
+        if self.h > 1:  # w_O is not needed for sinlge headed attention
+            self.w_O = tf.keras.layers.Dense(units=self.d_k * self.h, name="output_projection")
         if scale:
             if windowed_ra:
                 self.attn_fn = SeqScaledWindowedRelativeAttention(dropout)
@@ -2468,12 +2490,18 @@ class MultiHeadedRelativeAttention(tf.keras.layers.Layer):
         window_len = 2 * self.rpr_k
         edges = tf.reshape(seq, [1, -1]) - tf.reshape(seq, [-1, 1]) + self.rpr_k
         edges = tf.clip_by_value(edges, 0, window_len)
-        return self.rpr_key(edges), self.rpr_value(edges)
+        if self.rpr_value_on:
+            return self.rpr_key(edges), self.rpr_value(edges)
+        else:
+            return self.rpr_key(edges), None
 
     def make_windowed_rpr(self):
         window_sz = 2 * self.rpr_k + 1
         window = tf.range(window_sz)
-        return self.rpr_key(window), self.rpr_value(window)
+        if self.rpr_value_on:
+            return self.rpr_key(window), self.rpr_value(window)
+        else:
+            return self.rpr_key(window), None
 
     def call(self, qkvm):
         """Low-order projections of query, key and value into multiple heads, then attention application and dropout
@@ -2492,7 +2520,7 @@ class MultiHeadedRelativeAttention(tf.keras.layers.Layer):
         # (B, T, H, D) -> (B, H, T, D)
         query = tf.transpose(tf.reshape(self.w_Q(query), [batchsz, -1, self.h, self.d_k]), [0, 2, 1, 3])
         key = tf.transpose(tf.reshape(self.w_K(key), [batchsz, -1, self.h, self.d_k]), [0, 2, 1, 3])
-        value = tf.transpose(tf.reshape(self.w_V(value), [batchsz, -1, self.h, self.d_k]), [0, 2, 1, 3])
+        value = tf.transpose(tf.reshape(self.w_V(value), [batchsz, -1, self.h, self.d_value]), [0, 2, 1, 3])
 
         if self.windowed_ra:
             rpr_key, rpr_value = self.make_windowed_rpr()
@@ -2502,8 +2530,11 @@ class MultiHeadedRelativeAttention(tf.keras.layers.Layer):
         self.attn = self.attn_fn.attn
         # (B, H, T, D) -> (B, T, H, D) -> (B, T, H*D)
         x = tf.transpose(x, [0, 2, 1, 3])
-        x = tf.reshape(x, [batchsz, -1, self.h * self.d_k])
-        return self.w_O(x)
+        x = tf.reshape(x, [batchsz, -1, self.h * self.d_value])
+        if self.h > 1:
+            return self.w_O(x)
+        else:
+            return x
 
 
 class TransformerEncoder(tf.keras.layers.Layer):
@@ -2521,6 +2552,7 @@ class TransformerEncoder(tf.keras.layers.Layer):
         layer_norms_after: bool = False,
         layer_norm_eps: float = 1.0e-6,
         windowed_ra: bool = False,
+        rpr_value_on: bool = True,
         name: Optional[str] = None
     ):
         super().__init__(name=name)
@@ -2529,7 +2561,7 @@ class TransformerEncoder(tf.keras.layers.Layer):
         self.d_ff = d_ff if d_ff is not None else 4 * d_model
         if rpr_k is not None:
             self.self_attn = MultiHeadedRelativeAttention(num_heads, d_model, rpr_k, pdrop, scale, d_k=d_k,
-                                                          windowed_ra=windowed_ra)
+                                                          windowed_ra=windowed_ra, rpr_value_on=rpr_value_on)
         else:
             self.self_attn = MultiHeadedAttention(num_heads, d_model, pdrop, scale=scale, d_k=d_k)
 
@@ -2621,6 +2653,7 @@ class TransformerEncoderStack(tf.keras.layers.Layer):
         layer_norms_after: bool = False,
         layer_norm_eps: float = 1.0e-6,
         windowed_ra: bool = False,
+        rpr_value_on: bool = True,
         name=None,
         **kwargs,
     ):
@@ -2638,7 +2671,7 @@ class TransformerEncoderStack(tf.keras.layers.Layer):
                     num_heads, d_model, pdrop, scale, activation, d_ff, d_k,
                     rpr_k=rpr_k[i], ffn_pdrop=ffn_pdrop,
                     layer_norms_after=layer_norms_after, layer_norm_eps=layer_norm_eps, windowed_ra=windowed_ra,
-                    name=name,
+                    rpr_value_on=rpr_value_on, name=name,
                 )
             )
 

--- a/layers/eight_mile/tf/serialize.py
+++ b/layers/eight_mile/tf/serialize.py
@@ -69,13 +69,17 @@ def to_attn_array(tf_attn: tf.keras.layers.Layer, name: str) -> Dict:
     d.update(to_weight_array(tf_attn.w_Q, f"{name}/w_Q"))
     d.update(to_weight_array(tf_attn.w_K, f"{name}/w_K"))
     d.update(to_weight_array(tf_attn.w_V, f"{name}/w_V"))
-    d.update(to_weight_array(tf_attn.w_O, f"{name}/w_O"))
+
+    if hasattr(tf_attn, 'w_O'):
+        d.update(to_weight_array(tf_attn.w_O, f"{name}/w_O"))
 
     if hasattr(tf_attn, 'rpr_key'):
         # Embeddings have same shape in PyTorch and TF [input_sz, output_sz]
         rpr_key_weights = tf_attn.rpr_key.get_weights()[0]
-        rpr_value_weights = tf_attn.rpr_value.get_weights()[0]
         d.update({f"{name}/rpr_key": rpr_key_weights})
+
+    if hasattr(tf_attn, 'rpr_value'):
+        rpr_value_weights = tf_attn.rpr_value.get_weights()[0]
         d.update({f"{name}/rpr_value": rpr_value_weights})
 
     return d
@@ -92,10 +96,14 @@ def from_attn_array(tf_attn: tf.keras.layers.Layer, d: Dict, name: str):
     from_weight_array(tf_attn.w_Q, d, f"{name}/w_Q")
     from_weight_array(tf_attn.w_K, d, f"{name}/w_K")
     from_weight_array(tf_attn.w_V, d, f"{name}/w_V")
-    from_weight_array(tf_attn.w_O, d, f"{name}/w_O")
+
+    if hasattr(tf_attn, 'w_O'):
+        from_weight_array(tf_attn.w_O, d, f"{name}/w_O")
 
     if hasattr(tf_attn, 'rpr_key'):
         tf_attn.rpr_key.set_weights([d[f"{name}/rpr_key"]])
+
+    if hasattr(tf_attn, 'rpr_value'):
         tf_attn.rpr_value.set_weights([d[f"{name}/rpr_value"]])
 
 


### PR DESCRIPTION
This PR adds single headed attention: when user set `num_heads=1`, the `query` and `key` will be projected to `d_k` (user should specify `d_k` explicitly, or it'll be set to `d_model`), but `value` will be projected to `d_model`, and no need for `w_O` in this case. (It reduces readability a little, but adding a new class will end up with 99% repeated codes.)

In the case of relative attention, `rpr_key` will have dim `d_k`, but `rpr_value` will have the same dim as `value`, which is a bit wasting. Since the original relative attention paper mentioned that using `rpr_value` didn't improve performance, and both conveRT and T5 don't use it, I added an option to turn it off. 