### PR TITLE
if a label is unattested, skip the sample/warn

### DIFF
--- a/baseline/reader.py
+++ b/baseline/reader.py
@@ -805,7 +805,10 @@ class LineSeqLabelReader(SeqLabelReader):
                 label, text = self.label_and_sentence(line, self.clean_fn, header)
                 if len(text) == 0:
                     continue
-                y = self.label2index[label]
+                y = self.label2index.get(label)
+                if y is None:
+                    logger.warning("Skipping unattested label [%s]", label)
+                    continue
                 example_dict = dict()
                 for k, vectorizer in self.vectorizers.items():
                     example_dict[k], lengths = vectorizer.run(text, vocabs[k])


### PR DESCRIPTION
this doesnt normally happen, but it could from API
examples if the label index is created only on the training data.
by testing it here, we can prevent it if it does occur for some reason