### PR TITLE
Feature/tf2 ckpt restore

### DIFF
--- a/baseline/tf/tagger/training/eager.py
+++ b/baseline/tf/tagger/training/eager.py
@@ -13,6 +13,7 @@ from baseline.model import create_model_for
 from baseline.train import register_training_func, EpochReportingTrainer
 from baseline.utils import get_model_file, get_metric_cmp
 from baseline.tf.tagger.training.utils import to_tensors
+from baseline.tf.tfy import setup_tf2_checkpoints
 # Number of batches to prefetch if using tf.datasets
 NUM_PREFETCH = 2
 # The shuffle buffer
@@ -159,12 +160,10 @@ class TaggerTrainerEagerTf(EpochReportingTrainer):
         self.evaluator = TaggerEvaluatorEagerTf(self.model, span_type, verbose)
         self.optimizer = EagerOptimizer(loss, **kwargs)
         self.nsteps = kwargs.get('nsteps', six.MAXSIZE)
-        self._checkpoint = tf.train.Checkpoint(optimizer=self.optimizer.optimizer, model=self.model)
-        checkpoint_dir = '{}-{}'.format("./tf-tagger", os.getpid())
-
-        self.checkpoint_manager = tf.train.CheckpointManager(self._checkpoint,
-                                                             directory=checkpoint_dir,
-                                                             max_to_keep=5)
+        checkpoint_dir = kwargs.get('checkpoint')
+        if checkpoint_dir is None:
+            checkpoint_dir = f'./tf-tagger-{os.getpid()}'
+        self._checkpoint, self.checkpoint_manager = setup_tf2_checkpoints(self.optimizer, self.model, checkpoint_dir)
 
     def checkpoint(self):
         """This method saves a checkpoint

--- a/baseline/tf/tfy.py
+++ b/baseline/tf/tfy.py
@@ -114,7 +114,7 @@ def setup_tf2_checkpoints(optimizer: EagerOptimizer, model: tf.keras.layers.Laye
     base = os.path.basename(checkpoint_dir)
     restore_file = None
     if base.startswith('ckpt-'):
-        restore_file = base
+        restore_file = checkpoint_dir
     elif os.path.isdir(checkpoint_dir):
         restore_file = checkpoint_manager.latest_checkpoint
     if restore_file:


### PR DESCRIPTION
It should be possible to restart from a TF2 checkpoint partway through processing.

This is useful in case a job is terminated, especially a long running one.  This use-case is handled in all of the API examples as they are typically run on GCP where they can be interrupted, but it is not a part of the `mead-train` path yet.

This changes that, wiring up the `--checkpoint` option passed to `mead-train` to the underlying trainers.  It introduces a new 
function `setup_tf2_checkpoints()` used by all of the eager task-specific trainers which will restore the latest checkpoint
if it is passed an existing directory, or it will restore a specific checkpoint if requested.

By default, when no `--checkpoint` is passed (as before), the checkpoint dir is created and no restoration attempt is made.
Because of how the checkpoint manager works, training is restarted at the last step prior to restoration, which means that the LR scheduler and checkpointing starts from there.  The MEAD trainer doesnt currently have the ability to limit the training by subtracting the missing steps and only running the difference, so if restarting from say, epoch 4 of 10, the caller would either use `patience` or change the number of epochs or pass that to the CL via `--x:train.epochs`


To restart from a TF2 checkpoint directory:

```
mead-train --x:train.epochs 3 --config config/trec-bert-base-uncased.json --backend tf --checkpoint /path/to/tf-classify-19069
```
To restart from a specific checkpoint:

```
mead-train --x:train.epochs 3 --config config/trec-bert-base-uncased.json --backend tf --checkpoint /path/to/tf-classify-19069/ckpt-2
```