### PR TITLE
add transform_fn to label_vectorizer

### DIFF
--- a/baseline/reader.py
+++ b/baseline/reader.py
@@ -304,6 +304,10 @@ class SeqPredictReader:
                 label_vectorizer_spec['model_file'] = SingleFileDownloader(label_vectorizer_spec['model_file'], cache).download()
             if 'vocab_file' in label_vectorizer_spec:
                 label_vectorizer_spec['vocab_file'] = SingleFileDownloader(label_vectorizer_spec['vocab_file'], cache).download()
+            if 'transform' in label_vectorizer_spec:
+                label_vectorizer_spec['transform_fn'] = label_vectorizer_spec['transform']
+            if 'transform_fn' in label_vectorizer_spec and isinstance(label_vectorizer_spec['transform_fn'], str):
+                label_vectorizer_spec['transform_fn'] = eval(label_vectorizer_spec['transform_fn'])
             self.label_vectorizer = create_vectorizer(**label_vectorizer_spec)
         else:
             self.label_vectorizer = Dict1DVectorizer(fields='y', mxlen=mxlen)

--- a/baseline/vectorizers.py
+++ b/baseline/vectorizers.py
@@ -708,7 +708,7 @@ class BPELabelDict1DVectorizer(BPEVectorizer1D):
             elif t == '<eos>':
                 yield t_label
             else:
-                subwords = self.tokenizer.apply([t_word])[0].split()
+                subwords = self.tokenizer.apply([self.transform_fn(t_word)])[0].split()
                 subwords = [Offsets.VALUES[Offsets.PAD]] * len(subwords)
                 subwords[0] = t_label
                 for x in subwords:


### PR DESCRIPTION
In a tagger model, when `vectorizer` has a `transform_fn` (e.g. lowercase), but `label_vectorizer` doesn't, it cause mismatch of lengths between texts and tags (e.g. data is mixed case and we are using BPE codes trained on lowercase data).  