### PR TITLE
one path to reload for DE and S2S

### DIFF
--- a/layers/eight_mile/pytorch/layers.py
+++ b/layers/eight_mile/pytorch/layers.py
@@ -3610,10 +3610,10 @@ def rm_old_checkpoints(base_path, current_epoch, last_n=10):
                 os.remove(checkpoint_name)
 
 
-def find_latest_checkpoint(checkpoint_dir: str, wildcard="checkpoint") -> str:
+def find_latest_checkpoint(checkpoint_dir: str, wildcard="checkpoint") -> Tuple[str, int]:
     step_num = 0
     for f in glob.glob(os.path.join(checkpoint_dir, f"{wildcard}*")):
-        last = f.split("-")[-1]
+        last = os.path.basename(f).split("-")[-1]
         for x in ('.pth', '.npz'):
             last = last.replace(x, '', -1)
         this_step_num = int(last)


### PR DESCRIPTION
this cleans up the reload of checkpoints so they
are unified between seq2seq and dual-encoder.

it makes it possible to pass in a directory, in which case
we find the latest checkpoint

for S2S reloading, it only updates the global step/epoch num
when it reloads either a PTH or a NPZ file for transformer
seq2seq models.  the backoff behavior remains, where we try and
reload the encoder from a transformer LM NPZ but this should be
treated as step 0, not whatever step was given in the checkpoint

additionally, for DEs, they only preserve step when reloading
a PTH, for NPZ reloads it use the transformer LM NPZ and loads
the .transformer and .embeddings only, so again, it should be
treated as step 0