### PR TITLE
Add dependency parser services and ONNX export

### DIFF
--- a/api-examples/deps_text.py
+++ b/api-examples/deps_text.py
@@ -1,0 +1,77 @@
+from __future__ import print_function
+
+import baseline as bl
+import argparse
+import os
+from eight_mile.utils import str2bool, read_conll
+
+
+parser = argparse.ArgumentParser(description='Parse dependencies on text with a model')
+parser.add_argument('--model', help='A tagger model with extended features', required=True, type=str)
+parser.add_argument('--text', help='raw value', type=str)
+parser.add_argument('--conll', help='is file type conll?', type=str2bool, default=False)
+parser.add_argument('--features', help='(optional) features in the format feature_name:index (column # in conll) or '
+                                       'just feature names (assumed sequential)', default=[], nargs='+')
+parser.add_argument('--backend', help='backend', default='tf')
+parser.add_argument('--device', help='device')
+parser.add_argument('--remote', help='(optional) remote endpoint', type=str) # localhost:8500
+parser.add_argument('--name', help='(optional) signature name', type=str)
+parser.add_argument('--preproc', help='(optional) where to perform preprocessing', choices={'client', 'server'}, default='client')
+parser.add_argument('--export_mapping', help='mapping between features and the fields in the grpc/ REST '
+                                                         'request, eg: token:word ner:ner. This should match with the '
+                                                         '`exporter_field` definition in the mead config',
+                    default=[], nargs='+')
+parser.add_argument('--prefer_eager', help="If running in TensorFlow, should we prefer eager model", type=str2bool)
+parser.add_argument('--batchsz', default=64, help="How many examples to run through the model at once", type=int)
+
+args = parser.parse_args()
+
+if args.backend == 'tf':
+    from eight_mile.tf.layers import set_tf_eager_mode
+    set_tf_eager_mode(args.prefer_eager)
+
+
+def create_export_mapping(feature_map_strings):
+    feature_map_strings = [x.strip() for x in feature_map_strings if x.strip()]
+    if not feature_map_strings:
+        return {}
+    else:
+        return {x[0]: x[1] for x in [y.split(':') for y in feature_map_strings]}
+
+
+def feature_index_mapping(features):
+    if not features:
+        return {}
+    elif ':' in features[0]:
+        return {feature.split(':')[0]: int(feature.split(':')[1]) for feature in features}
+    else:
+        return {feature: index for index, feature in enumerate(features)}
+
+
+if os.path.exists(args.text) and os.path.isfile(args.text):
+    texts = []
+    if args.conll:
+        feature_indices = feature_index_mapping(args.features)
+        for sentence in read_conll(args.text):
+            if feature_indices:
+                texts.append([{k: line[v] for k, v in feature_indices.items()} for line in sentence])
+            else:
+                texts.append([line[0] for line in sentence])
+    else:
+        with open(args.text, 'r') as f:
+            for line in f:
+                text = line.strip().split()
+                texts += [text]
+else:
+    texts = [args.text.split()]
+
+m = bl.DependencyParserService.load(args.model, backend=args.backend, remote=args.remote,
+                                    name=args.name, preproc=args.preproc, device=args.device)
+
+batched = [texts[i:i+args.batchsz] for i in range(0, len(texts), args.batchsz)]
+
+for texts in batched:
+    for sen in m.predict(texts, export_mapping=create_export_mapping(args.export_mapping)):
+        for word_tag in sen:
+            print("{} {}".format(word_tag['text'], word_tag['label'], word_tag['head']))
+        print()

--- a/api-examples/deps_text.py
+++ b/api-examples/deps_text.py
@@ -73,5 +73,5 @@ batched = [texts[i:i+args.batchsz] for i in range(0, len(texts), args.batchsz)]
 for texts in batched:
     for sen in m.predict(texts, export_mapping=create_export_mapping(args.export_mapping)):
         for word_tag in sen:
-            print("{} {}".format(word_tag['text'], word_tag['label'], word_tag['head']))
+            print("{} {} {}".format(word_tag['text'], word_tag['label'], word_tag['head']))
         print()

--- a/baseline/pytorch/deps/model.py
+++ b/baseline/pytorch/deps/model.py
@@ -63,12 +63,6 @@ class DependencyParserModelBase(nn.Module, DependencyParserModel):
         model.gpu = False if device == 'cpu' else model.gpu
         return model
 
-    #def arc_lookup(self, arc_keys):
-    #    shape = arc_keys.shape
-    #    arc_keys = arc_keys.view(-1)
-    #    t = torch.tensor([self.idx2head[k.item()] for k in arc_keys])
-    #    return t.view(shape)
-
     def save(self, outname: str):
         logger.info('saving %s' % outname)
         torch.save(self, outname)
@@ -85,9 +79,6 @@ class DependencyParserModelBase(nn.Module, DependencyParserModel):
         model.gpu = not bool(kwargs.get('nogpu', False))
         model.labels = labels["labels"]
         model.punct = labels["labels"].get("punct", Offsets.PAD)
-
-        #model.idx2head = {v: int(k) for k, v in model.labels['heads'].items() if k not in Offsets.VALUES}
-        #model.idx2head[0] = -1
         model.create_layers(embeddings, **kwargs)
         logger.info(model)
         return model
@@ -162,12 +153,6 @@ class DependencyParserModelBase(nn.Module, DependencyParserModel):
 
         y = batch_dict.get('heads')
         if y is not None:
-            #y = self.arc_lookup(y)
-
-            #for b_y, b_l in zip(y, lengths):
-            #    mx_by = max(b_y).item()
-            #    if mx_by >= b_l.item():
-            #        raise Exception("Invalid head", mx_by, b_l.item())
             if numpy_to_tensor:
                 y = torch.from_numpy(y)
 
@@ -320,6 +305,4 @@ class BiAffineDependencyParser(DependencyParserModelBase):
         mask = truncate_mask_over_time(mask, arcs_h)
         score_arcs = self.arc_attn(arcs_d, arcs_h, mask)
         score_rels = self.rel_attn(rels_d, rels_h, mask.unsqueeze(1)).permute(0, 2, 3, 1)
-        #if not self.training:
-        #    return decode_results(score_arcs, score_rels)
         return score_arcs, score_rels

--- a/baseline/pytorch/deps/train.py
+++ b/baseline/pytorch/deps/train.py
@@ -70,7 +70,6 @@ class DependencyParserTrainerPyTorch(EpochReportingTrainer):
                 labels_gold = example.pop('labels')
                 heads_gold = example.pop('heads')
                 batchsz = self._get_batchsz(batch_dict)
-                # The predicted heads has an additional T dimension
                 greedy_heads_pred, greedy_labels_pred = self.model.decode(example)
                 T = greedy_labels_pred.shape[1]
                 labels_gold_trimmed = labels_gold[:, :T]

--- a/baseline/services.py
+++ b/baseline/services.py
@@ -660,7 +660,7 @@ class DependencyParserService(Service):
     def predict(self, tokens, **kwargs):
         """
         Utility function to convert lists of sentence tokens to integer value one-hots which
-        are then passed to the tagger.  The resultant output is then converted back to label and token
+        are then passed to the parser.  The resultant output is then converted back to label and token
         to be printed.
 
         This method is not aware of any input features other than words and characters (and lengths).  If you
@@ -669,23 +669,18 @@ class DependencyParserService(Service):
         :param tokens: (``list``) A list of tokens
 
         """
-        preproc = kwargs.get('preproc', None)
-        if preproc is not None:
-            logger.warning("Warning: Passing `preproc` to `TaggerService.predict` is deprecated.")
         export_mapping = kwargs.get('export_mapping', {})  # if empty dict argument was passed
         if not export_mapping:
             export_mapping = {'tokens': 'text'}
         label_field = kwargs.get('label', 'label')
         tokens_batch = self.batch_input(tokens)
         self.prepare_vectorizers(tokens_batch)
-        # TODO: here we allow vectorizers even for preproc=server to get `word_lengths`.
-        # vectorizers should not be available when preproc=server.
         examples = self.vectorize(tokens_batch)
         if self.preproc == 'server':
             unfeaturized_examples = {}
             for exporter_field in export_mapping:
                 unfeaturized_examples[exporter_field] = np.array([" ".join([y[export_mapping[exporter_field]]
-                                                                   for y in x]) for x in tokens_batch])
+                                                                            for y in x]) for x in tokens_batch])
             unfeaturized_examples[self.model.lengths_key] = examples[self.model.lengths_key]  # remote model
             examples = unfeaturized_examples
 
@@ -693,7 +688,6 @@ class DependencyParserService(Service):
         return self.format_output(outcomes, tokens_batch=tokens_batch, label_field=label_field, vectorized_examples=examples)
 
     def format_output(self, predicted, tokens_batch=None, label_field='label', arc_field='head', vectorized_examples=None, **kwargs):
-        """This code got very messy dealing with BPE/WP outputs."""
         assert tokens_batch is not None
         assert vectorized_examples is not None
         outputs = []

--- a/layers/eight_mile/pytorch/layers.py
+++ b/layers/eight_mile/pytorch/layers.py
@@ -37,6 +37,32 @@ def sequence_mask(lengths: torch.Tensor, max_len: int = -1) -> torch.Tensor:
     mask = row < col
     return mask
 
+def sequence_mask_mxlen(lengths: torch.Tensor, max_len: int) -> torch.Tensor:
+    """Generate a sequence mask of shape `BxT` based on the given lengths, with a maximum value
+
+    This function primarily exists to make ONNX tracing work better
+    :param lengths: A `B` tensor containing the lengths of each example
+    :param max_len: The maximum width (length) allowed in this mask (default to None)
+    :return: A mask
+    """
+    lens = lengths.cpu()
+    max_len_v = max_len
+    # 1 x T
+    row = torch.arange(0, max_len_v).type_as(lens).view(1, -1)
+    # B x 1
+    col = lens.view(-1, 1)
+    # Broadcast to B x T, compares increasing number to max
+    mask = row < col
+    return mask
+
+
+@torch.jit.script
+def truncate_mask_over_time(mask: torch.Tensor, x: torch.Tensor) -> torch.Tensor:
+
+    Tout = x.shape[1]
+    mask = mask[:, :Tout]
+    #mask = mask.narrow(1, 0, arcs_h.shape[1])
+    return mask
 
 def vec_log_sum_exp(vec: torch.Tensor, dim: int) -> torch.Tensor:
     """Vectorized version of log-sum-exp
@@ -3825,13 +3851,19 @@ def tie_weight(to_layer, from_layer):
 
 class BilinearAttention(nn.Module):
 
-    def __init__(self, in_hsz, out_hsz=1, bias_x=True, bias_y=True):
+    def __init__(self, in_hsz: int, out_hsz: int = 1, bias_x: bool = True, bias_y: bool = True):
         super().__init__()
 
         self.in_hsz = in_hsz
         self.out_hsz = out_hsz
         self.bias_x = bias_x
         self.bias_y = bias_y
+        a1 = in_hsz
+        a2 = in_hsz
+        if self.bias_x:
+            a1 += 1
+        if self.bias_y:
+            a2 += 1
         self.weight = nn.Parameter(torch.Tensor(out_hsz, in_hsz + bias_x, in_hsz + bias_y))
         self.reset_parameters()
 
@@ -3849,16 +3881,17 @@ class BilinearAttention(nn.Module):
                 A scoring tensor of shape ``[batch_size, n_out, seq_len, seq_len]``.
                 If ``n_out=1``, the dimension for ``n_out`` will be squeezed automatically.
         """
-        if self.bias_x:
+        if self.bias_x is True:
             ones = torch.ones(x.shape[:-1] + (1,), device=x.device)
             x = torch.cat([x, ones], -1)
-        if self.bias_y:
+        if self.bias_y is True:
             ones = torch.ones(x.shape[:-1] + (1,), device=y.device)
             y = torch.cat([y, ones], -1)
         x = x.unsqueeze(1)
         y = y.unsqueeze(1)
         u = x @ self.weight
         s = u @ y.transpose(-2, -1)
-        s = s.squeeze(1)
-        s = s.masked_fill((mask == MASK_FALSE).unsqueeze(1), -1e9)
+        if self.out_hsz == 1:
+            s = s.squeeze(1)
+        s = s.masked_fill((mask.bool() == MASK_FALSE).unsqueeze(1), -1e9)
         return s


### PR DESCRIPTION
- make decoding an option in `model.predict`
- adds a dependency parser service.  for now this calls `model.predict` with decode defaulting to `True`
-  truncation of mask can be done in compiled JIT script but not traced, put this in layers
- `sequence_mask` is an ongoing issue with ONNX tracing due to argument.  Make a more explicit version
- adds an ONNX dependency parser exporter.  distributions returned from ONNX
-  adds an ONNX dependency parser service.  this does greedy prediction client side
- add a dependency parser API example