### PR TITLE
API ex: convert FT transformer to NPZ w/ output

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -99,7 +99,6 @@ jobs:
       max-parallel: 4
       matrix:
         pyt-version:
-        - 1.3-cuda10.1-cudnn7-runtime
         - 1.4-cuda10.1-cudnn7-runtime
         - 1.5-cuda10.1-cudnn7-runtime
         - 1.6.0-cuda10.1-cudnn7-runtime

--- a/api-examples/finetuned_transformer_to_npz.py
+++ b/api-examples/finetuned_transformer_to_npz.py
@@ -1,0 +1,49 @@
+"""Convert a fine-tuned Transformer model from Baseline PyTorcy output to NPZ
+
+These models will have the entire transformer inside the primary embeddings key,
+and a single output layer on the model.  We will use
+`eight_mile.pytorch.serialize.save_tlm_output_npz()`
+
+Because these models are serialized with pickle, if you used an addon, you need to
+ensure that this addon is in the path.  This can be done via the command-line by
+passing `--modules m1 m2 ...`
+"""
+
+import argparse
+import os
+import torch
+import logging
+from baseline.utils import import_user_module
+from eight_mile.pytorch.serialize import save_tlm_output_npz
+parser = argparse.ArgumentParser(
+    description='Convert finetuned transformer model trained with PyTorch classifier to an TLM NPZ'
+)
+parser.add_argument('--model', help='The path to the .pyt file created by training', required=True, type=str)
+parser.add_argument('--device', help='device')
+parser.add_argument('--npz', help='Output file name, defaults to the original name with replaced suffix')
+parser.add_argument('--modules', help='modules to load: local files, remote URLs or mead-ml/hub refs', default=[], nargs='+', required=False)
+
+args = parser.parse_args()
+
+logger = logging.getLogger(__file__)
+
+for module in args.modules:
+    import_user_module(module)
+
+if args.npz is None:
+    args.npz = args.model.replace('.pyt', '') + '.npz'
+
+bl_model = torch.load(args.model, map_location=args.device)
+tpt_embed_dict = bl_model.embeddings
+
+keys = list(tpt_embed_dict.keys())
+if len(keys) > 1:
+    raise Exception(
+        "Unsupported model! Multiple embeddings are applied in this model, "
+        "but this converter only supports a single embedding"
+    )
+
+tpt_embed = tpt_embed_dict[keys[0]]
+# Monkey patch the embedding to contain an output_layer
+tpt_embed.output_layer = bl_model.output_layer
+save_tlm_output_npz(tpt_embed, args.npz, verbose=True)

--- a/layers/eight_mile/pytorch/serialize.py
+++ b/layers/eight_mile/pytorch/serialize.py
@@ -2,7 +2,15 @@ import torch
 import torch.nn as nn
 import numpy as np
 from typing import Dict, List
-from eight_mile.pytorch.layers import Dense, TransformerEncoderStack, TransformerEncoder, TransformerDecoderStack, TransformerDecoder, EmbeddingsStack
+from eight_mile.pytorch.layers import (
+    Dense,
+    TransformerEncoderStack,
+    TransformerEncoder,
+    TransformerDecoderStack,
+    TransformerDecoder,
+    EmbeddingsStack,
+    WithDropout,
+)
 from eight_mile.pytorch.embeddings import LookupTableEmbeddings, LearnedPositionalLookupTableEmbeddingsWithBias
 
 # BERT HuggingFace Tokenizers checkpoints can be converted into MEAD Baseline Transformer checkpoints
@@ -114,6 +122,8 @@ def to_weight_array(pytorch_layer: nn.Module, name: str) -> Dict:
     :param name: The name of this layer to serialize
     :return: A Dictionary containing `weights` and `bias` keys
     """
+    if isinstance(pytorch_layer, WithDropout):
+        pytorch_layer = pytorch_layer.layer
     if isinstance(pytorch_layer, Dense):
         pytorch_layer = pytorch_layer.layer
     weights = pytorch_layer.weight.cpu().detach().numpy()


### PR DESCRIPTION
this adds an API example which shows how to convert
a model trained with `mead-train` back into a TLM
NPZ file so that it can be used as an embedding later