### PR TITLE
add an option to define the default progress bar

### DIFF
--- a/layers/eight_mile/progress.py
+++ b/layers/eight_mile/progress.py
@@ -16,7 +16,7 @@ def register_progress(cls, name=None):
 
 
 @export
-class Progress(object):
+class Progress:
     """Progress hook
 
     Provide interface for progress updates
@@ -79,7 +79,7 @@ class ProgressBarJupyter(Progress):
 # Modifed from here
 # http://stackoverflow.com/questions/3160699/python-progress-bar#3160819
 @export
-@register_progress('default')
+@register_progress('terminal')
 class ProgressBarTerminal(Progress):
     """Simple terminal-based progress bar
 
@@ -160,3 +160,9 @@ class ProgressBarTQDM(Progress):
 @export
 def create_progress_bar(steps, name='default', **kwargs):
     return MEAD_LAYERS_PROGRESS[name](steps, **kwargs)
+
+
+def SET_DEFAULT_PROGRESS_BAR(type):
+    MEAD_LAYERS_PROGRESS['default'] = MEAD_LAYERS_PROGRESS[type]
+
+SET_DEFAULT_PROGRESS_BAR('terminal')

--- a/mead/tasks.py
+++ b/mead/tasks.py
@@ -7,6 +7,7 @@ import numpy as np
 import baseline
 from copy import deepcopy
 from baseline.reporting import create_reporting
+from eight_mile.progress import SET_DEFAULT_PROGRESS_BAR
 from baseline.utils import (
     exporter,
     get_version,
@@ -219,6 +220,10 @@ class Task:
         if basedir is not None and not os.path.exists(basedir):
             logger.info('Creating: %s', basedir)
             os.makedirs(basedir)
+        progress_bar_type = self.config_params.get('progress_bar', os.getenv('MEAD_PROGRESS_BAR'))
+        if progress_bar_type is not None:
+            logger.info("Setting progress bar type %s", progress_bar_type)
+            SET_DEFAULT_PROGRESS_BAR(progress_bar_type)
         self.config_params['train']['basedir'] = basedir
         # Read GPUS from env variables now so that the reader has access
         if self.config_params['train'].get('gpus', -1) == -1:


### PR DESCRIPTION
This change makes it easy to reset the default progress bar provider, which defaults to `terminal`.  For example, if you already have
`tqdm` installed, you can tell mead to use that as the provider either by settting `export MEAD_PROGRESS_BAR=tqdm` prior to running `mead-train` or by setting the property `progress_bar` to `tqdm` in the mead configuration file or to the command via `-x:progress_bar`.

The actual implementation is simply to define the `default` key in the registry to a key that is bound by some other name via a new call `SET_PROGRESS_BAR()` .  The code is retrofitted to do this at init time for 8mi's progress.py file