### PR TITLE
fix mutate issue with predefined vocab

### DIFF
--- a/baseline/embeddings.py
+++ b/baseline/embeddings.py
@@ -196,7 +196,7 @@ def load_embeddings(name, **kwargs):
             model = RandomInitVecModel(dsz, known_vocab=known_vocab, unif_weight=unif, counts=not preserve_vocab_indices)
         # If there, is use the PretrainedEmbeddingsModel loader
         else:
-            if is_sequence(filename):
+            if is_sequence(filename) or preserve_vocab_indices:
                 model = PretrainedEmbeddingsStack(
                     listify(filename),
                     known_vocab=known_vocab,

--- a/layers/eight_mile/embeddings.py
+++ b/layers/eight_mile/embeddings.py
@@ -351,7 +351,7 @@ class PretrainedEmbeddingsStack(EmbeddingsModel):
         embeddings = []
 
         for file in filenames:
-            embeddings.append(PretrainedEmbeddingsModel(file, known_vocab))
+            embeddings.append(PretrainedEmbeddingsModel(file, copy.deepcopy(known_vocab)))
 
         self.dsz = sum([embedding.dsz for embedding in embeddings])
         self.weights = np.random.uniform(-uw, uw, (self.vsz, self.dsz)).astype(np.float32)


### PR DESCRIPTION
When the `known_vocab` passed in is not counts (ie its indices), we cannot mutate it, but the base approach
does that to figure out the gaps.  In the case of pretrained stacked embeddings, the sub component embeddings and concatenates
them into a single embedding along the (now destroyed) index.