### PR TITLE
Feature/pass vocab to tpt embeddings

### DIFF
--- a/baseline/pytorch/embeddings.py
+++ b/baseline/pytorch/embeddings.py
@@ -95,10 +95,13 @@ class TransformerLMEmbeddings(PyTorchEmbeddings):
         # If you trained your model with MEAD/Baseline, you will have a `*.json` file which would want to
         # reference here
         vocab_file = kwargs.get('vocab_file')
-        if vocab_file and vocab_file.endswith('.json'):
-            self.vocab = read_config_stream(kwargs.get('vocab_file'))
+        if vocab_file:
+            if vocab_file.endswith('.json'):
+                self.vocab = read_config_stream(kwargs.get('vocab_file'))
+            else:
+                self.vocab = load_bert_vocab(kwargs.get('vocab_file'))
         else:
-            self.vocab = load_bert_vocab(kwargs.get('vocab_file'))
+            self.vocab = kwargs.get('vocab')
         # When we reload, allows skipping restoration of these embeddings
         # If the embedding wasnt trained with token types, this allows us to add them later
         self.skippable = set(listify(kwargs.get('skip_restore_embeddings', [])))

--- a/layers/eight_mile/pytorch/serialize.py
+++ b/layers/eight_mile/pytorch/serialize.py
@@ -82,19 +82,20 @@ def convert_transformers_keys(num_layers: int, d: Dict, nested_layer_map: Dict =
     return m
 
 
-def tlm_load_state_dict(module: nn.Module, checkpoint_file: str):
+def tlm_load_state_dict(module: nn.Module, checkpoint_file: str, map_location=None, str_map = None):
     """
 
     :param tlm: Safely loads the state dict for a transformer encoder
     :param checkpoint_file: The file name
     :return: None
     """
-    str_map = {'transformer': 'generator'}
-    if hasattr(module, 'transformer'):
-        str_map = {'generator': 'transformer'}
+    if str_map is None:
+        str_map = {'transformer': 'generator'}
+        if hasattr(module, 'transformer'):
+            str_map = {'generator': 'transformer'}
     if hasattr(module, 'reduction_layer'):
         str_map.update({'reduction_layer_1': 'reduction_layer'})
-    ckpt_dict = torch.load(checkpoint_file)
+    ckpt_dict = torch.load(checkpoint_file, map_location=map_location)
     renamed = {}
     for k, v in ckpt_dict.items():
         for from_str, to_str in str_map.items():


### PR DESCRIPTION
- Adds an option to pass `vocab` directly to TPT model. If you already have a `vectorizer`, can pass `vocab=vectorizer.vocab`
- Add some options to the serialize util `tlm_load_state_dict`, getting the `map_location` and keys to patch