### PR TITLE
when running tfms, need to trim "unary"

### DIFF
--- a/baseline/tf/embeddings.py
+++ b/baseline/tf/embeddings.py
@@ -250,7 +250,7 @@ class TransformerLMEmbeddings(TensorFlowEmbeddings):
         return z
 
     def get_output(self, inputs, z):
-        return tf.stop_gradient(z)
+        return tf.stop_gradient(z) if self.finetune is False else z
 
     def get_vocab(self):
         return self.vocab

--- a/layers/eight_mile/tf/layers.py
+++ b/layers/eight_mile/tf/layers.py
@@ -2907,7 +2907,7 @@ class TaggerGreedyDecoder(tf.keras.layers.Layer):
         lengths = tf.cast(lengths, tf.int32)
         max_length = tf.reduce_max(lengths)
         tags = tags[:, :max_length]
-
+        unary = unary[:, :max_length, :]
         mask = tf.sequence_mask(lengths, max_length)
         cross_entropy = tf.nn.sparse_softmax_cross_entropy_with_logits(labels=tags, logits=unary)
         cross_entropy *= tf.cast(mask, tf.float32)


### PR DESCRIPTION
Right now, pass-through models do not trim the length of the input, but transducer models do.  For instance, if a BiLSTM is run through, the output of the unaries is truncated to the valid length, and this is compared against the valid labels.

Transformers are implemented usually as pass-through, meaning there isnt really a transduction "phase", the outputs are just transformed via a linear layer from the embeddings (the headless model for fine-tuning) and the output layer, meaning no truncation occurs.  This fixes the loss to trim the unaries accroding to the label length.

Also, for our TFM embeddings we were not allowing fine-tuning when features were passed in, which caused a mismatch in API with PyTorch.

This PR fixes both of those.  I tested that TF 1.x and TF 2.x work with the modifications as before