### PR TITLE
add support for camembert

### DIFF
--- a/mead/config/embeddings.json
+++ b/mead/config/embeddings.json
@@ -41,6 +41,13 @@
     "dsz": 768
   },
   {
+    "label": "camembert-base-npz",
+    "file": "https://www.dropbox.com/s/q8lxnv209on4ozg/camembert-base.npz?dl=1",
+    "unzip": false,
+    "dsz": 768
+  },
+
+  {
     "label": "sentence-bert-mean-npz",
     "file": "https://www.dropbox.com/s/z5iczzz1r5n0nxk/bert-base-nli-mean-tokens.npz?dl=1",
     "unzip": false,

--- a/mead/config/vecs.json
+++ b/mead/config/vecs.json
@@ -155,6 +155,13 @@
     "vocab_file": "https://www.dropbox.com/s/ck7dyhjawlmv2kp/vocab.json?dl=1"
   },
   {
+    "label": "camembert-base",
+    "type": "camembert-spm1d",
+    "emit_begin_tok": "<s>",
+    "emit_end_tok": "</s>",
+    "model_file": "https://www.dropbox.com/s/op5pbfoub7ln7s7/camembert-base-sentencepiece.bpe.model?dl=1"
+  },
+  {
     "label": "xlmr-base",
     "type": "xlmr-spm1d",
     "emit_begin_tok": "<s>",


### PR DESCRIPTION
XLMR and Camembert are basically the same model, RoBERTa + SPM.  For XLMR the pad is on 1, and for Camembert its on 0.
This change factors out a base class for facebook style SPM stuff and subclasses appropriately to bridge the gap