### PR TITLE
test sentinels and only append the token if not

### DIFF
--- a/mead/api_examples/seq2seq_generate_response.py
+++ b/mead/api_examples/seq2seq_generate_response.py
@@ -39,10 +39,10 @@ def decode_sentences(model, vectorizer, queries, word2index, index2word, beamsz,
         best_sentence_idx = candidate[0]
         best_sentence_toks = []
         for x in best_sentence_idx:
-            best_sentence_toks.append(index2word[x])
+
             if x in sentinels:
                 break
-
+            best_sentence_toks.append(index2word[x])
         best_sentence = ' '.join(best_sentence_toks)
         sentences.append(best_sentence.replace('@@ ', ''))
     return sentences


### PR DESCRIPTION
the previous approach meant that extra tokens were
generated at the end which makes it unsuitable for
most metrics, as the extra token is not present
in the ref