### PR TITLE
makes the dual loss trainable inside its module

### DIFF
--- a/api-examples/pretrain_paired_pytorch.py
+++ b/api-examples/pretrain_paired_pytorch.py
@@ -233,10 +233,10 @@ def train():
         logger.info("Restarting from a previous checkpoint %s.\n\tStarting at global_step=%d, epoch=%d",
                     args.restart_from, global_step, start_epoch+1)
 
+    target = model if args.model_type == 'encoder-decoder' else loss_function
 
-    optimizer = OptimizerManager(model, global_step, optim=args.optim, lr=args.lr, lr_function=lr_sched, weight_decay=args.weight_decay)
-    logger.info("Model has {:,} parameters".format(sum(p.numel() for p in model.parameters() if p.requires_grad)))
-
+    optimizer = OptimizerManager(target, global_step, optim=args.optim, lr=args.lr, lr_function=lr_sched, weight_decay=args.weight_decay)
+    logger.info("Model has {:,} parameters".format(sum(p.numel() for p in target.parameters() if p.requires_grad)))
     # Prepare model for distributed training if needed
     if args.distributed:
         model = DistributedDataParallel(model, device_ids=[args.device], output_device=args.device)

--- a/api-examples/pretrain_paired_pytorch.py
+++ b/api-examples/pretrain_paired_pytorch.py
@@ -135,6 +135,9 @@ def train():
     parser.add_argument("--tgt_begin_tok", type=str, nargs='+', default=['<GO>'])
     parser.add_argument("--tgt_end_tok", type=str, nargs='+', default=['<EOS>'])
     parser.add_argument("--loss", type=str, default='all', choices=['triplet', 'all', 'all_mean', 'contrastive', 'symmetric'])
+    parser.add_argument("--learn_temp", type=str2bool, default=True,
+                        help="If 'constrastive' or 'symmetric' loss, should we learn the temperature scaling")
+    parser.add_argument("--init_temp", type=float, help="Initialize the temperature for 'contrastive' or 'symmetric' loss")
     parser.add_argument('--rpr_k',
                         help='Relative attention positional sizes pass 0 if you dont want relative attention',
                         type=int, default=[8], nargs='+')
@@ -206,11 +209,15 @@ def train():
                          logger=logger)
 
     model.to(args.device)
-    loss_function = model.create_loss(loss_type=args.loss)
+    if args.model_type == 'encoder_decoder':
+        run_step = run_step_s2s
+    else:
+        run_step = run_step_dual
+        logger.info(f"Creating {args.loss}, init temperature: {args.init_temp}, learnable: {args.learn_temp}")
+    loss_function = model.create_loss(loss_type=args.loss, init_temp=args.init_temp, learn_temp=args.learn_temp)
     loss_function.to(args.device)
-    run_step = run_step_s2s if args.model_type == 'encoder-decoder' else run_step_dual
 
-    logger.info("Loaded model and loss")
+    logger.info("Created model and loss")
 
     steps_per_epoch = len(train_loader) // num_gpus
     valid_steps = len(valid_loader)

--- a/layers/eight_mile/pytorch/layers.py
+++ b/layers/eight_mile/pytorch/layers.py
@@ -4170,15 +4170,15 @@ class DualEncoderModel(nn.Module):
         encoded_response = self.encode_response(response)
         return encoded_query, encoded_response
 
-    def create_loss(self, loss_type='all'):
+    def create_loss(self, loss_type='all', init_temp=None, learn_temp=False):
         if loss_type == 'all':
             return AllLoss(self)
         elif loss_type == 'all_mean':
             return AllLoss(self, reduction_type='mean')
         elif loss_type == 'contrastive':
-            return ContrastiveLoss(self)
+            return ContrastiveLoss(self, init_temp, learn_temp)
         elif loss_type == 'symmetric':
-            return SymmetricContrastiveLoss(self)
+            return SymmetricContrastiveLoss(self, init_temp, learn_temp)
 
         return TripletLoss(self)
 

--- a/layers/eight_mile/pytorch/layers.py
+++ b/layers/eight_mile/pytorch/layers.py
@@ -3979,10 +3979,12 @@ class TripletLoss(nn.Module):
 
 
 class ContrastiveLoss(nn.Module):
-    def __init__(self, model, t=1.0):
+    def __init__(self, model, t=1.0, train_temperature=True):
         super().__init__()
         self.model = model
-        self.t = nn.Parameter(torch.tensor(t).float())
+        if t is None:
+            t = math.sqrt(self.model.output_dim)
+        self.t = nn.Parameter(torch.tensor(t).float(), requires_grad=train_temperature)
 
     def forward(self, inputs, targets):
         query = self.model.encode_query(inputs)  # [B, H]
@@ -3996,10 +3998,12 @@ class ContrastiveLoss(nn.Module):
 
 
 class SymmetricContrastiveLoss(nn.Module):
-    def __init__(self, model, t=1.0):
+    def __init__(self, model, t=1.0, train_temperature=True):
         super().__init__()
-        self.t = nn.Parameter(torch.tensor(t))
         self.model = model
+        if t is None:
+            t = math.sqrt(self.model.output_dim)
+        self.t = nn.Parameter(torch.tensor(t).float(), requires_grad=train_temperature)
 
     def forward(self, inputs, targets):
         query = self.model.encode_query(inputs)  # [B, H]
@@ -4145,6 +4149,7 @@ class DualEncoderModel(nn.Module):
         else:
             self.ff1 = nn.Identity()
             self.ff2 = nn.Identity()
+        self.output_dim = d_out
 
     def encode_query_base(self, query: torch.Tensor) -> torch.Tensor:
         pass


### PR DESCRIPTION
previously the symmetric and contrastive losses werent
trainable from the pretrain_paired_pytorch harness code
b/c they werent being passed into the optimizer.  b/c the
loss function for dual encoder holds a model reference, its
possible to just pass the loss function to the OptimizerManager
it its place.

also, sometimes we dont want to train this, so make that an option
too