### PR TITLE
this adds support for skipping embeddings on load

### DIFF
--- a/baseline/pytorch/embeddings.py
+++ b/baseline/pytorch/embeddings.py
@@ -99,6 +99,10 @@ class TransformerLMEmbeddings(PyTorchEmbeddings):
             self.vocab = read_config_stream(kwargs.get('vocab_file'))
         else:
             self.vocab = load_bert_vocab(kwargs.get('vocab_file'))
+        # When we reload, allows skipping restoration of these embeddings
+        # If the embedding wasnt trained with token types, this allows us to add them later
+        self.skippable = set(listify(kwargs.get('skip_restore_embeddings', [])))
+
         self.cls_index = self.vocab['[CLS]']
         self.vsz = max(self.vocab.values()) + 1
         self.d_model = int(kwargs.get('dsz', kwargs.get('d_model', 768)))
@@ -187,7 +191,13 @@ class TransformerLMEmbeddings(PyTorchEmbeddings):
             if unmatch['missing'] or unmatch['unexpected']:
                 raise Exception("Unable to load the HuggingFace checkpoint")
         if mime_type(embeddings) == 'application/zip':
-            load_tlm_npz(c, embeddings)
+            keys_to_restore = set(list(c.embeddings.keys()))
+            filtered_keys = keys_to_restore.difference(c.skippable)
+            if not keys_to_restore:
+                raise Exception("No keys to restore!")
+            if len(filtered_keys) < len(keys_to_restore):
+                logger.warning("Restoring only key [%s]", ' '.join(filtered_keys))
+            load_tlm_npz(c, embeddings, filtered_keys)
         else:
             tlm_load_state_dict(c, embeddings)
         return c


### PR DESCRIPTION
for instance, if we have trained a transformer without
a segment embedding, this allows us to create it for
fine-tuning but leave it randomly initialized so we can
fine-tune it only on the problem, without erroring because
its not in the checkpoint