### PR TITLE
support warmstarting DE from BERT checkpoint

### DIFF
--- a/baseline/vectorizers.py
+++ b/baseline/vectorizers.py
@@ -1119,7 +1119,7 @@ class WordpieceVectorizer1D(AbstractVectorizer, HasSubwordTokens):
         self.tokenizer = WordpieceTokenizer(self.read_vocab(kwargs.get('vocab_file')))
         self.mxlen = kwargs.get('mxlen', -1)
         self.dtype = kwargs.get('dtype', 'int')
-        self._special_tokens = {"[CLS]", "[UNK]", "[SEP]"}
+        self._special_tokens = {"[CLS]", "<unk>", "<EOS>"}
 
     def read_vocab(self, file):
         return load_bert_vocab(file)

--- a/baseline/vectorizers.py
+++ b/baseline/vectorizers.py
@@ -1119,7 +1119,7 @@ class WordpieceVectorizer1D(AbstractVectorizer, HasSubwordTokens):
         self.tokenizer = WordpieceTokenizer(self.read_vocab(kwargs.get('vocab_file')))
         self.mxlen = kwargs.get('mxlen', -1)
         self.dtype = kwargs.get('dtype', 'int')
-        self._special_tokens = {"[CLS]", "<unk>", "<EOS>"}
+        self._special_tokens = {"[CLS]", "[UNK]", "[SEP]"}
 
     def read_vocab(self, file):
         return load_bert_vocab(file)
@@ -1173,7 +1173,7 @@ class WordpieceVectorizer1D(AbstractVectorizer, HasSubwordTokens):
             if i == self.mxlen:
                 i -= len(self.emit_end_tok)
                 for j, x in enumerate(self.emit_end_tok):
-                    vec1d[i + j] = vocab.get(x)
+                    vec1d[i + j] = vocab.get(x, vocab['[UNK]'])
                 i = self.mxlen - 1
                 break
             vec1d[i] = atom

--- a/layers/eight_mile/pytorch/layers.py
+++ b/layers/eight_mile/pytorch/layers.py
@@ -4379,7 +4379,8 @@ class PairedModel(DualEncoderModel):
                  windowed_ra=False,
                  rpr_value_on=False,
                  reduction_type="2ha",
-                 freeze_encoders=False):
+                 freeze_encoders=False,
+                 layer_norms_after=False):
         super().__init__(2*d_model if reduction_type.startswith("2") else d_model, stacking_layers, d_out, ffn_pdrop)
 
         reduction_type = reduction_type.lower()
@@ -4408,7 +4409,8 @@ class PairedModel(DualEncoderModel):
         self.transformer = TransformerEncoderStack(num_heads=num_heads, d_model=d_model,
                                                    pdrop=dropout, layers=num_layers, activation='gelu', d_ff=d_ff,
                                                    ffn_pdrop=ffn_pdrop,
-                                                   d_k=d_k, rpr_k=rpr_k, windowed_ra=windowed_ra, rpr_value_on=rpr_value_on)
+                                                   d_k=d_k, rpr_k=rpr_k, windowed_ra=windowed_ra, rpr_value_on=rpr_value_on,
+                                                   layer_norms_after=layer_norms_after)
 
         self.embeddings = EmbeddingsStack({'x': embeddings})
         self.freeze = freeze_encoders
@@ -4469,7 +4471,8 @@ class TransformerBoWPairedModel(DualEncoderModel):
                  windowed_ra=False,
                  rpr_value_on=False,
                  reduction_type_1="2ha",
-                 freeze_encoders=False):
+                 freeze_encoders=False,
+                 layer_norms_after=False):
         super().__init__(d_model, stacking_layers, d_out, ffn_pdrop)
 
         reduction_type_1 = reduction_type_1.lower()
@@ -4495,7 +4498,8 @@ class TransformerBoWPairedModel(DualEncoderModel):
         self.transformer = TransformerEncoderStack(num_heads=num_heads, d_model=d_model,
                                                    pdrop=dropout, layers=num_layers, activation='gelu', d_ff=d_ff,
                                                    ffn_pdrop=ffn_pdrop,
-                                                   d_k=d_k, rpr_k=rpr_k, windowed_ra=windowed_ra, rpr_value_on=rpr_value_on)
+                                                   d_k=d_k, rpr_k=rpr_k, windowed_ra=windowed_ra, rpr_value_on=rpr_value_on,
+                                                   layer_norms_after=layer_norms_after)
 
         self.embeddings = EmbeddingsStack({'x': embeddings})
         self.freeze = freeze_encoders

--- a/layers/eight_mile/pytorch/serialize.py
+++ b/layers/eight_mile/pytorch/serialize.py
@@ -725,7 +725,8 @@ def from_tlm_array(pytorch_tlm: nn.Module, d: Dict, embeddings_keys: List[str] =
         if isinstance(pytorch_tlm.embeddings[embeddings_key], LearnedPositionalLookupTableEmbeddingsWithBias):
             tt = LookupTableEmbeddings(vsz=2, dsz=pytorch_tlm.embeddings.output_dim)
             from_embed_array(tt, d, f"{name}/Embeddings/tt")
-            pytorch_tlm.embeddings[embeddings_key].bias = nn.Parameter(tt.embeddings.weight[0])
+            device = pytorch_tlm.embeddings[embeddings_key].embeddings.weight.device
+            pytorch_tlm.embeddings[embeddings_key].bias = nn.Parameter(tt.embeddings.weight[0].to(device=device))
         else:
             from_embed_array(pytorch_tlm.embeddings[embeddings_key], d, f"{name}/Embeddings/{embeddings_key}")
     if hasattr(pytorch_tlm.embeddings.reduction, 'ln'):
@@ -816,7 +817,8 @@ def seq2seq_enc_from_tlm_array(pytorch_tlm: nn.Module, d: Dict, embeddings_keys:
         if isinstance(pytorch_tlm.src_embeddings[embeddings_key], LearnedPositionalLookupTableEmbeddingsWithBias):
             tt = LookupTableEmbeddings(vsz=2, dsz=pytorch_tlm.embeddings.output_dim)
             from_embed_array(tt, d, f"{name}/Embeddings/tt")
-            pytorch_tlm.src_embeddings[embeddings_key].bias = nn.Parameter(tt.embeddings.weight[0])
+            device = pytorch_tlm.embeddings[embeddings_key].embeddings.weight.device
+            pytorch_tlm.src_embeddings[embeddings_key].bias = nn.Parameter(tt.embeddings.weight[0].to(device=device))
         else:
             from_embed_array(pytorch_tlm.src_embeddings[embeddings_key], d, f"{name}/Embeddings/{embeddings_key}")
     if hasattr(pytorch_tlm.src_embeddings.reduction, 'ln'):


### PR DESCRIPTION
add support to warmstart the dual-encoder in this API example from BERT checkpoint.
most of our API examples only show BPE-based vocabularies, and do pre-layer norm placement.
this works well for models we have trained, but it would make it more accessible if our demos
included BERT models.  this also requires using a WordPieceVectorizer instead of BPE
and layer norm placement option to be passed in