### PR TITLE
Add mbert

### DIFF
--- a/api-examples/convert_huggingface_checkpoints.py
+++ b/api-examples/convert_huggingface_checkpoints.py
@@ -131,11 +131,13 @@ if os.path.isdir(args.model):
     config_url = os.path.join(args.model, args.config_file_name)
     bert_checkpoint = os.path.join(args.model, args.checkpoint)
     checkpoint_disk_loc = bert_checkpoint
+    output_file = os.path.basename(args.model)
 else:
     config_url = BERT_PRETRAINED_CONFIG_ARCHIVE_MAP[args.model]
     bert_checkpoint = BERT_PRETRAINED_MODEL_ARCHIVE_MAP[args.model]
     checkpoint_basename = os.path.basename(bert_checkpoint)
     checkpoint_disk_loc = os.path.join(args.target_dir, checkpoint_basename)
+    output_file = args.model
 
 model, num_layers = create_transformer_lm(config_url)
 mapped_keys = convert_checkpoint(bert_checkpoint, num_layers, args.target_dir, checkpoint_disk_loc)
@@ -145,5 +147,5 @@ for k in unknown_keys.missing_keys:
         print(f'Warning: missing key: {k}')
 for k in unknown_keys.unexpected_keys:
     print(f'Warning: unexpected key {k}')
-output_file = os.path.join(args.target_dir, args.model + '.npz')
+output_file = os.path.join(args.target_dir, output_file + '.npz')
 write_npz(output_file, model)

--- a/layers/eight_mile/pytorch/serialize.py
+++ b/layers/eight_mile/pytorch/serialize.py
@@ -35,10 +35,10 @@ BERT_HF_LAYER_MAP = {
     ## LN weights
     # The names in of layer norm our transformers are a bit unspecific
     # think of ln1 as ln_x and ln2 as ln_attn_output
-    'bert.encoder.layer.{}.output.LayerNorm.bias': 'generator.encoders.{}.ln1.bias',
-    'bert.encoder.layer.{}.output.LayerNorm.weight': 'generator.encoders.{}.ln1.weight',
-    'bert.encoder.layer.{}.attention.output.LayerNorm.bias': 'generator.encoders.{}.ln2.bias',
-    'bert.encoder.layer.{}.attention.output.LayerNorm.weight': 'generator.encoders.{}.ln2.weight'
+    'bert.encoder.layer.{}.output.LayerNorm.beta': 'generator.encoders.{}.ln1.bias',
+    'bert.encoder.layer.{}.output.LayerNorm.gamma': 'generator.encoders.{}.ln1.weight',
+    'bert.encoder.layer.{}.attention.output.LayerNorm.beta': 'generator.encoders.{}.ln2.bias',
+    'bert.encoder.layer.{}.attention.output.LayerNorm.gamma': 'generator.encoders.{}.ln2.weight'
 }
 
 BERT_HF_FT_LAYER_MAP = {
@@ -61,10 +61,10 @@ BERT_HF_FT_LAYER_MAP = {
     ## LN weights
     # The names in of layer norm our transformers are a bit unspecific
     # think of ln1 as ln_x and ln2 as ln_attn_output
-    'bert.encoder.layer.{}.output.LayerNorm.bias': 'transformer.encoders.{}.ln1.bias',
+    'bert.encoder.layer.{}.output.LayerNorm.beta': 'transformer.encoders.{}.ln1.bias',
     'bert.encoder.layer.{}.output.LayerNorm.weight': 'transformer.encoders.{}.ln1.weight',
     'bert.encoder.layer.{}.attention.output.LayerNorm.beta': 'transformer.encoders.{}.ln2.bias',
-    'bert.encoder.layer.{}.attention.output.LayerNorm.weight': 'transformer.encoders.{}.ln2.weight'
+    'bert.encoder.layer.{}.attention.output.LayerNorm.gamma': 'transformer.encoders.{}.ln2.weight'
 }
 
 BERT_HF_EMBED_MAP = {
@@ -72,8 +72,8 @@ BERT_HF_EMBED_MAP = {
     'bert.embeddings.word_embeddings.weight': 'embeddings.embeddings.0.embeddings.weight',
     'bert.embeddings.position_embeddings.weight': 'embeddings.embeddings.0.pos_embeddings.weight',
     'bert.embeddings.token_type_embeddings.weight': 'embeddings.embeddings.1.embeddings.weight',
-    'bert.embeddings.LayerNorm.bias': 'embeddings.reduction.ln.bias',
-    'bert.embeddings.LayerNorm.weight': 'embeddings.reduction.ln.weight',
+    'bert.embeddings.LayerNorm.beta': 'embeddings.reduction.ln.bias',
+    'bert.embeddings.LayerNorm.gamma': 'embeddings.reduction.ln.weight',
 }
 
 

--- a/mead/config/embeddings.json
+++ b/mead/config/embeddings.json
@@ -14,6 +14,20 @@
     "dsz": 768
   },
   {
+    "label": "mbert-base-uncased-npz",
+    "file": "https://www.dropbox.com/s/ghs0ltoj64cj560/bert-base-multilingual-uncased.npz?dl=1",
+    "sha1": "a791b8e947653f84e1b573cc523cecc9377193db",
+    "unzip": false,
+    "dsz": 768
+  },
+  {
+    "label": "mbert-base-cased-npz",
+    "file": "https://www.dropbox.com/s/tj68ulg6473myau/bert-base-multilingual-cased.npz?dl=1",
+    "sha1": "c0e1b5510cad771e080b2b34eb6ec111da141005",
+    "unzip": false,
+    "dsz": 768
+  },
+  {
     "label": "sentence-bert-mean-npz",
     "file": "https://www.dropbox.com/s/z5iczzz1r5n0nxk/bert-base-nli-mean-tokens.npz?dl=1",
     "unzip": false,

--- a/mead/config/vecs.json
+++ b/mead/config/vecs.json
@@ -13,33 +13,16 @@
     "emit_begin_tok": []
   },
   {
-    "label": "bert-base-cased-no-cls",
-    "type": "wordpiece1d",
-    "vocab_file": "https://s3.amazonaws.com/models.huggingface.co/bert/bert-base-cased-vocab.txt",
-    "emit_begin_tok": []
-  },
-  {
     "label": "bert-base-uncased-dict1d",
     "type": "wordpiece-dict1d",
     "vocab_file": "https://s3.amazonaws.com/models.huggingface.co/bert/bert-base-uncased-vocab.txt",
     "transform": "baseline.lowercase"
   },
   {
-    "label": "bert-base-cased-dict1d",
-    "type": "wordpiece-dict1d",
-    "vocab_file": "https://s3.amazonaws.com/models.huggingface.co/bert/bert-base-cased-vocab.txt"
-  },
-  {
     "label": "bert-base-uncased-no-cls-dict1d",
     "type": "wordpiece-dict1d",
     "vocab_file": "https://s3.amazonaws.com/models.huggingface.co/bert/bert-base-uncased-vocab.txt",
     "transform": "baseline.lowercase",
-    "emit_begin_tok": []
-  },
-  {
-    "label": "bert-base-cased-no-cls-dict1d",
-    "type": "wordpiece-dict1d",
-    "vocab_file": "https://s3.amazonaws.com/models.huggingface.co/bert/bert-base-cased-vocab.txt",
     "emit_begin_tok": []
   },
   {
@@ -50,6 +33,31 @@
     "emit_begin_tok": [],
     "emit_end_tok": []
   },
+
+  {
+    "label": "bert-base-cased",
+    "type": "wordpiece1d",
+    "vocab_file": "https://s3.amazonaws.com/models.huggingface.co/bert/bert-base-cased-vocab.txt"
+  },
+  {
+    "label": "bert-base-cased-no-cls",
+    "type": "wordpiece1d",
+    "vocab_file": "https://s3.amazonaws.com/models.huggingface.co/bert/bert-base-cased-vocab.txt",
+    "emit_begin_tok": []
+  },
+
+  {
+    "label": "bert-base-cased-dict1d",
+    "type": "wordpiece-dict1d",
+    "vocab_file": "https://s3.amazonaws.com/models.huggingface.co/bert/bert-base-cased-vocab.txt"
+  },
+
+  {
+    "label": "bert-base-cased-no-cls-dict1d",
+    "type": "wordpiece-dict1d",
+    "vocab_file": "https://s3.amazonaws.com/models.huggingface.co/bert/bert-base-cased-vocab.txt",
+    "emit_begin_tok": []
+  },
   {
     "label": "bert-base-cased-no-extra-dict1d",
     "type": "wordpiece-dict1d",
@@ -57,16 +65,81 @@
     "emit_begin_tok": [],
     "emit_end_tok": []
   },
+
+  {
+    "label": "mbert-base-uncased",
+    "type": "wordpiece1d",
+    "vocab_file": "https://s3.amazonaws.com/models.huggingface.co/bert/bert-base-multilingual-uncased-vocab.txt",
+    "transform": "baseline.lowercase"
+  },
+  {
+    "label": "mbert-base-uncased-no-cls",
+    "type": "wordpiece1d",
+    "vocab_file": "https://s3.amazonaws.com/models.huggingface.co/bert/bert-base-multilingual-uncased-vocab.txt",
+    "transform": "baseline.lowercase",
+    "emit_begin_tok": []
+  },
+  {
+    "label": "mbert-base-uncased-dict1d",
+    "type": "wordpiece-dict1d",
+    "vocab_file": "https://s3.amazonaws.com/models.huggingface.co/bert/bert-base-multilingual-uncased-vocab.txt",
+    "transform": "baseline.lowercase"
+  },
+  {
+    "label": "mbert-base-uncased-no-cls-dict1d",
+    "type": "wordpiece-dict1d",
+    "vocab_file": "https://s3.amazonaws.com/models.huggingface.co/bert/bert-base-multilingual-uncased-vocab.txt",
+    "transform": "baseline.lowercase",
+    "emit_begin_tok": []
+  },
+  {
+    "label": "mbert-base-uncased-no-extra-dict1d",
+    "type": "wordpiece-dict1d",
+    "vocab_file": "https://s3.amazonaws.com/models.huggingface.co/bert/bert-base-multilingual-uncased-vocab.txt",
+    "transform": "baseline.lowercase",
+    "emit_begin_tok": [],
+    "emit_end_tok": []
+  },
+
+  {
+    "label": "mbert-base-cased",
+    "type": "wordpiece1d",
+    "vocab_file": "https://s3.amazonaws.com/models.huggingface.co/bert/bert-base-multilingual-cased-vocab.txt"
+  },
+  {
+    "label": "mbert-base-cased-no-cls",
+    "type": "wordpiece1d",
+    "vocab_file": "https://s3.amazonaws.com/models.huggingface.co/bert/bert-base-multilingual-cased-vocab.txt",
+    "emit_begin_tok": []
+  },
+
+  {
+    "label": "mbert-base-cased-dict1d",
+    "type": "wordpiece-dict1d",
+    "vocab_file": "https://s3.amazonaws.com/models.huggingface.co/bert/bert-base-multilingual-cased-vocab.txt"
+  },
+
+  {
+    "label": "mbert-base-cased-no-cls-dict1d",
+    "type": "wordpiece-dict1d",
+    "vocab_file": "https://s3.amazonaws.com/models.huggingface.co/bert/bert-base-multilingual-cased-vocab.txt",
+    "emit_begin_tok": []
+  },
+  {
+    "label": "mbert-base-cased-no-extra-dict1d",
+    "type": "wordpiece-dict1d",
+    "vocab_file": "https://s3.amazonaws.com/models.huggingface.co/bert/bert-base-multilingual-cased-vocab.txt",
+    "emit_begin_tok": [],
+    "emit_end_tok": []
+  },
+
+
+
   {
     "label": "bert-large-uncased",
     "type": "wordpiece1d",
     "vocab_file": "https://s3.amazonaws.com/models.huggingface.co/bert/bert-large-uncased-vocab.txt",
     "transform": "baseline.lowercase"
-  },
-  {
-    "label": "bert-base-cased",
-    "type": "wordpiece1d",
-    "vocab_file": "https://s3.amazonaws.com/models.huggingface.co/bert/bert-base-cased-vocab.txt"
   },
   {
     "label": "bert-large-cased",


### PR DESCRIPTION
Adds support for multilingual BERT in embeddings and vectorizers
- The embeddings are converted from HF checkpoints as usual to MEAD TLM NPZ format
- The vectorizers are updated to point at vocabs from HF online
- The converter script was busted.  This needs to be investigated farther, as it appears that checkpoints may be different WRT LN
  - For now, I reverted this to work with BERT original format