### PR TITLE
stop hardcoding the pad

### DIFF
--- a/addons/pretrained_transformer_tagger.py
+++ b/addons/pretrained_transformer_tagger.py
@@ -29,7 +29,7 @@ class TransformerTagger(tf.keras.Model):
         self.output_layer = tf.keras.layers.Dense(num_labels)
 
     def call(self, inputs):
-        input_mask = tf.expand_dims(tf.expand_dims(tf.cast(inputs['x'] != 0, tf.int32), 1), 1)
+        input_mask = tf.expand_dims(tf.expand_dims(tf.cast(inputs['x'] != Offsets.PAD, tf.int32), 1), 1)
         embed = self.embeddings(inputs)
         transformed = self.transformer((embed, input_mask))
         output = self.output_layer(transformed)

--- a/api-examples/generate_lm.py
+++ b/api-examples/generate_lm.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__file__)
 
 def decode_sentence(model, vectorizer, query, word2index, index2word, device, end_token='<EOS>', sample=True, sample_temperature=1.0):
     vec, length = vectorizer.run(query, word2index)
-    bpe = [index2word[v] for v in vec if v != 0]
+    bpe = [index2word[v] for v in vec if v != Offsets.PAD]
     logger.info('[BPE] ' + ' '.join(bpe))
     toks = torch.from_numpy(vec).to(device=device)
 

--- a/api-examples/generate_mlm.py
+++ b/api-examples/generate_mlm.py
@@ -23,7 +23,7 @@ def decode_sentence(model, vectorizer, query, word2index, index2word, device, sa
         if vec[i] == UNK:
             vec[i] = MASK
 
-    bpe = [index2word[v] for v in vec if v != 0]
+    bpe = [index2word[v] for v in vec if v != Offsets.PAD]
     print('[BPE] ' + ' '.join(bpe))
     toks = torch.from_numpy(vec).unsqueeze(0).to(device=device)
 

--- a/api-examples/pretrain_paired_pytorch.py
+++ b/api-examples/pretrain_paired_pytorch.py
@@ -71,8 +71,8 @@ def run_step_dual(x, y, model, loss_function, device, distributed):
 
 
 def run_step_s2s(x, y, model, loss_function, device, distributed):
-    x_lengths = torch.sum(x != 0, 1)
-    y_lengths = torch.sum(y != 0, 1)
+    x_lengths = torch.sum(x != Offsets.PAD, 1)
+    y_lengths = torch.sum(y != Offsets.PAD, 1)
     if distributed:
         inputs = model.module.make_input({'x': x, 'x_lengths': x_lengths, 'tgt': y, 'tgt_lengths': y_lengths})
         pred = model(inputs)

--- a/baseline/tf/embeddings.py
+++ b/baseline/tf/embeddings.py
@@ -241,7 +241,7 @@ class TransformerLMEmbeddings(TensorFlowEmbeddings):
                                                    activation=activation, layer_norms_after=layer_norms_after,
                                                    layer_norm_eps=layer_norm_eps, windowed_ra=windowed_ra,
                                                    rpr_value_on=rpr_value_on)
-        self.mlm = kwargs.get('mlm', False)
+        self.mlm = kwargs.get('mlm', True)
         self.finetune = kwargs.get('finetune', True)
 
     def encode(self, x, token_type=None):

--- a/layers/eight_mile/pytorch/layers.py
+++ b/layers/eight_mile/pytorch/layers.py
@@ -3855,7 +3855,7 @@ class TransformerDiscriminator(nn.Module):
     def forward(self, features):
         embedded = self.embeddings(features)
         x = features[self.lengths_feature]
-        input_mask = torch.zeros(x.shape, device=x.device, dtype=torch.long).masked_fill(x != 0, 1).unsqueeze(1).unsqueeze(1)
+        input_mask = torch.zeros(x.shape, device=x.device, dtype=torch.long).masked_fill(x != Offsets.PAD, 1).unsqueeze(1).unsqueeze(1)
         transformer_out = self.transformer((embedded, input_mask))
         binary = self.proj_to_output(transformer_out)
         return torch.sigmoid(binary)

--- a/layers/eight_mile/tf/layers.py
+++ b/layers/eight_mile/tf/layers.py
@@ -2898,7 +2898,7 @@ class TransformerDiscriminator(tf.keras.Model):
     def call(self, features):
         embedded = self.embeddings(features)
         x = features[self.lengths_feature]
-        input_mask = tf.expand_dims(tf.expand_dims(tf.cast(x != 0, tf.int32), 1), 1)
+        input_mask = tf.expand_dims(tf.expand_dims(tf.cast(x != Offsets.PAD, tf.int32), 1), 1)
         #input_mask = tf.expand_dims(tf.expand_dims(tf.ones_like(x, dtype=tf.uint8), 1), 1)
         transformer_out = self.transformer((embedded, input_mask))
         binary = tf.squeeze(self.proj_to_output(transformer_out), -1)

--- a/layers/eight_mile/utils.py
+++ b/layers/eight_mile/utils.py
@@ -461,7 +461,7 @@ def read_config_stream(config_stream) -> Dict:
             path_to_save, _ = urlretrieve(config_stream)
             return read_config_stream(path_to_save)
         else:
-            logger.info("No file found '{}...', loading as string".format(config_stream[:12]))
+            logger.info("No file found '...{}', loading as string".format(config_stream[-32:]))
     return json.loads(config)
 
 
@@ -1605,8 +1605,8 @@ def to_numpy(x):
 def mlm_masking(inputs, mask_value, vocab_size, ignore_prefix, ignore_suffix, pad_y=True):
     labels = np.copy(inputs)
     masked_indices = np.random.binomial(size=len(inputs), n=1, p=0.15)
-    masked_indices = masked_indices & (labels != 0)
-    masked_indices[np.random.randint(1, sum(labels != 0))] = 1  #ensure at least one token is masked
+    masked_indices = masked_indices & (labels != Offsets.PAD)
+    masked_indices[np.random.randint(1, sum(labels != Offsets.PAD))] = 1  #ensure at least one token is masked
     if ignore_prefix:
         masked_indices[0] = 0
     if ignore_suffix:


### PR DESCRIPTION
this also changes mlm=True as default for TPT
embeddings.  Finally, it adds backoff in case
the vocabs.json isnt present.  There really is
no reason to use that anymore