### PR TITLE
safety check to make sure records are valid

### DIFF
--- a/mead/api_examples/preproc_paired.py
+++ b/mead/api_examples/preproc_paired.py
@@ -115,8 +115,9 @@ def run(input_files=[], input_pattern='*.txt', codes=None, vocab=None, nctx=256,
                 x_t[:len(x)] = x
                 y_t[:len(y)] = y
                 record = {'x': x_t, 'y': y_t, 'x_str': [indices2word[s] for s in x_t], 'y_str': [indices2word[s] for s in y_t]}
-                fw.write(record)
-                num_samples_this_worker += 1
+                if masking.is_valid(record):
+                    fw.write(record)
+                    num_samples_this_worker += 1
 
     fw.close()
     duration = timer.elapsed()

--- a/mead/api_examples/preproc_utils.py
+++ b/mead/api_examples/preproc_utils.py
@@ -38,6 +38,9 @@ class Masking:
     def __call__(self, chunk: np.ndarray, ignore_prefix: bool, ignore_suffix: bool):
         pass
 
+    def is_valid(self, record: dict) -> bool:
+        return True
+
 
 @register_masking("mlm")
 class MaskMLM(Masking):
@@ -50,8 +53,8 @@ class MaskMLM(Masking):
         self.pad_y = pad_y
 
     def __call__(self, chunk: np.ndarray, ignore_prefix: bool, ignore_suffix: bool):
-
         return mlm_masking(chunk, self.mask_value, self.vocab_size, ignore_prefix, ignore_suffix, pad_y=self.pad_y)
+
 
 def in_bytes(mb):
     return mb * 1024 * 1024


### PR DESCRIPTION
normally this isnt a problem, but if the
data gets truncated, it may be necessary to
throw the sample away in rare cases.

here we add an option to test if the final
record matches our expectation, and if not,
we will throw it out.

currently this behavior only affects the paired
preproc program although it might be also
desirable in other cases