### PR TITLE
Fix NPZ serialize for layer norm 3 in tfm decoder

### DIFF
--- a/api-examples/seq2seq_generate_response.py
+++ b/api-examples/seq2seq_generate_response.py
@@ -40,6 +40,7 @@ def decode_sentence(model, vectorizer, query, word2index, index2word, device, ma
                 output = torch.argmax(predictions, -1).squeeze(0)
                 output = output[token_offset].item()
             else:
+
                 # using a multinomial distribution to predict the word returned by the model
                 predictions = predictions.exp().squeeze(0)
                 output = torch.multinomial(predictions, num_samples=1).squeeze(0)[token_offset].item()

--- a/layers/eight_mile/pytorch/serialize.py
+++ b/layers/eight_mile/pytorch/serialize.py
@@ -322,7 +322,7 @@ def from_decoder_array(pytorch_decoder: TransformerDecoder, d: Dict, name: str):
     """
     from_weight_array(pytorch_decoder.ln1, d, f"{name}/ln1")
     from_weight_array(pytorch_decoder.ln2, d, f"{name}/ln2")
-    from_weight_array(pytorch_decoder.ln2, d, f"{name}/ln3")
+    from_weight_array(pytorch_decoder.ln3, d, f"{name}/ln3")
     from_attn_array(pytorch_decoder.src_attn, d, f"{name}/src_attn")
     from_attn_array(pytorch_decoder.self_attn, d, f"{name}/self_attn")
     from_ffn_array(pytorch_decoder.ffn, d, f"{name}/ffn")
@@ -338,7 +338,7 @@ def to_decoder_array(pytorch_decoder: TransformerDecoder, name: str) -> Dict:
     d = {}
     d.update(to_weight_array(pytorch_decoder.ln1, f"{name}/ln1"))
     d.update(to_weight_array(pytorch_decoder.ln2, f"{name}/ln2"))
-    d.update(to_weight_array(pytorch_decoder.ln2, f"{name}/ln3"))
+    d.update(to_weight_array(pytorch_decoder.ln3, f"{name}/ln3"))
     d.update(to_attn_array(pytorch_decoder.self_attn, f"{name}/self_attn"))
     d.update(to_attn_array(pytorch_decoder.src_attn, f"{name}/src_attn"))
     d.update(to_ffn_array(pytorch_decoder.ffn, f"{name}/ffn"))

--- a/layers/eight_mile/tf/serialize.py
+++ b/layers/eight_mile/tf/serialize.py
@@ -146,7 +146,7 @@ def to_decoder_array(tf_decoder: TransformerDecoder, name: str) -> Dict:
     d = {}
     d.update(to_weight_array(tf_decoder.ln1, f"{name}/ln1"))
     d.update(to_weight_array(tf_decoder.ln2, f"{name}/ln2"))
-    d.update(to_weight_array(tf_decoder.ln2, f"{name}/ln3"))
+    d.update(to_weight_array(tf_decoder.ln3, f"{name}/ln3"))
     d.update(to_attn_array(tf_decoder.self_attn, f"{name}/self_attn"))
     d.update(to_attn_array(tf_decoder.src_attn, f"{name}/src_attn"))
     d.update(to_ffn_array(tf_decoder.ffn, f"{name}/ffn"))
@@ -257,7 +257,7 @@ def from_decoder_array(tf_decoder: TransformerDecoder, d: Dict, name: str):
     """
     from_weight_array(tf_decoder.ln1, d, f"{name}/ln1")
     from_weight_array(tf_decoder.ln2, d, f"{name}/ln2")
-    from_weight_array(tf_decoder.ln2, d, f"{name}/ln3")
+    from_weight_array(tf_decoder.ln3, d, f"{name}/ln3")
     from_attn_array(tf_decoder.src_attn, d, f"{name}/src_attn")
     from_attn_array(tf_decoder.self_attn, d, f"{name}/self_attn")
     from_ffn_array(tf_decoder.ffn, d, f"{name}/ffn")


### PR DESCRIPTION
there was a typo on layer norm 3 which was in both PyTorch
and TF.  This caused the TF not to export properly, and neither
to init properly