### PR TITLE
add dual encoder options

### DIFF
--- a/api-examples/pretrain_paired_pytorch.py
+++ b/api-examples/pretrain_paired_pytorch.py
@@ -263,7 +263,7 @@ def train():
 
 
             x, y = batch
-            loss = run_step(x, y, model, loss_function, args.device, args.distributed, step)
+            loss = run_step(x, y, model, loss_function, args.device, args.distributed)
             loss.backward()
             avg_loss.update(loss.item())
 


### PR DESCRIPTION
1. make it possible to pass alternate pooling methods
  - [2s]ha (sqrt_length), [2s]ha_max, [2s]ha_mean
2. support freezing and unfreezing encoders in DE
  - defaults to unfrozen, pass `freeze_encoders` True
3. support unfreezing encoders in `pretrain_paired`
4. set the default to False for scaling in SHA/2HA layers
  - this was being set to False explicitly in the encoders
  - defaulted off in 2HA, on in SHA before