### PR TITLE
added support for subword-nmt package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,7 @@ def main():
             'report': ['visdom', 'tensorboard'],
             'yaml': ['pyyaml'],
             'bpe': ['fastBPE'],
+            'bpex': ['fastBPE', 'subword-nmt'],
             'tf2': ['tensorflow_addons'],
             'grpc': ['grpc'],
             'onnx': ['onnxruntime']


### PR DESCRIPTION
previously, we supported Lample's fastBPE, which
is a fast C++ implementation of Rico Sennrich's BPE
software (subword-nmt).  The subword-nmt package
supports some train time features like BPE-dropout,
and it supports glossaries during BPE application.

this adds support for subword NMT as an alternate
provider.  This support is also compatible with fastBPE-
trained models, which we achieve by inheriting the base
package's BPE class and modifying the codes reader.

The original BPE can be accessed by setting `use_fast_bpe`
to `False`, and new words can be added by passing in
`glossaries` as either a list or a file