### PR TITLE
WIP: switch to ONNX compat torch-only tril

### DIFF
--- a/baseline/pytorch/seq2seq/model.py
+++ b/baseline/pytorch/seq2seq/model.py
@@ -187,7 +187,7 @@ class EncoderDecoderModelBase(nn.Module, EncoderDecoderModel):
         else:
             inputs = batch_dict
         encoder_outputs = self.encode(inputs, inputs['src_len'])
-        outs, lengths, scores = self.decoder.beam_search(encoder_outputs, **kwargs)
+        outs, lengths, scores = self.decoder.decode(encoder_outputs, **kwargs)
         if make:
             outs = unsort_batch(outs, perm_idx)
             lengths = unsort_batch(lengths, perm_idx)

--- a/layers/eight_mile/pytorch/layers.py
+++ b/layers/eight_mile/pytorch/layers.py
@@ -2673,8 +2673,7 @@ def pytorch_embedding(weights: torch.Tensor, finetune: bool = True) -> nn.Embedd
     return lut
 
 
-def tril_onnx(inputs: torch.FloatTensor,
-              diagonal: Optional[int] = 0) -> torch.FloatTensor:
+def tril_onnx(inputs: torch.Tensor) -> torch.Tensor:
     """Caveat to export an tril-based operator with ONNX.
 
     Taken from https://github.com/pytorch/pytorch/issues/34129
@@ -2686,9 +2685,9 @@ def tril_onnx(inputs: torch.FloatTensor,
         (torch.FloatTensor): Output tensor.
 
     """
-
-    arange = torch.arange(inputs.size(0), device=inputs.device)
-    arange2 = torch.arange(inputs.size(1), device=inputs.device)
+    diagonal: int = 0
+    arange = torch.arange(inputs.size(0), dtype=torch.long, device=inputs.device)
+    arange2 = torch.arange(inputs.size(1), dtype=torch.long, device=inputs.device)
 
     mask = arange.unsqueeze(-1).expand(-1, inputs.size(1)) >= (arange2 - diagonal)
 
@@ -3968,8 +3967,8 @@ class BeamSearchBase:
                 last = paths[:, :, -1]
                 eoses = last == Offsets.EOS
                 lengths = update_lengths(lengths, eoses, i + 1)
-                if (lengths != 0).all():
-                    break
+                #if (lengths != 0).all():
+                #    break
             else:
                 # This runs if the loop didn't break meaning one beam hit the max len
                 # Add an EOS to anything that hasn't hit the end. This makes the scores real.

--- a/layers/eight_mile/pytorch/layers.py
+++ b/layers/eight_mile/pytorch/layers.py
@@ -14,7 +14,7 @@ import glob
 from eight_mile.utils import listify, Offsets, is_sequence, str2bool, get_alibi_slopes
 from eight_mile.utils import transition_mask as transition_mask_np
 
-MASK_FALSE = False
+MASK_FALSE = 0
 logger = logging.getLogger("mead.layers")
 
 
@@ -3113,7 +3113,7 @@ class SeqScaledWindowedRelativeAttention(SequenceSequenceRelativeAttention):
         scores = (scores_qk + scores_qrk) / math.sqrt(d_k)
         if mask is not None:
             mask = self._unfold_mask(mask, B, rpr_k).unsqueeze(-2)  # [B, 1, T, 1, W]
-            scores = scores.masked_fill(mask == False, -1e9)
+            scores = scores.masked_fill(mask == MASK_FALSE, -1e9)
         return F.softmax(scores, dim=-1)
 
     def _update(self, a: torch.Tensor, value: torch.Tensor, rpr_value: torch.Tensor) -> torch.Tensor:

--- a/mead/utils.py
+++ b/mead/utils.py
@@ -517,9 +517,9 @@ def get_output_paths(
     server_path = os.path.join(*server_path)
     client_path = os.path.join(*client_path)
     if remote:
-        os.makedirs(client_path)
+        os.makedirs(client_path, exist_ok=True)
     if make_server:
-        os.makedirs(server_path)
+        os.makedirs(server_path, exist_ok=True)
     return client_path, server_path
 
 


### PR DESCRIPTION
our tril impl was using numpy -- according to the ONNX docs, this is not the right way during tracing,
it should be tensor/pyt ops.  PyTorch does have the proper operators now for this, but when I switched
to that, I got an error on export.  I tracked that down in this ticket: https://github.com/pytorch/pytorch/issues/34129

It seems that its fixed in the latest PyTorch but we are still supporting older versions, so for now, follow
the recipe in the ticket to ensure that it does what we want