### PR TITLE
WIP: Feature/save vec json

### DIFF
--- a/baseline/utils.py
+++ b/baseline/utils.py
@@ -269,7 +269,7 @@ def save_vectorizers_pickle(basedir, vectorizers, name='vectorizers'):
     write_json(vectorizer_modules, module_file)
 
 @export
-def save_vectorizers(basedir, vectorizers, fmt="json", name='vectorizers'):
+def save_vectorizers(basedir, vectorizers, fmt="pickle", name='vectorizers'):
     if fmt == "pickle":
         return save_vectorizers_pickle(basedir, vectorizers, name)
     vec_params = {}

--- a/baseline/utils.py
+++ b/baseline/utils.py
@@ -39,6 +39,33 @@ export(str2bool)
 
 
 @export
+def lowercase(x):
+    return x.lower()
+
+
+UNREP_EMOTICONS = (
+    ':)',
+    ':(((',
+    ':D',
+    '=)',
+    ':-)',
+    '=(',
+    '(=',
+    '=[[',
+)
+
+
+@export
+def web_cleanup(word):
+    if word.startswith('http'): return 'URL'
+    if word.startswith('@'): return '@@@@'
+    if word.startswith('#'): return '####'
+    if word == '"': return ','
+    if word in UNREP_EMOTICONS: return ';)'
+    if word == '<3': return '&lt;3'
+    return word
+
+@export
 def normalize_backend(name: str) -> str:
     allowed_backends = {'tf', 'pytorch'}
     name = name.lower()

--- a/baseline/vectorizers.py
+++ b/baseline/vectorizers.py
@@ -60,7 +60,7 @@ class Vectorizer:
         c = {}
         for k, v in self.__dict__.items():
 
-            if k == 'transform_fn' and v != None:
+            if k == 'transform_fn' and v is not None:
                 c['transform_fn'] = v.__name__
             elif hasattr(v, '__getstate__'):
                 c[k] = v.__getstate__()
@@ -74,7 +74,7 @@ class Vectorizer:
     def __setstate__(self, state):
         for k, v in state.items():
 
-            if k == 'transform_fn' and v != None:
+            if k == 'transform_fn' and v is not None:
                 if isinstance(v, str):
                     self.transform_fn = eval(v)
                 else:
@@ -1276,10 +1276,24 @@ class WordpieceVectorizer1D(AbstractVectorizer, HasSubwordTokens):
             self.tokenizer = WordpieceTokenizer(self.read_vocab(kwargs.get('vocab_file')))
         else:
             raise Exception("No vocab file and no previously serialized model provided for WordpieceTokenizer")
-        
+
         self.mxlen = kwargs.get('mxlen', -1)
         self.dtype = kwargs.get('dtype', 'int')
         self._special_tokens = {"[CLS]", "<unk>", "<EOS>"}
+
+    def __setstate__(self, state):
+        for k, v in state.items():
+            if k == 'tokenizer':
+                self.__dict__[k] = WordpieceTokenizer(v['vocab'],
+                                                      v.get('unk_token', "[UNK]"),
+                                                      v.get('max_input_chars_per_word', 200))
+            elif k == 'transform_fn' and v is not None:
+                if isinstance(v, str):
+                    self.transform_fn = eval(v)
+                else:
+                    self.transform_fn = v
+            else:
+                self.__dict__[k] = v
 
     def read_vocab(self, file):
         return load_bert_vocab(file)

--- a/baseline/vectorizers.py
+++ b/baseline/vectorizers.py
@@ -1265,7 +1265,18 @@ class WordpieceVectorizer1D(AbstractVectorizer, HasSubwordTokens):
     def __init__(self, **kwargs):
         super().__init__(kwargs.get('transform_fn'), kwargs.get('emit_begin_tok', ['[CLS]']), kwargs.get('emit_end_tok', ['[SEP]']))
         self.max_seen = 128
-        self.tokenizer = WordpieceTokenizer(self.read_vocab(kwargs.get('vocab_file')))
+
+        vocab_file = kwargs.get('vocab_file')
+        tokenizer = kwargs.get('tokenizer')
+        if tokenizer is not None:
+            self.tokenizer = WordpieceTokenizer(tokenizer['vocab'],
+                                                tokenizer.get('unk_token', "[UNK]"),
+                                                tokenizer.get('max_input_chars_per_word', 200))
+        elif vocab_file is not None:
+            self.tokenizer = WordpieceTokenizer(self.read_vocab(kwargs.get('vocab_file')))
+        else:
+            raise Exception("No vocab file and no previously serialized model provided for WordpieceTokenizer")
+        
         self.mxlen = kwargs.get('mxlen', -1)
         self.dtype = kwargs.get('dtype', 'int')
         self._special_tokens = {"[CLS]", "<unk>", "<EOS>"}

--- a/layers/eight_mile/utils.py
+++ b/layers/eight_mile/utils.py
@@ -71,13 +71,13 @@ export = exporter(__all__)
 
 
 @export
-def register(cls, registry, name=None, error=""):
+def register(cls, registry, name=None, warning=""):
     if name is None:
         name = cls.__name__
     if name in registry:
-        raise Exception(
-            "Error: attempt to re-define previously registered {} {} (old: {}, new: {})".format(
-                error, name, registry[name], cls
+        logger.warning(
+            "Warning: attempt to re-define previously registered {} {} (old: {}, new: {})".format(
+                warning, name, registry[name], cls
             )
         )
     if hasattr(cls, "create"):

--- a/mead/tasks.py
+++ b/mead/tasks.py
@@ -39,7 +39,7 @@ __all__ = []
 export = exporter(__all__)
 logger = logging.getLogger('mead')
 
-
+DEFAULT_VEC_FMT = "json"
 def merge_reporting_with_settings(reporting, settings):
     default_reporting = settings.get('reporting_hooks', {})
     # Add default reporting information to the reporting settings.
@@ -306,7 +306,7 @@ class Task:
         :return: Nothing
         """
         self._reorganize_params()
-        baseline.save_vectorizers(self.get_basedir(), self.vectorizers)
+        baseline.save_vectorizers(self.get_basedir(), self.vectorizers, self.config_params.get("vec_fmt", DEFAULT_VEC_FMT))
         self._load_dataset()
 
         model_params = self.config_params['model']
@@ -681,7 +681,7 @@ class TaggerTask(Task):
 
     def train(self, checkpoint=None):
         self._load_dataset()
-        baseline.save_vectorizers(self.get_basedir(), self.vectorizers)
+        baseline.save_vectorizers(self.get_basedir(), self.vectorizers, self.config_params.get("vec_fmt", DEFAULT_VEC_FMT))
         self._reorganize_params()
         conll_output = self.config_params.get("conll_output", None)
         model_params = self.config_params['model']
@@ -799,7 +799,7 @@ class DependencyParserTask(Task):
 
     def train(self, checkpoint=None):
         self._load_dataset()
-        baseline.save_vectorizers(self.get_basedir(), self.vectorizers)
+        baseline.save_vectorizers(self.get_basedir(), self.vectorizers, self.config_params.get("vec_fmt", DEFAULT_VEC_FMT))
         self._reorganize_params()
         conll_output = self.config_params.get("conll_output", None)
         model_params = self.config_params['model']
@@ -1046,7 +1046,7 @@ class LanguageModelingTask(Task):
         self._load_dataset()
         # Dont do this here!  We need to move train_data elsewhere
         calc_lr_params(self.config_params['train'], self.train_data.steps)
-        baseline.save_vectorizers(self.get_basedir(), self.vectorizers)
+        baseline.save_vectorizers(self.get_basedir(), self.vectorizers, self.config_params.get("vec_fmt", DEFAULT_VEC_FMT))
 
         model_params = self.config_params['model']
         model_params['task'] = self.task_name()


### PR DESCRIPTION
The current vectorizers write out pickle files which make them incompatible with other programming languages.
Most of the behavior of the vectorizers is straightforward to implement in any language, and `mead-export`
supports conversion to popular runtime or serving formats such as TF-serving and ONNX, which leaves the
vectorizers client side.  Due to the approach we have now, the vectorizers would have to be loaded in Python
and possibly converted to some external format.

The change here is to support a JSON-backend format for vectorizers that can be used to allow vectorization
in other programming languages with more minimal hassle.  Additionally the choice of serialization format can
be controlled via the `vec_fmt` property in the mead config (or at the command line with `--x:vec_fmt json|pickle`).

To facilitate these changes, the old save method was factored out into a pickle-specific method, and for these new
files, all of the serialization is done in the vectorizer JSON file.  Pickle supports serialization of objects to be specified
via `__getstate__` and rehydrated with `__setstate__`.   It seemed desirable to support this via the JSON serialization as
well.

We need to test a lot of combinations since any vectorizer could have unique complications using this methodology