### PR TITLE
chore: return scores from the model part of the seq2seq

### DIFF
--- a/baseline/pytorch/seq2seq/model.py
+++ b/baseline/pytorch/seq2seq/model.py
@@ -183,7 +183,7 @@ class EncoderDecoderModelBase(nn.Module, EncoderDecoderModel):
             outs = unsort_batch(outs, perm_idx)
             lengths = unsort_batch(lengths, perm_idx)
             scores = unsort_batch(scores, perm_idx)
-        return outs.cpu().numpy()
+        return outs.cpu().numpy(), scores.cpu().numpy()
 
 
 @register_model(task='seq2seq', name=['default', 'attn'])

--- a/baseline/pytorch/seq2seq/train.py
+++ b/baseline/pytorch/seq2seq/train.py
@@ -81,7 +81,7 @@ class Seq2SeqTrainerPyTorch(Trainer):
             toks = self._num_toks(tgt_lens)
             total_loss += loss.item() * toks
             total_toks += toks
-            greedy_preds = [p[0] for p in self._predict(input_, beam=1, make_input=False)]
+            greedy_preds = [p[0] for p in self._predict(input_, beam=1, make_input=False)[0]]
             preds.extend(convert_seq2seq_preds(greedy_preds, self.tgt_rlut))
             golds.extend(convert_seq2seq_golds(tgt.cpu().numpy(), tgt_lens, self.tgt_rlut))
 
@@ -102,7 +102,7 @@ class Seq2SeqTrainerPyTorch(Trainer):
         for batch_dict in pg(es):
             tgt = batch_dict['tgt']
             tgt_lens = batch_dict['tgt_lengths']
-            pred = [p[0] for p in self._predict(batch_dict, numpy_to_tensor=False, **kwargs)]
+            pred = [p[0] for p in self._predict(batch_dict, numpy_to_tensor=False, **kwargs)[0]]
             preds.extend(convert_seq2seq_preds(pred, self.tgt_rlut))
             golds.extend(convert_seq2seq_golds(tgt, tgt_lens, self.tgt_rlut))
         metrics = {'bleu': bleu(preds, golds, self.bleu_n_grams)[0]}

--- a/baseline/services.py
+++ b/baseline/services.py
@@ -799,7 +799,7 @@ class EncoderDecoderService(Service):
         examples = self.vectorize(tokens_batch)
 
         kwargs['beam'] = int(kwargs.get('beam', K))
-        outcomes = self.model.predict(examples, **kwargs)
+        outcomes, scores = self.model.predict(examples, **kwargs)
         return self.format_output(outcomes, K=K)
 
     def format_output(self, predicted, K=1, **kwargs):

--- a/baseline/tf/seq2seq/model.py
+++ b/baseline/tf/seq2seq/model.py
@@ -208,7 +208,7 @@ if not tf.executing_eagerly():
                 # Add a fake K
                 vec = np.expand_dims(vec, axis=2)
             # convert to (B x K x T)
-            return vec.transpose(1, 2, 0)
+            return vec.transpose(1, 2, 0), np.zeros(vec.shape[:2], dtype=np.float32)
 
         def step(self, batch_dict):
             """
@@ -482,7 +482,7 @@ else:
             #outs = self.greedy_decode(encoder_outputs, **kwargs)
             #return outs
             outs, lengths, scores = self.decoder.beam_search(encoder_outputs, **kwargs)
-            return outs.numpy()
+            return outs.numpy(), scores.numpy()
 
         def greedy_decode(self, encoder_outputs, **kwargs):
             mxlen = kwargs.get('mxlen', 100)

--- a/baseline/tf/seq2seq/training/eager.py
+++ b/baseline/tf/seq2seq/training/eager.py
@@ -178,7 +178,7 @@ class Seq2SeqTrainerEagerTf(Trainer):
         for features, tgt in es:
             features['dst'] = tgt[:, :-1]
             tgt_lens = features.pop('tgt_len')
-            top_preds = self.model.predict(features, make_input=False, **kwargs)
+            top_preds = self.model.predict(features, make_input=False, **kwargs)[0]
             preds.extend(convert_seq2seq_preds(top_preds[:, 0, :], self.tgt_rlut))
             golds.extend(convert_seq2seq_golds(tgt, tgt_lens, self.tgt_rlut))
         metrics = {'bleu': bleu(preds, golds, self.bleu_n_grams)[0]}
@@ -216,7 +216,7 @@ class Seq2SeqTrainerEagerTf(Trainer):
         start = time.time()
         for features, tgt in vs:
             features['dst'] = tgt[:, :-1]
-            top_preds = self.model.predict(features, beam=1, make_input=False)
+            top_preds = self.model.predict(features, beam=1, make_input=False)[0]
             loss_value = self.loss(self.model, features, tgt).numpy()
             toks = tf.cast(self._num_toks(features['tgt_len']), tf.float32).numpy()
             total_loss += loss_value * toks

--- a/baseline/tf/seq2seq/training/utils.py
+++ b/baseline/tf/seq2seq/training/utils.py
@@ -213,7 +213,7 @@ class Seq2SeqTrainerTf(Trainer):
         for batch_dict in pg(es):
             tgt = batch_dict.pop('tgt')
             tgt_lens = batch_dict.pop('tgt_lengths')
-            pred = [p[0] for p in self.model.predict(batch_dict)]
+            pred = [p[0] for p in self.model.predict(batch_dict)[0]]
             preds.extend(convert_seq2seq_preds(pred, self.tgt_rlut))
             golds.extend(convert_seq2seq_golds(tgt, tgt_lens, self.tgt_rlut))
         metrics = {'bleu': bleu(preds, golds, self.bleu_n_grams)[0]}

--- a/baseline/utils.py
+++ b/baseline/utils.py
@@ -417,7 +417,7 @@ def _try_user_cmp(user_cmp):
 
 @export
 def show_examples(model, es, rlut1, rlut2, vocab, mxlen, sample, prob_clip, max_examples, reverse):
-    """Expects model.predict to return [B, K, T]."""
+    """Expects model.predict to return (preds [B, K, T], scores [B, K])."""
     try:
         si = np.random.randint(0, len(es))
         batch_dict = es[si]
@@ -441,7 +441,7 @@ def show_examples(model, es, rlut1, rlut2, vocab, mxlen, sample, prob_clip, max_
         logger.info('[OP] %s' % sent)
         sent = lookup_sentence(rlut2, example['tgt'].squeeze())
         logger.info('[Actual] %s' % sent)
-        dst_i = model.predict(example)[0][0]
+        dst_i = model.predict(example)[0][0][0]
         sent = lookup_sentence(rlut2, dst_i)
         logger.info('Guess: %s' % sent)
         logger.info('------------------------------------------------------------------------')


### PR DESCRIPTION
There have been lots of asks about various scoring methods from different mead models. This PR updates the core seq2seq model to return both the predicted output sequences and the associated scores. The main service interface is unchanged, it is just the model itself that is changed.

This changes lets users get scores by subclassing the service if they choose, in the current setup they would need to subclass and retrain a model

Tested by training and running models with `ed_text.py` for tf1, tf2 eager, and pytorch