### PR TITLE
Feature/roberta native

### DIFF
--- a/api-examples/convert_huggingface_checkpoints.py
+++ b/api-examples/convert_huggingface_checkpoints.py
@@ -138,18 +138,20 @@ args = parser.parse_args()
 
 if os.path.isdir(args.model):
     config_url = os.path.join(args.model, args.config_file_name)
-    bert_checkpoint = os.path.join(args.model, args.checkpoint)
-    checkpoint_disk_loc = bert_checkpoint
+    pt_checkpoint = os.path.join(args.model, args.checkpoint)
+    checkpoint_disk_loc = pt_checkpoint
+    if not args.target_dir:
+        args.target_dir = args.model
     output_file = os.path.basename(args.model)
 else:
     config_url = BERT_PRETRAINED_CONFIG_ARCHIVE_MAP[args.model]
-    bert_checkpoint = BERT_PRETRAINED_MODEL_ARCHIVE_MAP[args.model]
-    checkpoint_basename = os.path.basename(bert_checkpoint)
+    pt_checkpoint = BERT_PRETRAINED_MODEL_ARCHIVE_MAP[args.model]
+    checkpoint_basename = os.path.basename(pt_checkpoint)
     checkpoint_disk_loc = os.path.join(args.target_dir, checkpoint_basename)
     output_file = args.model
 
 model, num_layers = create_transformer_lm(config_url)
-mapped_keys = convert_checkpoint(bert_checkpoint, num_layers, args.target_dir, checkpoint_disk_loc,
+mapped_keys = convert_checkpoint(pt_checkpoint, num_layers, args.target_dir, checkpoint_disk_loc,
                                  nested_layer_map=MODEL_MAPS[args.model_type]['layers'],
                                  flat_map=MODEL_MAPS[args.model_type]['embed'])
 unknown_keys = model.load_state_dict(mapped_keys, strict=False)

--- a/baseline/pytorch/embeddings.py
+++ b/baseline/pytorch/embeddings.py
@@ -106,7 +106,7 @@ class TransformerLMEmbeddings(PyTorchEmbeddings):
         # If the embedding wasnt trained with token types, this allows us to add them later
         self.skippable = set(listify(kwargs.get('skip_restore_embeddings', [])))
 
-        self.cls_index = self.vocab['[CLS]']
+        self.cls_index = self.vocab.get('[CLS]', self.vocab.get('<s>'))
         self.vsz = max(self.vocab.values()) + 1
         self.d_model = int(kwargs.get('dsz', kwargs.get('d_model', 768)))
         self.init_embed(**kwargs)

--- a/baseline/pytorch/embeddings.py
+++ b/baseline/pytorch/embeddings.py
@@ -125,7 +125,7 @@ class TransformerLMEmbeddings(PyTorchEmbeddings):
         # `learned-positional` with a token type feature
         # or `learned-positional-w-bias` if you dont care about the token type
         embed_type = kwargs.get('word_embed_type', 'learned-positional')
-        x_embedding = create_embeddings(vsz=self.vsz, dsz=self.d_model, embed_type=embed_type)
+        x_embedding = create_embeddings(vsz=self.vsz, dsz=self.d_model, embed_type=embed_type, mxlen=kwargs.get('mxlen', 512))
 
         embeddings = {'x': x_embedding}
         # This is for BERT support when we are using 2 features
@@ -149,7 +149,7 @@ class TransformerLMEmbeddings(PyTorchEmbeddings):
         d_k = kwargs.get('d_k')
         rpr_k = kwargs.get('rpr_k')
         layer_norms_after = kwargs.get('layer_norms_after', False)
-        layer_norm_eps = kwargs.get('layer_norm_eps', 1e-12)
+        layer_norm_eps = float(kwargs.get('layer_norm_eps', 1e-12))
         activation = kwargs.get('activation', 'gelu')
         windowed_ra = kwargs.get('windowed_ra', False)
         rpr_value_on = kwargs.get('rpr_value_on', True)

--- a/baseline/pytorch/embeddings.py
+++ b/baseline/pytorch/embeddings.py
@@ -125,7 +125,8 @@ class TransformerLMEmbeddings(PyTorchEmbeddings):
         # `learned-positional` with a token type feature
         # or `learned-positional-w-bias` if you dont care about the token type
         embed_type = kwargs.get('word_embed_type', 'learned-positional')
-        x_embedding = create_embeddings(vsz=self.vsz, dsz=self.d_model, embed_type=embed_type, mxlen=kwargs.get('mxlen', 512))
+        x_embedding = create_embeddings(vsz=self.vsz, dsz=self.d_model, embed_type=embed_type, offset=kwargs.get("offset", 0),
+                                        mxlen=kwargs.get('mxlen', 512))
 
         embeddings = {'x': x_embedding}
         # This is for BERT support when we are using 2 features

--- a/baseline/reader.py
+++ b/baseline/reader.py
@@ -1048,7 +1048,7 @@ class IndexPairLabelReader(SeqLabelReader):
                 logger.warning(f"total length {total_length} exceeds allocated vectorizer width of {vectorizer.mxlen}")
                 vec = vec[:vectorizer.mxlen]
             elif extend > 0:
-                vec = np.concatenate([vec, np.zeros(extend, vec.dtype)])
+                vec = np.concatenate([vec, np.full(extend, Offsets.PAD, vec.dtype)])
 
             example_dict[key] = vec
             if self.use_token_type:

--- a/baseline/tf/embeddings.py
+++ b/baseline/tf/embeddings.py
@@ -190,7 +190,7 @@ class TransformerLMEmbeddings(TensorFlowEmbeddings):
         # If the embedding wasnt trained with token types, this allows us to add them later
         self.skippable = set(listify(kwargs.get('skip_restore_embeddings', [])))
 
-        self.cls_index = self.vocab['[CLS]']
+        self.cls_index = self.vocab.get('[CLS]', self.vocab.get('<s>'))
         self.vsz = max(self.vocab.values()) + 1
         self.d_model = int(kwargs.get('dsz', kwargs.get('d_model', 768)))
         self.init_embed(**kwargs)

--- a/baseline/vectorizers.py
+++ b/baseline/vectorizers.py
@@ -11,6 +11,12 @@ from eight_mile.downloads import open_file_or_url, get_file_or_url
 from eight_mile.utils import exporter, optional_params, listify, register, Offsets, is_sequence
 from baseline.utils import import_user_module
 
+try:
+    import regex
+except:
+    # If this doesnt work, no GPT2
+    pass
+
 __all__ = []
 export = exporter(__all__)
 
@@ -1478,7 +1484,7 @@ class Encoder:
         self.cache = {}
 
         # Should haved added re.IGNORECASE so BPE merges can happen for capitalized versions of contractions
-        self.pat = re.compile(r"""'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+""")
+        self.pat = regex.compile(r"""'s|'t|'re|'ve|'m|'ll|'d| ?\p{L}+| ?\p{N}+| ?[^\s\p{L}\p{N}]+|\s+(?!\S)|\s+""")
 
     def bpe(self, token):
         if token in self.cache:
@@ -1523,14 +1529,14 @@ class Encoder:
 
     def encode(self, text):
         bpe_tokens = []
-        for token in re.findall(self.pat, text):
+        for token in regex.findall(self.pat, text):
             token = ''.join(self.byte_encoder[b] for b in token.encode('utf-8'))
             bpe_tokens.extend(self.encoder[bpe_token] for bpe_token in self.bpe(token).split(' '))
         return bpe_tokens
 
     def encode_subword(self, text):
         bpe_tokens = []
-        for token in re.findall(self.pat, text):
+        for token in regex.findall(self.pat, text):
             token = ''.join(self.byte_encoder[b] for b in token.encode('utf-8'))
             bpe_tokens.extend(bpe_token for bpe_token in self.bpe(token).split(' '))
         return bpe_tokens

--- a/baseline/vectorizers.py
+++ b/baseline/vectorizers.py
@@ -650,7 +650,7 @@ class BPEVectorizer1D(AbstractVectorizer, HasSubwordTokens):
         self.model_file = kwargs.get('model_file')
         self.vocab_file = kwargs.get('vocab_file')
         use_fast_bpe = kwargs.get('use_fast_bpe', True)
-        self._special_tokens = {"[CLS]", "<unk>", "<EOS>"}
+        self._special_tokens = {"[CLS]", "<unk>", "<EOS>", "<UNK>", "<s>", "</s>"}
 
         extra_tokens = []
         if use_fast_bpe:

--- a/baseline/vectorizers.py
+++ b/baseline/vectorizers.py
@@ -678,14 +678,8 @@ class BPEVectorizer1D(AbstractVectorizer, HasSubwordTokens):
 
         self.mxlen = kwargs.get('mxlen', -1)
         vocab_list = self.read_vocab(self.vocab_file)
-        self._vocab = {}
-        for i in range(len(vocab_list)):
-            if vocab_list[i] in self._vocab:
-                print(f'ERROR {vocab_list[i]} already in the list')
-            self._vocab[vocab_list[i]] = i
-        #self._vocab = {k: i for i, k in enumerate(vocab_list)}
-        #self._vocab = {k: i for i, k in enumerate(vocab_list + extra_tokens)}
-        print(len(self._vocab), len(vocab_list))
+        self._vocab = {k: i for i, k in enumerate(vocab_list + extra_tokens)}
+
     @property
     def vocab(self):
         return self._vocab

--- a/layers/eight_mile/pytorch/embeddings.py
+++ b/layers/eight_mile/pytorch/embeddings.py
@@ -243,11 +243,12 @@ class LearnedPositionalMixin(PositionalMixin):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.mxlen = int(kwargs.get("mxlen", 512))
+        self.offset = int(kwargs.get("offset", 0))
         self.pos_embeddings = nn.Embedding(self.mxlen, self.get_dsz())
 
     def positional(self, length):
         return self.pos_embeddings(
-            torch.arange(length, dtype=torch.long, device=self.pos_embeddings.weight.device)
+            torch.arange(self.offset, self.offset + length, dtype=torch.long, device=self.pos_embeddings.weight.device)
         ).unsqueeze(0)
 
 

--- a/layers/eight_mile/pytorch/serialize.py
+++ b/layers/eight_mile/pytorch/serialize.py
@@ -374,7 +374,8 @@ def from_embed_array(pytorch_embed: nn.Module, d: Dict, name: str):
     device = pytorch_embed.embeddings.weight.device
     pytorch_embed.embeddings.weight = torch.nn.Parameter(torch.from_numpy(d[f"{name}/weights"]).to(device=device), requires_grad=True)
     if hasattr(pytorch_embed, 'pos_embeddings'):
-        pytorch_embed.pos_embeddings.weight = torch.nn.Parameter(torch.from_numpy(d[f"{name}/pos_weights"]).to(device=device),
+        pos_weights = torch.from_numpy(d[f"{name}/pos_weights"])
+        pytorch_embed.pos_embeddings.weight = torch.nn.Parameter(pos_weights.to(device=device),
                                                                  requires_grad=True)
 
 

--- a/layers/eight_mile/pytorch/serialize.py
+++ b/layers/eight_mile/pytorch/serialize.py
@@ -76,6 +76,67 @@ BERT_HF_EMBED_MAP = {
     'bert.embeddings.LayerNorm.gamma': 'embeddings.reduction.ln.weight',
 }
 
+ROBERTA_HF_LAYER_MAP = {
+    ## FFN weights
+    'roberta.encoder.layer.{}.intermediate.dense.weight': 'generator.encoders.{}.ffn.0.layer.weight',
+    'roberta.encoder.layer.{}.intermediate.dense.bias': 'generator.encoders.{}.ffn.0.layer.bias',
+    'roberta.encoder.layer.{}.output.dense.weight': 'generator.encoders.{}.ffn.3.layer.weight',
+    'roberta.encoder.layer.{}.output.dense.bias': 'generator.encoders.{}.ffn.3.layer.bias',
+
+    ## MHA weights
+    'roberta.encoder.layer.{}.attention.self.key.weight': 'generator.encoders.{}.self_attn.w_K.layer.weight',
+    'roberta.encoder.layer.{}.attention.self.key.bias': 'generator.encoders.{}.self_attn.w_K.layer.bias',
+    'roberta.encoder.layer.{}.attention.self.query.weight': 'generator.encoders.{}.self_attn.w_Q.layer.weight',
+    'roberta.encoder.layer.{}.attention.self.query.bias': 'generator.encoders.{}.self_attn.w_Q.layer.bias',
+    'roberta.encoder.layer.{}.attention.self.value.weight': 'generator.encoders.{}.self_attn.w_V.layer.weight',
+    'roberta.encoder.layer.{}.attention.self.value.bias': 'generator.encoders.{}.self_attn.w_V.layer.bias',
+    'roberta.encoder.layer.{}.attention.output.dense.weight': 'generator.encoders.{}.self_attn.w_O.layer.weight',
+    'roberta.encoder.layer.{}.attention.output.dense.bias': 'generator.encoders.{}.self_attn.w_O.layer.bias',
+
+    ## LN weights
+    # The names in of layer norm our transformers are a bit unspecific
+    # think of ln1 as ln_x and ln2 as ln_attn_output
+    'roberta.encoder.layer.{}.output.LayerNorm.bias': 'generator.encoders.{}.ln1.bias',
+    'roberta.encoder.layer.{}.output.LayerNorm.weight': 'generator.encoders.{}.ln1.weight',
+    'roberta.encoder.layer.{}.attention.output.LayerNorm.bias': 'generator.encoders.{}.ln2.bias',
+    'roberta.encoder.layer.{}.attention.output.LayerNorm.weight': 'generator.encoders.{}.ln2.weight'
+}
+
+ROBERTA_HF_FT_LAYER_MAP = {
+    ## FFN weights
+    'roberta.encoder.layer.{}.intermediate.dense.weight': 'transformer.encoders.{}.ffn.0.layer.weight',
+    'roberta.encoder.layer.{}.intermediate.dense.bias': 'transformer.encoders.{}.ffn.0.layer.bias',
+    'roberta.encoder.layer.{}.output.dense.weight': 'transformer.encoders.{}.ffn.3.layer.weight',
+    'roberta.encoder.layer.{}.output.dense.bias': 'transformer.encoders.{}.ffn.3.layer.bias',
+
+    ## MHA weights
+    'roberta.encoder.layer.{}.attention.self.key.weight': 'transformer.encoders.{}.self_attn.w_K.layer.weight',
+    'roberta.encoder.layer.{}.attention.self.key.bias': 'transformer.encoders.{}.self_attn.w_K.layer.bias',
+    'roberta.encoder.layer.{}.attention.self.query.weight': 'transformer.encoders.{}.self_attn.w_Q.layer.weight',
+    'roberta.encoder.layer.{}.attention.self.query.bias': 'transformer.encoders.{}.self_attn.w_Q.layer.bias',
+    'roberta.encoder.layer.{}.attention.self.value.weight': 'transformer.encoders.{}.self_attn.w_V.layer.weight',
+    'roberta.encoder.layer.{}.attention.self.value.bias': 'transformer.encoders.{}.self_attn.w_V.layer.bias',
+    'roberta.encoder.layer.{}.attention.output.dense.weight': 'transformer.encoders.{}.self_attn.w_O.layer.weight',
+    'roberta.encoder.layer.{}.attention.output.dense.bias': 'transformer.encoders.{}.self_attn.w_O.layer.bias',
+
+    ## LN weights
+    # The names in of layer norm our transformers are a bit unspecific
+    # think of ln1 as ln_x and ln2 as ln_attn_output
+    'roberta.encoder.layer.{}.output.LayerNorm.bias': 'transformer.encoders.{}.ln1.bias',
+    'roberta.encoder.layer.{}.output.LayerNorm.weight': 'transformer.encoders.{}.ln1.weight',
+    'roberta.encoder.layer.{}.attention.output.LayerNorm.beta': 'transformer.encoders.{}.ln2.bias',
+    'roberta.encoder.layer.{}.attention.output.LayerNorm.weight': 'transformer.encoders.{}.ln2.weight'
+}
+
+ROBERTA_HF_EMBED_MAP = {
+    ## Embedding weights
+    'roberta.embeddings.word_embeddings.weight': 'embeddings.embeddings.0.embeddings.weight',
+    'roberta.embeddings.position_embeddings.weight': 'embeddings.embeddings.0.pos_embeddings.weight',
+    'roberta.embeddings.token_type_embeddings.weight': 'embeddings.embeddings.1.embeddings.weight',
+    'roberta.embeddings.LayerNorm.bias': 'embeddings.reduction.ln.bias',
+    'roberta.embeddings.LayerNorm.weight': 'embeddings.reduction.ln.weight',
+}
+
 
 def convert_transformers_keys(num_layers: int, d: Dict, nested_layer_map: Dict = BERT_HF_LAYER_MAP, flat_map: Dict = BERT_HF_EMBED_MAP) -> Dict:
     m = {}

--- a/layers/eight_mile/tf/embeddings.py
+++ b/layers/eight_mile/tf/embeddings.py
@@ -3,7 +3,7 @@ import copy
 import logging
 import numpy as np
 import tensorflow as tf
-from eight_mile.utils import write_json, Offsets, is_sequence, calc_nfeats
+from eight_mile.utils import write_json, Offsets, is_sequence, calc_nfeats, pads
 from eight_mile.tf.layers import *
 
 
@@ -335,7 +335,7 @@ class SinusoidalPositionalMixin(PositionalMixin):
         log_timescale_increment = math.log(max_timescale) / float(word_dsz)
         inv_timescales = np.exp(np.arange(0, word_dsz, 2, dtype=np.float32) * -log_timescale_increment)
 
-        pe = np.zeros((mxlen, word_dsz), dtype=np.float32)
+        pe = pads((mxlen, word_dsz), dtype=np.float32)
         position = np.expand_dims(np.arange(0, mxlen, dtype=np.float32), 1)
 
         pe[:, 0::2] = np.sin(position * inv_timescales)

--- a/layers/eight_mile/utils.py
+++ b/layers/eight_mile/utils.py
@@ -87,12 +87,46 @@ def register(cls, registry, name=None, error=""):
     return cls
 
 
+class classproperty(property):
+    def __get__(self, cls, owner):
+        return classmethod(self.fget).__get__(None, owner)()
+
+
 @export
 class Offsets:
-    """Support pre 3.4"""
+    INDICES = {
+        "PAD": 0,
+        "GO": 1,
+        "EOS": 2,
+        "UNK": 3,
+        "OFFSET": 4
+    }
+    VALUES = [
+        "<PAD>", "<GO>", "<EOS>", "<UNK>"
+    ]
 
-    PAD, GO, EOS, UNK, OFFSET = range(0, 5)
-    VALUES = ["<PAD>", "<GO>", "<EOS>", "<UNK>"]
+    @classproperty
+    def PAD(cls):
+        return cls.INDICES["PAD"]
+
+    @classproperty
+    def GO(cls):
+        return cls.INDICES["GO"]
+
+    @classproperty
+    def EOS(cls):
+        return cls.INDICES["EOS"]
+
+    @classproperty
+    def UNK(cls):
+        return cls.INDICES["UNK"]
+
+    @classproperty
+    def OFFSET(cls):
+        return cls.INDICES["OFFSET"]
+
+
+
 
 
 @export

--- a/layers/eight_mile/utils.py
+++ b/layers/eight_mile/utils.py
@@ -465,6 +465,9 @@ def validate_url(url: str) -> bool:
     )
     return re.match(regex, url) is not None
 
+@export
+def pads(shape, dtype):
+    return np.full(shape, Offsets.PAD, dtype)
 
 
 @export

--- a/mead/config/embeddings.json
+++ b/mead/config/embeddings.json
@@ -35,6 +35,12 @@
     "dsz": 768
   },
   {
+    "label": "xlmr-base-npz",
+    "file": "https://www.dropbox.com/s/2bjznv25xpt11vl/xlm-roberta-base.npz?dl=1",
+    "unzip": false,
+    "dsz": 768
+  },
+  {
     "label": "sentence-bert-mean-npz",
     "file": "https://www.dropbox.com/s/z5iczzz1r5n0nxk/bert-base-nli-mean-tokens.npz?dl=1",
     "unzip": false,

--- a/mead/config/embeddings.json
+++ b/mead/config/embeddings.json
@@ -28,6 +28,13 @@
     "dsz": 768
   },
   {
+    "label": "roberta-base-npz",
+    "file": "https://www.dropbox.com/s/7oyhphna2dtoq2k/roberta-base.npz?dl=1",
+    "sha1": "ea4bfe5c504cc5e21f63f5f6fd90474b78155fa4",
+    "unzip": false,
+    "dsz": 768
+  },
+  {
     "label": "sentence-bert-mean-npz",
     "file": "https://www.dropbox.com/s/z5iczzz1r5n0nxk/bert-base-nli-mean-tokens.npz?dl=1",
     "unzip": false,
@@ -102,11 +109,5 @@
     "file": "https://www.dropbox.com/s/s8q2feew1fmwl3p/senna-50.txt.gz?dl=1",
     "sha1": "5258af089f40f9071bbb8f4f5ac2b2f35b18fea2",
     "dsz": 50
-  },
-  { 
-    "label": "wnut-gaz",
-    "file": "https://www.dropbox.com/s/3p76mbx50uk22m7/wnut-gaz.txt?dl=1",
-    "sha1": "83f6ebdd1c8351ff37e0b8bf00d27faca6f5e685",
-    "dsz": "7"
   }
 ]

--- a/mead/config/trec-roberta-base.json
+++ b/mead/config/trec-roberta-base.json
@@ -1,0 +1,49 @@
+{
+  "task": "classify",
+  "basedir": "./trec-roberta-base",
+  "backend": "pytorch",
+  "dataset": "trec",
+  "batchsz": 10,
+  "features": [
+    {
+      "name": "roberta",
+      "vectorizer": {
+        "label": "roberta-base"
+      },
+      "embeddings": {
+        "finetune": true,
+        "word_embed_type": "learned-positional-w-bias",
+        "offset": 2,
+        "mxlen": 514,
+        "label": "roberta-base-npz",
+        "type": "tlm-words-embed-pooled",
+        "reduction": "sum-layer-norm",
+        "layer_norms_after": true,
+        "layer_norm_eps": 1e-5,
+        "dropout": 0.1,
+        "mlm": true
+      }
+    }
+  ],
+  "preproc": {
+    "mxlen": 100
+  },
+  "loader": {
+    "reader_type": "default"
+  },
+  "unif": 0.25,
+  "model": {
+    "model_type": "fine-tune"
+  },
+  "train": {
+    "epochs": 5,
+    "optim": "adamw",
+    "eta":  0.00001,
+    "weight_decay": 1.0e-8,
+    "early_stopping_metric": "acc",
+    "verbose": {
+      "console": true,
+      "file": "trec-cm.csv"
+    }
+  }
+}

--- a/mead/config/vecs.json
+++ b/mead/config/vecs.json
@@ -148,7 +148,7 @@
   },
   {
     "label": "roberta-base",
-    "type": "gpt2_bpe1d",
+    "type": "gpt2-bpe1d",
     "emit_begin_tok": "<s>",
     "emit_end_tok": "</s>",
     "model_file": "https://www.dropbox.com/s/2p86azt5cigrdhw/merges.txt?dl=1",

--- a/mead/config/vecs.json
+++ b/mead/config/vecs.json
@@ -153,6 +153,18 @@
     "emit_end_tok": "</s>",
     "model_file": "https://www.dropbox.com/s/2p86azt5cigrdhw/merges.txt?dl=1",
     "vocab_file": "https://www.dropbox.com/s/ck7dyhjawlmv2kp/vocab.json?dl=1"
+  },
+  {
+    "label": "xlmr-base",
+    "type": "xlmr-spm1d",
+    "emit_begin_tok": "<s>",
+    "emit_end_tok": "</s>",
+    "model_file": "https://www.dropbox.com/s/dzdhgamoh4nqvbz/xlm-roberta-base-sentencepiece.bpe.model?dl=1"
+  },
+  {
+    "label": "xlmr-base-nostart",
+    "type": "xlmr-spm1d",
+    "emit_end_tok": "</s>",
+    "model_file": "https://www.dropbox.com/s/dzdhgamoh4nqvbz/xlm-roberta-base-sentencepiece.bpe.model?dl=1"
   }
-
 ]

--- a/mead/config/vecs.json
+++ b/mead/config/vecs.json
@@ -145,5 +145,14 @@
     "label": "bert-large-cased",
     "type": "wordpiece1d",
     "vocab_file": "https://s3.amazonaws.com/models.huggingface.co/bert/bert-large-cased-vocab.txt"
+  },
+  {
+    "label": "roberta-base",
+    "type": "gpt2_bpe1d",
+    "emit_begin_tok": "<s>",
+    "emit_end_tok": "</s>",
+    "model_file": "https://www.dropbox.com/s/2p86azt5cigrdhw/merges.txt?dl=1",
+    "vocab_file": "https://www.dropbox.com/s/ck7dyhjawlmv2kp/vocab.json?dl=1"
   }
+
 ]

--- a/setup.py
+++ b/setup.py
@@ -86,6 +86,7 @@ def main():
             'report': ['tensorboard'],
             'yaml': ['pyyaml'],
             'bpe': ['fastBPE'],
+            'regex': ['regex'],
             'bpex': ['fastBPE', 'subword-nmt'],
             'tf2': ['tensorflow_addons'],
             'grpc': ['grpc'],


### PR DESCRIPTION
Adds support for RoBERTa flavor of models (RoBERTa, XLM-R, etc.) executed through the normal 8mi layers
- RoBERTa uses the GPT2 tokenizer so add support for this in `vectorizers.py`
- The Offsets are mucked up so that pad isnt 0.  This can be fixed by hacking the variables, but
instead, try and make the class more friendly for overrides
- The positional embeddings are odd because of pad being 1, so they are 514 and the values
applied should start at 2
- The checkpoints were converted to TLM NPZ format, posted to dropbox and referenced in `embeddings.json`
- All of the raw literals are replaced with `Offsets.*`
- The GPT2 model vocabs are up on dropbox and referenced in `vecs.json`
- A sample config is added `mead/config/trec-roberta-base.json`