### PR TITLE
add support for scaling the grads in pytorch

### DIFF
--- a/layers/eight_mile/pytorch/optz.py
+++ b/layers/eight_mile/pytorch/optz.py
@@ -216,6 +216,12 @@ class OptimizerManager:
         self.current_lr = self.update_lr()
         self.global_step += 1
 
+    def scale_grads(self, scalar):
+        for param_group in self.optimizer.param_groups:
+            for p in param_group['params']:
+                if p.grad is not None:
+                    p.grad.data.mul_(scalar)
+
     def zero_grad(self):
         self.optimizer.zero_grad()
 


### PR DESCRIPTION
If DDP is being used, the gradients are going to
get averaged over the world_size and thats not
necessarily what we want to happen.  Add a function
to apply a scalar