### PR TITLE
Feature/ra updates

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -58,7 +58,7 @@ jobs:
       max-parallel: 4
       matrix:
         pyt-version:
-        - 1.6.0-cuda10.1-cudnn7-runtime
+	- 1.7.1-cuda11.0-cudnn8-runtime
     container: pytorch/pytorch:${{matrix.pyt-version}}
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -58,8 +58,6 @@ jobs:
       max-parallel: 4
       matrix:
         pyt-version:
-        - 1.4-cuda10.1-cudnn7-runtime
-        - 1.5-cuda10.1-cudnn7-runtime
         - 1.6.0-cuda10.1-cudnn7-runtime
     container: pytorch/pytorch:${{matrix.pyt-version}}
     steps:

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -58,7 +58,7 @@ jobs:
       max-parallel: 4
       matrix:
         pyt-version:
-	- 1.7.1-cuda11.0-cudnn8-runtime
+        - 1.7.1-cuda11.0-cudnn8-runtime
     container: pytorch/pytorch:${{matrix.pyt-version}}
     steps:
     - uses: actions/checkout@v2

--- a/baseline/embeddings.py
+++ b/baseline/embeddings.py
@@ -138,9 +138,6 @@ def load_embeddings_overlay(global_embeddings_settings, embeddings_section, voca
 
             embeddings_section = {**embed_model, **embeddings_section}
             try:
-                # We arent necessarily going to get an `embed_file`. For instance, using the HuggingFace
-                # models in the Hub addon, the `embed_file` should be downloaded using HuggingFace's library,
-                # not by us.  In this case we want it to be None and we dont want to download it
                 if embed_file:
                     embed_file = EmbeddingDownloader(embed_file, embed_dsz, embed_sha1, data_download_cache, unzip_file=unzip_file).download()
                     embed_files.append(embed_file)

--- a/baseline/pytorch/embeddings.py
+++ b/baseline/pytorch/embeddings.py
@@ -159,6 +159,7 @@ class TransformerLMEmbeddings(PyTorchEmbeddings):
         activation = kwargs.get('activation', 'gelu')
         windowed_ra = kwargs.get('windowed_ra', False)
         rpr_value_on = kwargs.get('rpr_value_on', True)
+        alibi = kwargs.get('alibi', False)
         is_mlp = kwargs.get("mlp", False)
         if is_mlp:
             self.transformer = GatedMLPEncoderStack(self.d_model, pdrop=pdrop, layers=num_layers,
@@ -171,7 +172,7 @@ class TransformerLMEmbeddings(PyTorchEmbeddings):
                                                        layers=num_layers, d_ff=d_ff, rpr_k=rpr_k, d_k=d_k,
                                                        activation=activation, ffn_pdrop=ff_pdrop,
                                                        layer_norms_after=layer_norms_after, layer_norm_eps=layer_norm_eps,
-                                                       windowed_ra=windowed_ra, rpr_value_on=rpr_value_on)
+                                                       windowed_ra=windowed_ra, rpr_value_on=rpr_value_on, alibi=alibi)
         self.mlm = kwargs.get('mlm', True)
         self.finetune = kwargs.get('finetune', True)
 
@@ -246,7 +247,7 @@ def _mean_pool(inputs, embeddings):
 
 def _max_pool(inputs, embeddings):
     mask = (inputs != Offsets.PAD)
-    embeddings = embeddings.masked_fill(mask.unsqueeze(-1) == False, 0.)
+    embeddings = embeddings.masked_fill(mask.unsqueeze(-1) == False, -1.0e8)
     return torch.max(embeddings, 1, False)[0]
 
 

--- a/baseline/pytorch/embeddings.py
+++ b/baseline/pytorch/embeddings.py
@@ -159,7 +159,7 @@ class TransformerLMEmbeddings(PyTorchEmbeddings):
         activation = kwargs.get('activation', 'gelu')
         windowed_ra = kwargs.get('windowed_ra', False)
         rpr_value_on = kwargs.get('rpr_value_on', True)
-        alibi = kwargs.get('alibi', False)
+        ra_type = kwargs.get('ra_type')
         is_mlp = kwargs.get("mlp", False)
         if is_mlp:
             self.transformer = GatedMLPEncoderStack(self.d_model, pdrop=pdrop, layers=num_layers,
@@ -172,7 +172,7 @@ class TransformerLMEmbeddings(PyTorchEmbeddings):
                                                        layers=num_layers, d_ff=d_ff, rpr_k=rpr_k, d_k=d_k,
                                                        activation=activation, ffn_pdrop=ff_pdrop,
                                                        layer_norms_after=layer_norms_after, layer_norm_eps=layer_norm_eps,
-                                                       windowed_ra=windowed_ra, rpr_value_on=rpr_value_on, alibi=alibi)
+                                                       windowed_ra=windowed_ra, rpr_value_on=rpr_value_on, ra_type=ra_type)
         self.mlm = kwargs.get('mlm', True)
         self.finetune = kwargs.get('finetune', True)
 

--- a/baseline/pytorch/lm/model.py
+++ b/baseline/pytorch/lm/model.py
@@ -216,7 +216,7 @@ class TransformerLanguageModel(AbstractGeneratorLanguageModel):
         layer_drop = kwargs.get('layer_drop', 0.0)
         windowed_ra = kwargs.get('windowed_ra', False)
         rpr_value_on = kwargs.get('rpr_value_on', True)
-        alibi = kwargs.get('alibi', False)
+        ra_type = kwargs.get('ra_type')
         self.mask_pad = kwargs.get('mask_pad', False)
         return TransformerEncoderStack(num_heads, d_model=d_model, pdrop=pdrop, scale=scale,
                                        layers=layers, d_ff=d_ff, rpr_k=rpr_k, d_k=d_k,
@@ -224,7 +224,7 @@ class TransformerLanguageModel(AbstractGeneratorLanguageModel):
                                        ffn_pdrop=ffn_pdrop,
                                        layer_norm_eps=layer_norm_eps,
                                        layer_norms_after=layer_norms_after, windowed_ra=windowed_ra,
-                                       rpr_value_on=rpr_value_on, alibi=alibi,
+                                       rpr_value_on=rpr_value_on, ra_type=ra_type,
                                        layer_drop=layer_drop)
 
     def create_layers(self, embeddings, **kwargs):

--- a/baseline/pytorch/lm/model.py
+++ b/baseline/pytorch/lm/model.py
@@ -216,6 +216,7 @@ class TransformerLanguageModel(AbstractGeneratorLanguageModel):
         layer_drop = kwargs.get('layer_drop', 0.0)
         windowed_ra = kwargs.get('windowed_ra', False)
         rpr_value_on = kwargs.get('rpr_value_on', True)
+        alibi = kwargs.get('alibi', False)
         self.mask_pad = kwargs.get('mask_pad', False)
         return TransformerEncoderStack(num_heads, d_model=d_model, pdrop=pdrop, scale=scale,
                                        layers=layers, d_ff=d_ff, rpr_k=rpr_k, d_k=d_k,
@@ -223,7 +224,7 @@ class TransformerLanguageModel(AbstractGeneratorLanguageModel):
                                        ffn_pdrop=ffn_pdrop,
                                        layer_norm_eps=layer_norm_eps,
                                        layer_norms_after=layer_norms_after, windowed_ra=windowed_ra,
-                                       rpr_value_on=rpr_value_on,
+                                       rpr_value_on=rpr_value_on, alibi=alibi,
                                        layer_drop=layer_drop)
 
     def create_layers(self, embeddings, **kwargs):

--- a/baseline/pytorch/seq2seq/decoders.py
+++ b/baseline/pytorch/seq2seq/decoders.py
@@ -330,7 +330,7 @@ class TransformerDecoderWrapper(torch.nn.Module):
                  activation='relu',
                  rpr_k=None,
                  layer_norm_eps=1e-6,
-                 layer_drop=0.0, scale=True, rpr_value_on=True, alibi=False,
+                 layer_drop=0.0, scale=True, rpr_value_on=True, ra_type=None,
                  d_k=None,
                  d_ff=None,
                  **kwargs):
@@ -347,7 +347,7 @@ class TransformerDecoderWrapper(torch.nn.Module):
                                                            pdrop=dropout, scale=scale, layers=layers,
                                                            rpr_k=rpr_k, d_k=d_k, activation_type=activation,
                                                            layer_drop=layer_drop, layer_norm_eps=layer_norm_eps,
-                                                           rpr_value_on=rpr_value_on, alibi=alibi)
+                                                           rpr_value_on=rpr_value_on, ra_type=ra_type)
 
         self.proj_to_hsz = self._identity
         self.proj_to_dsz = self._identity

--- a/baseline/pytorch/seq2seq/encoders.py
+++ b/baseline/pytorch/seq2seq/encoders.py
@@ -43,7 +43,7 @@ class TransformerEncoderWrapper(torch.nn.Module):
                  activation='relu',
                  rpr_k=None,
                  layer_norm_eps=1e-6,
-                 layer_drop=0.0, scale=True, rpr_value_on=True, alibi=False,
+                 layer_drop=0.0, scale=True, rpr_value_on=True, ra_type=None,
                  d_k=None,
                  d_ff=None,
                  **kwargs):
@@ -58,7 +58,7 @@ class TransformerEncoderWrapper(torch.nn.Module):
                                                    pdrop=dropout, scale=scale, layers=layers,
                                                    rpr_k=rpr_k, d_k=d_k, activation=activation, layer_drop=layer_drop,
                                                    layer_norm_eps=layer_norm_eps,
-                                                   rpr_value_on=rpr_value_on, alibi=alibi)
+                                                   rpr_value_on=rpr_value_on, ra_type=ra_type)
 
     def _identity(self, x):
         return x

--- a/baseline/reader.py
+++ b/baseline/reader.py
@@ -396,8 +396,6 @@ class SeqPredictReader:
 
     def convert_to_tensors(self, texts, vocabs):
         ts = []
-        i2l = revlut(self.label2index)
-        i2w = revlut(self.vectorizers['word'].vocab)
         for i, example_tokens in enumerate(texts):
             example = {}
             for k, vectorizer in self.vectorizers.items():
@@ -405,15 +403,12 @@ class SeqPredictReader:
                 if lengths is not None:
                     example['{}_lengths'.format(k)] = lengths
 
-
             example['y'], lengths = self.label_vectorizer.run(example_tokens, self.label2index)
-            #print(example['y'])
-            print([f"{i2w[w]}/{l}" for w, l in zip(example['word'][:lengths+2], example['y'][:lengths+2])])
             example['y_lengths'] = lengths
             example['ids'] = i
             # Uncomment for sanity check that you wont receive truncated sequences
-            if len(example[k]) != len(example['y']):
-                raise Exception(f"{len(example[k])} != {len(example['y'])}")
+            #if len(example[k]) != len(example['y']):
+            #    raise Exception(f"{len(example[k])} != {len(example['y'])}")
             ts.append(example)
 
         return ts

--- a/baseline/reader.py
+++ b/baseline/reader.py
@@ -396,6 +396,8 @@ class SeqPredictReader:
 
     def convert_to_tensors(self, texts, vocabs):
         ts = []
+        i2l = revlut(self.label2index)
+        i2w = revlut(self.vectorizers['word'].vocab)
         for i, example_tokens in enumerate(texts):
             example = {}
             for k, vectorizer in self.vectorizers.items():
@@ -405,11 +407,13 @@ class SeqPredictReader:
 
 
             example['y'], lengths = self.label_vectorizer.run(example_tokens, self.label2index)
+            #print(example['y'])
+            print([f"{i2w[w]}/{l}" for w, l in zip(example['word'][:lengths+2], example['y'][:lengths+2])])
             example['y_lengths'] = lengths
             example['ids'] = i
             # Uncomment for sanity check that you wont receive truncated sequences
-            #if len(example[k]) != len(example['y']):
-            #    raise Exception(f"{len(example[k])} != {len(example['y'])}")
+            if len(example[k]) != len(example['y']):
+                raise Exception(f"{len(example[k])} != {len(example['y'])}")
             ts.append(example)
 
         return ts

--- a/baseline/tf/embeddings.py
+++ b/baseline/tf/embeddings.py
@@ -206,7 +206,7 @@ class TransformerLMEmbeddings(TensorFlowEmbeddings):
         if not self.finetune:
             z = tf.stop_gradient(z)
         if hasattr(self, 'return_mask') and self.return_mask:
-            return (z, mask,)
+            return (z, input_mask,)
         return z
 
     def get_vocab(self):

--- a/baseline/tf/embeddings.py
+++ b/baseline/tf/embeddings.py
@@ -181,11 +181,12 @@ class TransformerLMEmbeddings(TensorFlowEmbeddings):
         activation = kwargs.get('activation', 'gelu')
         windowed_ra = kwargs.get('windowed_ra', False)
         rpr_value_on = kwargs.get('rpr_value_on', True)
+        alibi = kwargs.get('alibi', False)
         self.transformer = TransformerEncoderStack(num_heads, d_model=self.d_model, pdrop=pdrop, scale=True,
                                                    layers=num_layers, d_ff=d_ff, rpr_k=rpr_k, d_k=d_k,
                                                    activation=activation, layer_norms_after=layer_norms_after,
                                                    layer_norm_eps=layer_norm_eps, windowed_ra=windowed_ra,
-                                                   rpr_value_on=rpr_value_on)
+                                                   rpr_value_on=rpr_value_on, alibi=alibi)
         self.mlm = kwargs.get('mlm', True)
         self.finetune = kwargs.get('finetune', True)
 
@@ -312,5 +313,5 @@ def _mean_pool(inputs, embeddings):
 
 def _max_pool(inputs, embeddings):
     mask = tf.not_equal(inputs, 0)
-    embeddings = tf.where(tf.expand_dims(mask, -1), embeddings, 0.)
+    embeddings = tf.where(tf.expand_dims(mask, -1), embeddings, -1.0e8)
     return tf.reduce_max(embeddings, 1, False)

--- a/baseline/tf/embeddings.py
+++ b/baseline/tf/embeddings.py
@@ -181,12 +181,12 @@ class TransformerLMEmbeddings(TensorFlowEmbeddings):
         activation = kwargs.get('activation', 'gelu')
         windowed_ra = kwargs.get('windowed_ra', False)
         rpr_value_on = kwargs.get('rpr_value_on', True)
-        alibi = kwargs.get('alibi', False)
+        ra_type = kwargs.get('ra_type')
         self.transformer = TransformerEncoderStack(num_heads, d_model=self.d_model, pdrop=pdrop, scale=True,
                                                    layers=num_layers, d_ff=d_ff, rpr_k=rpr_k, d_k=d_k,
                                                    activation=activation, layer_norms_after=layer_norms_after,
                                                    layer_norm_eps=layer_norm_eps, windowed_ra=windowed_ra,
-                                                   rpr_value_on=rpr_value_on, alibi=alibi)
+                                                   rpr_value_on=rpr_value_on, ra_type=ra_type)
         self.mlm = kwargs.get('mlm', True)
         self.finetune = kwargs.get('finetune', True)
 

--- a/baseline/tf/lm/model.py
+++ b/baseline/tf/lm/model.py
@@ -325,6 +325,7 @@ class TransformerLanguageModel(AbstractGeneratorModel):
         layer_drop = kwargs.get('layer_drop', 0.0)
         windowed_ra = kwargs.get('windowed_ra', False)
         rpr_value_on = kwargs.get('rpr_value_on', True)
+        alibi = kwargs.get('alibi', False)
         self.mask_pad = kwargs.get('mask_pad', False)
         return TransformerEncoderStack(num_heads, d_model=d_model, pdrop=pdrop, scale=scale,
                                        layers=layers, d_ff=d_ff, rpr_k=rpr_k, d_k=d_k,
@@ -332,7 +333,7 @@ class TransformerLanguageModel(AbstractGeneratorModel):
                                        ffn_pdrop=ffn_pdrop,
                                        layer_norm_eps=layer_norm_eps,
                                        layer_norms_after=layer_norms_after, windowed_ra=windowed_ra,
-                                       rpr_value_on=rpr_value_on,
+                                       rpr_value_on=rpr_value_on, alibi=alibi,
                                        layer_drop=layer_drop)
 
     def create_mask(self, bth, inputs):

--- a/baseline/tf/lm/model.py
+++ b/baseline/tf/lm/model.py
@@ -325,7 +325,7 @@ class TransformerLanguageModel(AbstractGeneratorModel):
         layer_drop = kwargs.get('layer_drop', 0.0)
         windowed_ra = kwargs.get('windowed_ra', False)
         rpr_value_on = kwargs.get('rpr_value_on', True)
-        alibi = kwargs.get('alibi', False)
+        ra_type = kwargs.get('ra_type')
         self.mask_pad = kwargs.get('mask_pad', False)
         return TransformerEncoderStack(num_heads, d_model=d_model, pdrop=pdrop, scale=scale,
                                        layers=layers, d_ff=d_ff, rpr_k=rpr_k, d_k=d_k,
@@ -333,7 +333,7 @@ class TransformerLanguageModel(AbstractGeneratorModel):
                                        ffn_pdrop=ffn_pdrop,
                                        layer_norm_eps=layer_norm_eps,
                                        layer_norms_after=layer_norms_after, windowed_ra=windowed_ra,
-                                       rpr_value_on=rpr_value_on, alibi=alibi,
+                                       rpr_value_on=rpr_value_on, ra_type=ra_type,
                                        layer_drop=layer_drop)
 
     def create_mask(self, bth, inputs):

--- a/baseline/tf/seq2seq/decoders.py
+++ b/baseline/tf/seq2seq/decoders.py
@@ -243,13 +243,13 @@ class TransformerDecoderWrapper(tf.keras.layers.Layer):
         activation = kwargs.get('activation', 'relu')
         scale = bool(kwargs.get('scale', True))
         layer_drop = float(kwargs.get('layer_drop', 0.0))
-        alibi = kwargs.get('alibi', False)
+        ra_type = kwargs.get('ra_type')
 
         self.transformer_decoder = TransformerDecoderStack(num_heads, d_model=hsz, d_ff=d_ff,
                                                            pdrop=dropout, scale=scale,
                                                            layers=layers, rpr_k=rpr_k, d_k=d_k,
                                                            activation_type=activation, layer_drop=layer_drop,
-                                                           alibi=alibi)
+                                                           ra_type=ra_type)
 
         self.proj_to_dsz = self._identity
         self.proj_to_hsz = self._identity

--- a/baseline/tf/seq2seq/decoders.py
+++ b/baseline/tf/seq2seq/decoders.py
@@ -243,11 +243,13 @@ class TransformerDecoderWrapper(tf.keras.layers.Layer):
         activation = kwargs.get('activation', 'relu')
         scale = bool(kwargs.get('scale', True))
         layer_drop = float(kwargs.get('layer_drop', 0.0))
+        alibi = kwargs.get('alibi', False)
 
         self.transformer_decoder = TransformerDecoderStack(num_heads, d_model=hsz, d_ff=d_ff,
                                                            pdrop=dropout, scale=scale,
                                                            layers=layers, rpr_k=rpr_k, d_k=d_k,
-                                                           activation_type=activation, layer_drop=layer_drop)
+                                                           activation_type=activation, layer_drop=layer_drop,
+                                                           alibi=alibi)
 
         self.proj_to_dsz = self._identity
         self.proj_to_hsz = self._identity

--- a/baseline/tf/seq2seq/encoders.py
+++ b/baseline/tf/seq2seq/encoders.py
@@ -50,11 +50,11 @@ class TransformerEncoderWrapper(tf.keras.layers.Layer):
         activation = kwargs.get('activation', 'relu')
         scale = bool(kwargs.get('scale', True))
         layer_drop = float(kwargs.get('layer_drop', 0.0))
-        alibi = kwargs.get('alibi', False)
+        ra_type = kwargs.get('ra_type')
         self.transformer = TransformerEncoderStack(num_heads, d_model=hsz, d_ff=d_ff,
                                                    pdrop=dropout, scale=scale, layers=layers,
                                                    rpr_k=rpr_k, d_k=d_k, activation=activation, layer_drop=layer_drop,
-                                                   alibi=alibi, scope=scope)
+                                                   ra_type=ra_type, scope=scope)
 
 
     def _identity(self, x):

--- a/baseline/tf/seq2seq/encoders.py
+++ b/baseline/tf/seq2seq/encoders.py
@@ -50,10 +50,11 @@ class TransformerEncoderWrapper(tf.keras.layers.Layer):
         activation = kwargs.get('activation', 'relu')
         scale = bool(kwargs.get('scale', True))
         layer_drop = float(kwargs.get('layer_drop', 0.0))
+        alibi = kwargs.get('alibi', False)
         self.transformer = TransformerEncoderStack(num_heads, d_model=hsz, d_ff=d_ff,
                                                    pdrop=dropout, scale=scale, layers=layers,
                                                    rpr_k=rpr_k, d_k=d_k, activation=activation, layer_drop=layer_drop,
-                                                   scope=scope)
+                                                   alibi=alibi, scope=scope)
 
 
     def _identity(self, x):

--- a/baseline/vectorizers.py
+++ b/baseline/vectorizers.py
@@ -1610,8 +1610,8 @@ class GPT2Dict1DVectorizer(GPT2Vectorizer1D):
 class GPT2LabelDict1DVectorizer(GPT2Vectorizer1D):
 
     def __init__(self, **kwargs):
-        kwargs['emit_begin_tok'] = kwargs.get('emit_begin_tok', ["<pad>"])
-        kwargs['emit_end_tok'] = kwargs.get('emit_end_tok', ["<pad>"])
+        kwargs['emit_begin_tok'] = kwargs.get('emit_begin_tok', [Offsets.VALUES[Offsets.PAD]])
+        kwargs['emit_end_tok'] = kwargs.get('emit_end_tok', [Offsets.VALUES[Offsets.PAD]])
         super().__init__(**kwargs)
         self.field = kwargs.get('fields', kwargs.get('field', 'text'))
         self.label = kwargs.get('label', 'label')
@@ -1623,7 +1623,7 @@ class GPT2LabelDict1DVectorizer(GPT2Vectorizer1D):
             t_word = t[self.field]
             t_label = t[self.label]
             subwords = [x for x in self.tokenizer.encode_subword(t_word)]
-            subwords = ["<pad>"] * len(subwords)
+            subwords = [Offsets.VALUES[Offsets.PAD]] * len(subwords)
             # TODO: The tokenizer sometimes cuts up the token and leaves nothing
             # how to handle this since we cannot get anything for it
             if len(subwords):
@@ -2094,7 +2094,6 @@ class SentencePieceDict1DVectorizer(SentencePieceVectorizer1D):
 
     def iterable(self, tokens):
         tok = [t[self.field] if isinstance(t, dict) else t for t in tokens]
-
         return super().iterable(tok)
 
 
@@ -2103,6 +2102,8 @@ class SentencePieceDict1DVectorizer(SentencePieceVectorizer1D):
 class SentencePieceLabelDict1DVectorizer(SentencePieceVectorizer1D):
 
     def __init__(self, **kwargs):
+        kwargs['emit_begin_tok'] = kwargs.get('emit_begin_tok', [Offsets.VALUES[Offsets.PAD]])
+        kwargs['emit_end_tok'] = kwargs.get('emit_end_tok', [Offsets.VALUES[Offsets.PAD]])
         super().__init__(**kwargs)
         self.field = kwargs.get('fields', kwargs.get('field', 'text'))
         self.label = kwargs.get('label', 'label')

--- a/baseline/vectorizers.py
+++ b/baseline/vectorizers.py
@@ -1589,19 +1589,28 @@ class GPT2Dict1DVectorizer(GPT2Vectorizer1D):
     def iterable(self, tokens):
         for t in self.emit_begin_tok:
             yield t
-        for t in tokens:
-            tok = t[self.field] if isinstance(t, dict) else t
-            if tok == '<unk>':
-                yield '<unk>'
-            elif tok == '<PAD>':
-                yield '<pad>'
-            elif tok == '<GO>':
-                yield '<s>'
-            elif tok == '<EOS>':
-                yield '</s>'
-            else:
-                for subtok in self.tokenizer.encode_subword(tok):
-                    yield subtok
+
+        if not isinstance(tokens, str):
+            tokens = ' '.join(tokens)
+
+        bpe_tokens = self.tokenizer.encode_subword(tokens)
+        for t in bpe_tokens:
+            yield t
+        for t in self.emit_end_tok:
+            yield t
+
+    def iterable(self, tokens):
+        for t in self.emit_begin_tok:
+            yield t
+
+        if isinstance(tokens[0], dict):
+            _tokens = ' '.join([t[self.field] for t in tokens])
+        else:
+            _tokens = ' '.join(tokens)
+
+        bpe_tokens = self.tokenizer.encode_subword(_tokens)
+        for t in bpe_tokens:
+            yield t
         for t in self.emit_end_tok:
             yield t
 

--- a/baseline/vectorizers.py
+++ b/baseline/vectorizers.py
@@ -1509,7 +1509,7 @@ class GPT2Vectorizer1D(AbstractVectorizer, HasSubwordTokens):
 
     @property
     def subword_sentinel(self):
-        return getattr(self.tokenizer, "subword_sentinel", "@@")
+        return 'Ġ'
 
     def valid_label_indices(self, tokens: Iterable) -> List[int]:
         indices = []
@@ -1520,10 +1520,10 @@ class GPT2Vectorizer1D(AbstractVectorizer, HasSubwordTokens):
                 continue
             if not in_subword:
                 indices.append(i)
-                if token.endswith(self.subword_sentinel):
+                if not token.startswith(self.subword_sentinel):
                     in_subword = True
             else:
-                if not token.endswith(self.subword_sentinel):
+                if token.startswith(self.subword_sentinel):
                     in_subword = False
         return indices
 
@@ -1628,17 +1628,22 @@ class GPT2LabelDict1DVectorizer(GPT2Vectorizer1D):
     def iterable(self, tokens):
         for t in self.emit_begin_tok:
             yield t
-        for t in tokens:
-            t_word = t[self.field]
-            t_label = t[self.label]
-            subwords = [x for x in self.tokenizer.encode_subword(t_word)]
-            subwords = [Offsets.VALUES[Offsets.PAD]] * len(subwords)
-            # TODO: The tokenizer sometimes cuts up the token and leaves nothing
-            # how to handle this since we cannot get anything for it
-            if len(subwords):
-                subwords[0] = t_label
-            for x in subwords:
-                yield x
+
+        if isinstance(tokens[0], dict):
+            _tokens = ' '.join([t[self.field] for t in tokens])
+        else:
+            _tokens = ' '.join(tokens)
+
+        bpe_tokens = self.tokenizer.encode_subword(_tokens)
+        j = 0
+        labels = [Offsets.VALUES[Offsets.PAD]] * len(bpe_tokens)
+        for i in range(len(bpe_tokens)):
+            if i == 0 or bpe_tokens[i].startswith(self.subword_sentinel):
+                labels[i] = tokens[j][self.label]
+                j += 1
+        for label in labels:
+            yield label
+
         for t in self.emit_end_tok:
             yield t
 

--- a/layers/eight_mile/pytorch/layers.py
+++ b/layers/eight_mile/pytorch/layers.py
@@ -2789,14 +2789,14 @@ class SeqScaledDotProductAttentionT5(SequenceSequenceAttention):
         num_buckets = self.num_buckets
         if self.bidirectional:
             num_buckets //= 2
-            ret += torch.less(n, 0).to(dtype=torch.long) * num_buckets
+            ret += torch.lt(n, 0).to(dtype=torch.long) * num_buckets
             n = torch.abs(n).to(dtype=torch.long)
         else:
             n = torch.maximum(n, 0).to(dtype=torch.long)
 
         # now n is in the range [0, inf)
         max_exact = num_buckets // 2
-        is_small = torch.less(n, max_exact)
+        is_small = torch.lt(n, max_exact)
         val_if_large = max_exact + (
             torch.log(n.to(dtype=torch.float32) / max_exact)
             / math.log(self.max_distance / max_exact) * (num_buckets - max_exact)).to(dtype=torch.long)
@@ -2884,14 +2884,14 @@ class SeqDotProductAttentionT5(SequenceSequenceAttention):
         num_buckets = self.num_buckets
         if self.bidirectional:
             num_buckets //= 2
-            ret += torch.less(n, 0).to(dtype=torch.long) * num_buckets
+            ret += torch.lt(n, 0).to(dtype=torch.long) * num_buckets
             n = torch.abs(n).to(dtype=torch.long)
         else:
             n = torch.maximum(n, 0).to(dtype=torch.long)
 
         # now n is in the range [0, inf)
         max_exact = num_buckets // 2
-        is_small = torch.less(n, max_exact)
+        is_small = torch.lt(n, max_exact)
         val_if_large = max_exact + (
                 torch.log(n.to(dtype=torch.float32) / max_exact)
                 / math.log(self.max_distance / max_exact) * (num_buckets - max_exact)).to(dtype=torch.long)

--- a/layers/eight_mile/pytorch/layers.py
+++ b/layers/eight_mile/pytorch/layers.py
@@ -2779,7 +2779,7 @@ class SeqScaledDotProductAttentionT5(SequenceSequenceAttention):
 
         rel_embedding = torch.nn.init.kaiming_normal_(torch.empty((self.num_heads, self.num_buckets),
                                                                   dtype=torch.float), nonlinearity='linear')
-        self.register_buffer("rel_embedding", rel_embedding)
+        self.rel_embedding = nn.Parameter(rel_embedding, requires_grad=True)
 
     def _relative_position_bucket(self, relative_position):
         """Taken from https://github.com/tensorflow/mesh/blob/bbb6ce7917e2a8ef1f3dc6990fcacd4f3b075acd/mesh_tensorflow/transformer/transformer_layers.py#L1014
@@ -2871,9 +2871,10 @@ class SeqDotProductAttentionT5(SequenceSequenceAttention):
         self.bidirectional = bidirectional
         self.num_buckets = num_buckets
         self.max_distance = max_distance
+
         rel_embedding = torch.nn.init.kaiming_normal_(torch.empty((self.num_heads, self.num_buckets),
                                                                   dtype=torch.float), nonlinearity='linear')
-        self.register_buffer("rel_embedding", rel_embedding)
+        self.rel_embedding = nn.Parameter(rel_embedding, requires_grad=True)
 
     def _relative_position_bucket(self, relative_position):
         """Taken from https://github.com/tensorflow/mesh/blob/bbb6ce7917e2a8ef1f3dc6990fcacd4f3b075acd/mesh_tensorflow/transformer/transformer_layers.py#L1014

--- a/layers/eight_mile/pytorch/layers.py
+++ b/layers/eight_mile/pytorch/layers.py
@@ -2776,7 +2776,9 @@ class SeqScaledDotProductAttentionT5(SequenceSequenceAttention):
         self.bidirectional = bidirectional
         self.num_buckets = num_buckets
         self.max_distance = max_distance
-        rel_embedding = torch.tensor((self.num_heads, self.num_buckets), dtype=torch.float)
+
+        rel_embedding = torch.nn.init.kaiming_normal_(torch.empty((self.num_heads, self.num_buckets),
+                                                                  dtype=torch.float), nonlinearity='linear')
         self.register_buffer("rel_embedding", rel_embedding)
 
     def _relative_position_bucket(self, relative_position):
@@ -2869,8 +2871,8 @@ class SeqDotProductAttentionT5(SequenceSequenceAttention):
         self.bidirectional = bidirectional
         self.num_buckets = num_buckets
         self.max_distance = max_distance
-
-        rel_embedding = torch.tensor((self.num_heads, self.num_buckets), dtype=torch.float)
+        rel_embedding = torch.nn.init.kaiming_normal_(torch.empty((self.num_heads, self.num_buckets),
+                                                                  dtype=torch.float), nonlinearity='linear')
         self.register_buffer("rel_embedding", rel_embedding)
 
     def _relative_position_bucket(self, relative_position):

--- a/layers/eight_mile/pytorch/layers.py
+++ b/layers/eight_mile/pytorch/layers.py
@@ -11,7 +11,7 @@ import torch.jit as jit
 import torch.autograd
 import contextlib
 import glob
-from eight_mile.utils import listify, Offsets, is_sequence, str2bool
+from eight_mile.utils import listify, Offsets, is_sequence, str2bool, get_alibi_slopes
 from eight_mile.utils import transition_mask as transition_mask_np
 
 MASK_FALSE = False
@@ -2723,7 +2723,7 @@ class SeqScaledDotProductAttention(SequenceSequenceAttention):
         """Scaled dot product attention, as defined in https://arxiv.org/abs/1706.03762
 
         We apply the query to the keys to receive our weights via softmax in a series of efficient
-        matrix operations. In the case of self-attntion the key and query are all low order
+        matrix operations. In the case of self-attention the key and query are all low order
         projections of the same input.
 
         :param query: a query for alignment. Can come from self in case of self-attn or decoder in case of E/D
@@ -2739,6 +2739,37 @@ class SeqScaledDotProductAttention(SequenceSequenceAttention):
         return F.softmax(scores, dim=-1)
 
 
+class SeqScaledDotProductAttentionALiBi(SequenceSequenceAttention):
+    def __init__(self, pdrop: float = 0.1, num_heads=None, **kwargs):
+        super().__init__(pdrop=pdrop, **kwargs)
+        self.num_heads = num_heads
+        slopes = torch.tensor(get_alibi_slopes(self.num_heads))
+        self.register_buffer("slopes", slopes)
+
+    def _attention(self, query: torch.Tensor, key: torch.Tensor, mask: Optional[torch.Tensor] = None) -> torch.Tensor:
+        """Attention with Linear Biases, defined in https://arxiv.org/pdf/2108.12409.pdf
+
+        :param query: a query for alignment. Can come from self in case of self-attn or decoder in case of E/D
+        :param key: a set of keys from encoder or self
+        :param mask: masking (for destination) to prevent seeing what we shouldnt
+        :return: A tensor that is (BxHxTxT)
+        """
+        # (., H, T_q, T_k) = (., H, T_q, D) x (., H, D, T_k)
+        d_k = query.size(-1)
+        scores = torch.matmul(query, key.transpose(-2, -1)) / math.sqrt(d_k)
+        T_k = scores.shape[-1]
+        T_q = scores.shape[-2]
+        offsets = - torch.abs(torch.arange(T_q).view(-1, 1) - torch.arange(T_k).view(1, -1)).to(self.slopes.device)  # [T_q, T_k]
+        alibi = self.slopes.unsqueeze(-1).unsqueeze(-1) * offsets.unsqueeze(0)  # [H, T_q, T_k]
+        alibi = alibi.unsqueeze(0)  # [1, H, T_q, T_k]
+        scores += alibi
+
+        if mask is not None:
+            scores = scores.masked_fill(mask == MASK_FALSE, -1e9)  # [B, 1, 1, T_k] broadcast to [B, 1, T_q, T_k]
+
+        return F.softmax(scores, dim=-1)
+
+
 class SeqDotProductAttention(SequenceSequenceAttention):
     def __init__(self, pdrop: float = 0.1, **kwargs):
         super().__init__(pdrop=pdrop, **kwargs)
@@ -2747,6 +2778,27 @@ class SeqDotProductAttention(SequenceSequenceAttention):
         scores = torch.matmul(query, key.transpose(-2, -1))
         if mask is not None:
             scores = scores.masked_fill(mask == MASK_FALSE, -1e9)
+        return F.softmax(scores, dim=-1)
+
+
+class SeqDotProductAttentionALiBi(SequenceSequenceAttention):
+    def __init__(self, pdrop: float = 0.1, num_heads=None, **kwargs):
+        super().__init__(pdrop=pdrop, **kwargs)
+        self.num_heads = num_heads
+        slopes = torch.tensor(get_alibi_slopes(self.num_heads))
+        self.register_buffer("slopes", slopes)
+
+    def _attention(self, query: torch.Tensor, key: torch.Tensor, mask: Optional[torch.Tensor] = None) -> torch.Tensor:
+        scores = torch.matmul(query, key.transpose(-2, -1))
+        T_k = scores.shape[-1]
+        T_q = scores.shape[-2]
+        offsets = - torch.abs(torch.arange(T_q).view(1, -1) - torch.arange(T_k).view(-1, 1)).to(self.slopes.device)  # [T_q, T_k]
+        alibi = self.slopes.unsqueeze(-1).unsqueeze(-1) * offsets.unsqueeze(0)  # [H, T_q, T_k]
+        alibi = alibi.unsqueeze(0)  # [1, H, T_q, T_k]
+        scores += alibi
+        if mask is not None:
+            scores = scores.masked_fill(mask == MASK_FALSE, -1e9)
+
         return F.softmax(scores, dim=-1)
 
 
@@ -2971,7 +3023,7 @@ class MultiHeadedAttention(nn.Module):
     """
 
     def __init__(
-        self, num_heads: int, d_model: int, dropout: float = 0.1, scale: bool = False, d_k: Optional[int] = None
+        self, num_heads: int, d_model: int, dropout: float = 0.1, scale: bool = False, d_k: Optional[int] = None, alibi: bool = False,
     ):
         """Constructor for multi-headed attention
 
@@ -2998,12 +3050,18 @@ class MultiHeadedAttention(nn.Module):
         self.w_Q = Dense(d_model, self.d_k * self.h)
         self.w_K = Dense(d_model, self.d_k * self.h)
         self.w_V = Dense(d_model, self.d_value * self.h)
-        if self.h > 1:  # w_O is not needed for sinlge headed attention
+        if self.h > 1:  # w_O is not needed for single headed attention
             self.w_O = Dense(self.d_k * self.h, d_model)
         if scale:
-            self.attn_fn = SeqScaledDotProductAttention(dropout)
+            if alibi:
+                self.attn_fn = SeqScaledDotProductAttentionALiBi(dropout, num_heads=num_heads)
+            else:
+                self.attn_fn = SeqScaledDotProductAttention(dropout)
         else:
-            self.attn_fn = SeqDotProductAttention(dropout)
+            if alibi:
+                self.attn_fn = SeqDotProductAttentionALiBi(dropout, num_heads=num_heads)
+            else:
+                self.attn_fn = SeqDotProductAttention(dropout)
         self.attn = None
 
     def forward(self, qkvm: Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]) -> torch.Tensor:
@@ -3170,7 +3228,8 @@ class TransformerEncoder(nn.Module):
         layer_norms_after: bool = False,
         layer_norm_eps: float = 1.0e-6,
         windowed_ra: Optional[bool] = False,
-        rpr_value_on: bool = True
+        rpr_value_on: bool = True,
+        alibi: bool = False,
     ):
         super().__init__()
         # to properly execute BERT models, we have to follow T2T and do layer norms after
@@ -3181,7 +3240,7 @@ class TransformerEncoder(nn.Module):
             self.self_attn = MultiHeadedRelativeAttention(num_heads, d_model, rpr_k, pdrop, scale, d_k=d_k,
                                                           windowed_ra=windowed_ra, rpr_value_on=rpr_value_on)
         else:
-            self.self_attn = MultiHeadedAttention(num_heads, d_model, pdrop, scale=scale, d_k=d_k)
+            self.self_attn = MultiHeadedAttention(num_heads, d_model, pdrop, scale=scale, d_k=d_k, alibi=alibi)
         self.ffn = nn.Sequential(
             Dense(self.d_model, self.d_ff),
             get_activation(activation_type),
@@ -3308,19 +3367,22 @@ class TransformerDecoder(nn.Module):
         rpr_k: Optional[int] = None,
         ffn_pdrop: Optional[float] = 0.0,
         layer_norms_after: bool = False,
-        layer_norm_eps: float = 1.0e-6
+        layer_norm_eps: float = 1.0e-6,
+        rpr_value_on: bool = True,
+        alibi: bool = False,
+
     ):
         super().__init__()
         self.d_model = d_model
         self.layer_norms_after = layer_norms_after
         self.d_ff = d_ff if d_ff is not None else 4 * d_model
         if rpr_k is not None:
-            self.self_attn = MultiHeadedRelativeAttention(num_heads, d_model, rpr_k, pdrop, scale, d_k=d_k)
-            self.src_attn = MultiHeadedRelativeAttention(num_heads, d_model, rpr_k, pdrop, scale, d_k=d_k)
+            self.self_attn = MultiHeadedRelativeAttention(num_heads, d_model, rpr_k, pdrop, scale, d_k=d_k, rpr_value_on=rpr_value_on)
+            self.src_attn = MultiHeadedRelativeAttention(num_heads, d_model, rpr_k, pdrop, scale, d_k=d_k, rpr_value_on=rpr_value_on)
 
         else:
-            self.self_attn = MultiHeadedAttention(num_heads, d_model, pdrop, scale, d_k=d_k)
-            self.src_attn = MultiHeadedAttention(num_heads, d_model, pdrop, scale, d_k=d_k)
+            self.self_attn = MultiHeadedAttention(num_heads, d_model, pdrop, scale, d_k=d_k, alibi=alibi)
+            self.src_attn = MultiHeadedAttention(num_heads, d_model, pdrop, scale, d_k=d_k, alibi=alibi)
 
         self.ffn = nn.Sequential(
             Dense(self.d_model, self.d_ff),
@@ -3369,6 +3431,7 @@ class TransformerEncoderStack(nn.Module):
         windowed_ra: Optional[bool] = False,
         rpr_value_on: bool = True,
         layer_drop: float = 0.0,
+        alibi: bool = False,
         **kwargs,
     ):
         super().__init__()
@@ -3385,7 +3448,7 @@ class TransformerEncoderStack(nn.Module):
                 TransformerEncoder(
                     num_heads, d_model, pdrop, scale, activation, d_ff, d_k,
                     rpr_k=rpr_k[i], ffn_pdrop=ffn_pdrop, layer_norms_after=layer_norms_after,
-                    layer_norm_eps=layer_norm_eps, windowed_ra=windowed_ra, rpr_value_on=rpr_value_on
+                    layer_norm_eps=layer_norm_eps, windowed_ra=windowed_ra, rpr_value_on=rpr_value_on, alibi=alibi
                 )
             )
 
@@ -3520,6 +3583,8 @@ class TransformerDecoderStack(nn.Module):
         layer_norms_after: bool = False,
         layer_norm_eps: float = 1.0e-6,
         layer_drop: float = 0.0,
+        rpr_value_on: bool = True,
+        alibi: bool = False,
         **kwargs,
 
     ):
@@ -3535,7 +3600,8 @@ class TransformerDecoderStack(nn.Module):
             self.decoders.append(
                 TransformerDecoder(num_heads, d_model, pdrop, scale, activation_type, d_ff,
                                    d_k=d_k, rpr_k=rpr_k[i], ffn_pdrop=ffn_pdrop,
-                                   layer_norms_after=layer_norms_after, layer_norm_eps=layer_norm_eps)
+                                   layer_norms_after=layer_norms_after, layer_norm_eps=layer_norm_eps,
+                                   rpr_value_on=rpr_value_on, alibi=alibi)
             )
 
     def forward(self, inputs):
@@ -4485,7 +4551,8 @@ class PairedModel(DualEncoderModel):
                  layer_norm_eps=1e-6,
                  output_layer=False,
                  output_activation='tanh',
-                 output_shared=False):
+                 output_shared=False,
+                 **kwargs):
         super().__init__(2*d_model if reduction_type.startswith("2") else d_model, stacking_layers,
                          d_out if d_out is not None else d_model, ffn_pdrop, None, output_layer,
                          output_activation, output_shared)
@@ -4515,11 +4582,13 @@ class PairedModel(DualEncoderModel):
         else:
             raise Exception("Unknown exception type")
         self.weight_std = weight_std
+        alibi = kwargs.get('alibi', False)
         self.transformer = TransformerEncoderStack(num_heads=num_heads, d_model=d_model,
                                                    pdrop=dropout, layers=num_layers, activation='gelu', d_ff=d_ff,
                                                    ffn_pdrop=ffn_pdrop,
                                                    d_k=d_k, rpr_k=rpr_k, windowed_ra=windowed_ra, rpr_value_on=rpr_value_on,
-                                                   layer_norms_after=layer_norms_after, layer_norm_eps=layer_norm_eps)
+                                                   layer_norms_after=layer_norms_after, layer_norm_eps=layer_norm_eps,
+                                                   alibi=alibi)
 
         self.embeddings = EmbeddingsStack({'x': embeddings}, 0.0, False, embeddings_reduction)
         self.freeze = freeze_encoders
@@ -4591,7 +4660,8 @@ class TransformerBoWPairedModel(DualEncoderModel):
                  rpr_value_on=False,
                  reduction_type_1="2ha",
                  freeze_encoders=False,
-                 layer_norms_after=False):
+                 layer_norms_after=False,
+                 **kwargs):
         super().__init__(d_model, stacking_layers, d_out, ffn_pdrop)
 
         reduction_type_1 = reduction_type_1.lower()
@@ -4614,11 +4684,12 @@ class TransformerBoWPairedModel(DualEncoderModel):
         else:
             raise Exception("Unknown exception type")
         self.weight_std = weight_std
+        alibi = kwargs.get('alibi', False)
         self.transformer = TransformerEncoderStack(num_heads=num_heads, d_model=d_model,
                                                    pdrop=dropout, layers=num_layers, activation='gelu', d_ff=d_ff,
                                                    ffn_pdrop=ffn_pdrop,
                                                    d_k=d_k, rpr_k=rpr_k, windowed_ra=windowed_ra, rpr_value_on=rpr_value_on,
-                                                   layer_norms_after=layer_norms_after)
+                                                   layer_norms_after=layer_norms_after, alibi=alibi)
 
         self.embeddings = EmbeddingsStack({'x': embeddings})
         self.freeze = freeze_encoders

--- a/layers/eight_mile/pytorch/serialize.py
+++ b/layers/eight_mile/pytorch/serialize.py
@@ -267,6 +267,10 @@ def to_attn_array(pytorch_attn: nn.Module, name: str) -> Dict:
     d.update(to_weight_array(pytorch_attn.w_K, f"{name}/w_K"))
     d.update(to_weight_array(pytorch_attn.w_V, f"{name}/w_V"))
 
+    # T5 relative embeddings
+    if hasattr(pytorch_attn.attn_fn, 'rel_embedding'):
+        d.update({f"{name}/rel_embedding": pytorch_attn.attn_fn.rel_embedding.cpu().detach().numpy()})
+
     if hasattr(pytorch_attn, 'w_O'):
         d.update(to_weight_array(pytorch_attn.w_O, f"{name}/w_O"))
 
@@ -294,6 +298,11 @@ def from_attn_array(pytorch_attn: nn.Module, d: Dict, name: str):
 
     if hasattr(pytorch_attn, 'w_O'):
         from_weight_array(pytorch_attn.w_O, d, f"{name}/w_O")
+
+    # T5 relative embeddings
+    if hasattr(pytorch_attn.attn_fn, 'rel_embedding'):
+        device = pytorch_attn.attn_fn.rel_embedding.device
+        pytorch_attn.attn_fn.rel_embedding = torch.nn.Parameter(torch.from_numpy(d[f"{name}/rel_embedding"]).to(device=device))
 
     if hasattr(pytorch_attn, 'rpr_key'):
         device = pytorch_attn.rpr_key.weight.device

--- a/layers/eight_mile/tf/layers.py
+++ b/layers/eight_mile/tf/layers.py
@@ -1756,9 +1756,11 @@ class SeqScaledDotProductAttentionT5(SequenceSequenceAttention):
         self.bidirectional = bidirectional
         self.num_buckets = num_buckets
         self.max_distance = max_distance
-        self.rel_embeddings = self.add_weight("rel_embeddings_t5", shape=[self.num_heads, self.num_buckets],
-                                              initializer=tf.keras.initializers.VarianceScaling(1.0, 'fan_in', 'normal'),
-                                              trainable=True)
+
+    def build(self, input_shape):
+        self.rel_embedding = self.add_weight("rel_embeddings_t5", shape=[self.num_heads, self.num_buckets],
+                                             initializer=tf.keras.initializers.VarianceScaling(1.0, 'fan_in', 'normal'),
+                                             trainable=True)
 
     def _relative_position_bucket(self, relative_position,
                                   bidirectional=True,
@@ -2040,9 +2042,10 @@ class SeqDotProductAttentionT5(SequenceSequenceAttention):
         self.bidirectional = bidirectional
         self.num_buckets = num_buckets
         self.max_distance = max_distance
-        self.rel_embeddings = self.add_weight("rel_embeddings_t5", shape=[self.num_heads, self.num_buckets],
-                                              initializer=tf.keras.initializers.VarianceScaling(1.0, 'fan_in', 'normal'),
-                                              trainable=True)
+    def build(self, input_shape):
+        self.rel_embedding = self.add_weight("rel_embeddings_t5", shape=[self.num_heads, self.num_buckets],
+                                             initializer=tf.keras.initializers.VarianceScaling(1.0, 'fan_in', 'normal'),
+                                             trainable=True)
 
     def _relative_position_bucket(self, relative_position,
                                   bidirectional=True,

--- a/layers/eight_mile/tf/serialize.py
+++ b/layers/eight_mile/tf/serialize.py
@@ -82,6 +82,9 @@ def to_attn_array(tf_attn: tf.keras.layers.Layer, name: str) -> Dict:
     d.update(to_weight_array(tf_attn.w_K, f"{name}/w_K"))
     d.update(to_weight_array(tf_attn.w_V, f"{name}/w_V"))
 
+    if hasattr(tf_attn.attn_fn, 'rel_embedding'):
+        d.update({f"{name}/rel_embedding": tf_attn.attn_fn.get_weights()[0]})
+
     if hasattr(tf_attn, 'w_O'):
         d.update(to_weight_array(tf_attn.w_O, f"{name}/w_O"))
 
@@ -108,6 +111,9 @@ def from_attn_array(tf_attn: tf.keras.layers.Layer, d: Dict, name: str):
     from_weight_array(tf_attn.w_Q, d, f"{name}/w_Q")
     from_weight_array(tf_attn.w_K, d, f"{name}/w_K")
     from_weight_array(tf_attn.w_V, d, f"{name}/w_V")
+
+    if hasattr(tf_attn.attn_fn, 'rel_embedding'):
+        tf_attn.attn_fn.set_weights([d["f{name}/rel_embedding"]])
 
     if hasattr(tf_attn, 'w_O'):
         from_weight_array(tf_attn.w_O, d, f"{name}/w_O")

--- a/mead/api_examples/pretrain_paired_pytorch.py
+++ b/mead/api_examples/pretrain_paired_pytorch.py
@@ -38,7 +38,7 @@ def create_model(embeddings, d_model, d_ff, dropout, num_heads, num_layers, mode
                                           reduction_d_k=reduction_d_k, stacking_layers=stacking_layers,
                                           ffn_pdrop=ff_pdrop, windowed_ra=windowed_ra,
                                           reduction_type_1=reduction_type, freeze_encoders=True,
-                                          layer_norms_after=layer_norms_after, alibi=alibi)
+                                          layer_norms_after=layer_norms_after, ra_type=ra_type)
     else:
         model = PairedModel(embeddings, d_model, d_ff, dropout, num_heads, num_layers, rpr_k=rpr_k, d_k=d_k,
                             reduction_d_k=reduction_d_k, stacking_layers=stacking_layers, ffn_pdrop=ff_pdrop,
@@ -123,7 +123,7 @@ def parse_args(argv):
     parser.add_argument("--tgt_end_tok", type=str, nargs='+', default=['<EOS>'])
     parser.add_argument('--lower', type=str2bool, default=False)
     parser.add_argument('--rpr_value_on', type=str2bool, default=True)
-    parser.add_argument('--alibi', type=str2bool, default=False, help='whether use ALiBi relative attention')
+    parser.add_argument('--ra_type', type=str, help="Specify a relative attention type")
     parser.add_argument("--loss", type=str, default='symmetric',
                         choices=['triplet', 'all', 'all_mean', 'contrastive', 'symmetric'])
     parser.add_argument("--learn_temp", type=str2bool, default=True,
@@ -208,7 +208,7 @@ def run(basedir=None, train_file=None, valid_file=None, dataset_key='paired', em
                          shared_output=shared_output,
                          layer_norms_after=layer_norms_after,
                          rpr_value_on=rpr_value_on,
-                         alibi=alibi,
+                         ra_type=ra_type,
                          logger=logger)
     model.to(device)
 

--- a/mead/api_examples/pretrain_paired_pytorch.py
+++ b/mead/api_examples/pretrain_paired_pytorch.py
@@ -35,8 +35,10 @@ def create_model(embeddings, d_model, d_ff, dropout, num_heads, num_layers, mode
 
     if model_type == 'transformer-bow':
         model = TransformerBoWPairedModel(embeddings, d_model, d_ff, dropout, num_heads, num_layers, rpr_k=rpr_k, d_k=d_k,
-                                          reduction_d_k=reduction_d_k, stacking_layers=stacking_layers, ffn_pdrop=ff_pdrop, windowed_ra=windowed_ra,
-                                          reduction_type_1=reduction_type, freeze_encoders=True, layer_norms_after=layer_norms_after)
+                                          reduction_d_k=reduction_d_k, stacking_layers=stacking_layers,
+                                          ffn_pdrop=ff_pdrop, windowed_ra=windowed_ra,
+                                          reduction_type_1=reduction_type, freeze_encoders=True,
+                                          layer_norms_after=layer_norms_after, alibi=alibi)
     else:
         model = PairedModel(embeddings, d_model, d_ff, dropout, num_heads, num_layers, rpr_k=rpr_k, d_k=d_k,
                             reduction_d_k=reduction_d_k, stacking_layers=stacking_layers, ffn_pdrop=ff_pdrop,
@@ -119,7 +121,9 @@ def parse_args(argv):
     parser.add_argument("--src_end_tok", type=str, nargs='+', default=['<EOS>'])
     parser.add_argument("--tgt_begin_tok", type=str, nargs='+', default=['<GO>'])
     parser.add_argument("--tgt_end_tok", type=str, nargs='+', default=['<EOS>'])
-    parser.add_argument('--lower', type=baseline.str2bool, default=False)
+    parser.add_argument('--lower', type=str2bool, default=False)
+    parser.add_argument('--rpr_value_on', type=str2bool, default=True)
+    parser.add_argument('--alibi', type=str2bool, default=False, help='whether use ALiBi relative attention')
     parser.add_argument("--loss", type=str, default='symmetric',
                         choices=['triplet', 'all', 'all_mean', 'contrastive', 'symmetric'])
     parser.add_argument("--learn_temp", type=str2bool, default=True,
@@ -203,6 +207,8 @@ def run(basedir=None, train_file=None, valid_file=None, dataset_key='paired', em
                          reduction_type=reduction_type,
                          shared_output=shared_output,
                          layer_norms_after=layer_norms_after,
+                         rpr_value_on=rpr_value_on,
+                         alibi=alibi,
                          logger=logger)
     model.to(device)
 

--- a/mead/api_examples/pretrain_paired_tf.py
+++ b/mead/api_examples/pretrain_paired_tf.py
@@ -123,7 +123,7 @@ def main():
     parser.add_argument('--rpr_k',
                         help='Relative attention positional sizes pass 0 if you dont want relative attention',
                         type=int, default=[8], nargs='+')
-    parser.add_argument('--alibi', type=str2bool, default=False, help='whether use ALiBi relative attention')
+    parser.add_argument('--ra_type', type=str, help="Specify a relative attention type")
     parser.add_argument("--reduction_d_k", type=int, default=64, help="Dimensions of Key and Query in the single headed"
                                                                       "reduction layers")
     parser.add_argument("--reduction_type", type=str, default="2ha",
@@ -242,7 +242,7 @@ def main():
     model = PairedModel(embeddings, args.d_model, args.d_ff, args.dropout, args.num_heads, args.num_layers, rpr_k=rpr_k,
                         d_k=args.d_k, reduction_d_k=args.reduction_d_k, stacking_layers=args.stacking_layers,
                         ffn_pdrop=args.ff_pdrop, reduction_type=args.reduction_type, freeze_encoders=False,
-                        alibi=args.alibi)
+                        ra_type=args.ra_type)
 
     loss_function = model.create_loss(loss_type=args.loss, init_temp=args.init_temp, learn_temp=args.learn_temp)
     logger.info("Loaded model and loss")

--- a/mead/api_examples/pretrain_paired_tf.py
+++ b/mead/api_examples/pretrain_paired_tf.py
@@ -123,6 +123,7 @@ def main():
     parser.add_argument('--rpr_k',
                         help='Relative attention positional sizes pass 0 if you dont want relative attention',
                         type=int, default=[8], nargs='+')
+    parser.add_argument('--alibi', type=str2bool, default=False, help='whether use ALiBi relative attention')
     parser.add_argument("--reduction_d_k", type=int, default=64, help="Dimensions of Key and Query in the single headed"
                                                                       "reduction layers")
     parser.add_argument("--reduction_type", type=str, default="2ha",
@@ -240,8 +241,8 @@ def main():
     logger.info("Creating dual encoder")
     model = PairedModel(embeddings, args.d_model, args.d_ff, args.dropout, args.num_heads, args.num_layers, rpr_k=rpr_k,
                         d_k=args.d_k, reduction_d_k=args.reduction_d_k, stacking_layers=args.stacking_layers,
-                        ffn_pdrop=args.ff_pdrop,
-                        reduction_type=args.reduction_type, freeze_encoders=False)
+                        ffn_pdrop=args.ff_pdrop, reduction_type=args.reduction_type, freeze_encoders=False,
+                        alibi=args.alibi)
 
     loss_function = model.create_loss(loss_type=args.loss, init_temp=args.init_temp, learn_temp=args.learn_temp)
     logger.info("Loaded model and loss")

--- a/mead/api_examples/pretrain_tlm_pytorch.py
+++ b/mead/api_examples/pretrain_tlm_pytorch.py
@@ -49,7 +49,7 @@ def run(basedir=None, train_file=None, valid_file=None, dataset_key='tlm', embed
         restart_tt=None, warmup_steps=10000, saves_per_epoch=10, mlm=True, preprocessed=True, rpr_k=[8],
         rpr_value_on=False, windowed_ra=False, device="cuda", distributed=False, local_rank=-1,
         extra_tokens=["[CLS]", "[MASK]"], do_early_stopping=False, model_type='transformer-mlm', modules=[],
-        alibi=False, **kwargs):
+        ra_type=None, **kwargs):
     if basedir is None:
         basedir = 'lm-{}-bpe-{}'.format(dataset_key, os.getpid())
     logging.basicConfig(level=logging.INFO if local_rank in [-1, 0] else logging.WARN)
@@ -131,7 +131,7 @@ def run(basedir=None, train_file=None, valid_file=None, dataset_key='tlm', embed
         rpr_value_on=rpr_value_on,
         layer_drop=layer_drop,
         model_type=model_type,
-        alibi=alibi,
+        ra_type=ra_type,
         src_keys=['x'], tgt_key='x')
     model.to(device)
 
@@ -348,7 +348,7 @@ def parse_args(argv):
     parser.add_argument('--rpr_value_on', type=str2bool, default=False,
                         help="In relative attention, whether add positional correction to values in addition to the "
                              "correction to attention matrix")
-    parser.add_argument("--alibi", type=str2bool, default=False, help='whether use AliBi to represent positions')
+    parser.add_argument("--ra_type", type=str, help='Select a relative attention type')
     parser.add_argument("--windowed_ra", type=str2bool, default=False, help="whether prevent attention beyond rpr_k")
     parser.add_argument("--device", type=str,
                         default="cuda" if torch.cuda.is_available() else "cpu",

--- a/mead/api_examples/pretrain_tlm_pytorch.py
+++ b/mead/api_examples/pretrain_tlm_pytorch.py
@@ -112,7 +112,11 @@ def run(basedir=None, train_file=None, valid_file=None, dataset_key='tlm', embed
     if len(rpr_k) == 0 or rpr_k[0] < 1:
         rpr_k = None
     elif len(rpr_k) == 1:
-        rpr_k = rpr_k[0]
+        rpr_k = None if rpr_k[0] == 0 else rpr_k[0]
+    if ra_type != None and ra_type != 'shaw' and rpr_k is not None:
+        print(f"Relative attention mismatch. You requested {ra_type} with rpr set.  Setting it to 0")
+        rpr_k = None
+
 
     model = create_lang_model(
         embeddings,

--- a/mead/api_examples/pretrain_tlm_pytorch.py
+++ b/mead/api_examples/pretrain_tlm_pytorch.py
@@ -48,7 +48,8 @@ def run(basedir=None, train_file=None, valid_file=None, dataset_key='tlm', embed
         lr_alpha=0.0, optim='adamw', lr=4.0e-4, clip=1.0, weight_decay=1.0e-2, epochs=32, restart_from=None,
         restart_tt=None, warmup_steps=10000, saves_per_epoch=10, mlm=True, preprocessed=True, rpr_k=[8],
         rpr_value_on=False, windowed_ra=False, device="cuda", distributed=False, local_rank=-1,
-        extra_tokens=["[CLS]", "[MASK]"], do_early_stopping=False, model_type='transformer-mlm', modules=[], **kwargs):
+        extra_tokens=["[CLS]", "[MASK]"], do_early_stopping=False, model_type='transformer-mlm', modules=[],
+        alibi=False, **kwargs):
     if basedir is None:
         basedir = 'lm-{}-bpe-{}'.format(dataset_key, os.getpid())
     logging.basicConfig(level=logging.INFO if local_rank in [-1, 0] else logging.WARN)
@@ -130,6 +131,7 @@ def run(basedir=None, train_file=None, valid_file=None, dataset_key='tlm', embed
         rpr_value_on=rpr_value_on,
         layer_drop=layer_drop,
         model_type=model_type,
+        alibi=alibi,
         src_keys=['x'], tgt_key='x')
     model.to(device)
 
@@ -346,6 +348,7 @@ def parse_args(argv):
     parser.add_argument('--rpr_value_on', type=str2bool, default=False,
                         help="In relative attention, whether add positional correction to values in addition to the "
                              "correction to attention matrix")
+    parser.add_argument("--alibi", type=str2bool, default=False, help='whether use AliBi to represent positions')
     parser.add_argument("--windowed_ra", type=str2bool, default=False, help="whether prevent attention beyond rpr_k")
     parser.add_argument("--device", type=str,
                         default="cuda" if torch.cuda.is_available() else "cpu",

--- a/mead/api_examples/pretrain_tlm_tf.py
+++ b/mead/api_examples/pretrain_tlm_tf.py
@@ -20,7 +20,7 @@ import tensorflow as tf
 import json
 logger = logging.getLogger(__file__)
 # If True, this will turn of autograph compilation.  Change this flag if you want to debug
-set_tf_eager_debug(False)
+set_tf_eager_debug(str2bool(os.getenv("MEAD_TF_EAGER_DEBUG", "FALSE")))
 
 """Pre-train a Transformer model in TensorFlow
 

--- a/mead/api_examples/pretrain_tlm_tf.py
+++ b/mead/api_examples/pretrain_tlm_tf.py
@@ -166,6 +166,7 @@ def main():
     parser.add_argument('--rpr_value_on', type=str2bool, default=True,
                         help="In relative attention, whether add positional correction to values in addition to the "
                              "correction to attention matrix")
+    parser.add_argument('--alibi', type=str2bool, default=False, help="whether use ALiBi relative attention")
     parser.add_argument('--windowed_ra', type=str2bool, default=False, help="whether prevent attention beyond rpr_k")
     parser.add_argument("--strategy", help="Training strategy, defaults to `mirror`", choices=["mirror"])
     parser.add_argument("--npz", help="Should we write out NPZ files?", type=str2bool, default=False)
@@ -444,6 +445,7 @@ def create_model(args, embeddings):
                            windowed_ra=args.windowed_ra,
                            rpr_value_on=args.rpr_value_on,
                            layer_drop=args.layer_drop,
+                           alibi=args.alibi,
                            src_keys=['x'], tgt_key='x')
     return model
 

--- a/mead/api_examples/pretrain_tlm_tf.py
+++ b/mead/api_examples/pretrain_tlm_tf.py
@@ -166,7 +166,7 @@ def main():
     parser.add_argument('--rpr_value_on', type=str2bool, default=True,
                         help="In relative attention, whether add positional correction to values in addition to the "
                              "correction to attention matrix")
-    parser.add_argument('--alibi', type=str2bool, default=False, help="whether use ALiBi relative attention")
+    parser.add_argument('--ra_type', type=str, help="Specify a relative attention type")
     parser.add_argument('--windowed_ra', type=str2bool, default=False, help="whether prevent attention beyond rpr_k")
     parser.add_argument("--strategy", help="Training strategy, defaults to `mirror`", choices=["mirror"])
     parser.add_argument("--npz", help="Should we write out NPZ files?", type=str2bool, default=False)
@@ -445,7 +445,7 @@ def create_model(args, embeddings):
                            windowed_ra=args.windowed_ra,
                            rpr_value_on=args.rpr_value_on,
                            layer_drop=args.layer_drop,
-                           alibi=args.alibi,
+                           ra_type=args.ra_type,
                            src_keys=['x'], tgt_key='x')
     return model
 

--- a/mead/api_examples/pretrain_tlm_tf.py
+++ b/mead/api_examples/pretrain_tlm_tf.py
@@ -429,7 +429,7 @@ def create_model(args, embeddings):
         if len(args.rpr_k) == 0 or args.rpr_k[0] < 1:
             rpr_k = None
         elif len(args.rpr_k) == 1:
-            rpr_k = args.rpr_k[0]
+            rpr_k = None if args.rpr_k[0] == 0 else args.rpr_k[0]
         else:
             rpr_k = args.rpr_k
 

--- a/mead/api_examples/pretrain_transformer_seq2seq_tf.py
+++ b/mead/api_examples/pretrain_transformer_seq2seq_tf.py
@@ -150,7 +150,7 @@ def train():
                         type=int, default=[8], nargs='+')
     parser.add_argument('--rpr_value_on', type=str2bool, default=True,
                         help="Whether have value correction due to relative position")
-    parser.add_argument('--alibi', type=str2bool, default=False, help="Whether use ALiBi relative attention")
+    parser.add_argument('--ra_type', type=str, help="Specify a relative attention type")
     parser.add_argument("--npz", help="Should we write out NPZ files?", type=str2bool, default=False)
     parser.add_argument("--tb", help="Turn on tensorboard?", type=str2bool, default=False)
     parser.add_argument("--convert_only", help="Should we just convert this file to NPZ and exit?", type=str2bool, default=False)
@@ -270,7 +270,7 @@ def train():
            "d_k": args.d_k,
            "rpr_k": rpr_k,
            "rpr_value_on": args.rpr_value_on,
-           "alibi": args.alibi}
+           "ra_type": args.ra_type}
     model = TiedEmbeddingsSeq2SeqModel(embeddings, **hps)
 
     logger.info("Loaded model and loss")

--- a/mead/api_examples/pretrain_transformer_seq2seq_tf.py
+++ b/mead/api_examples/pretrain_transformer_seq2seq_tf.py
@@ -148,6 +148,9 @@ def train():
     parser.add_argument('--rpr_k',
                         help='Relative attention positional sizes pass 0 if you dont want relative attention',
                         type=int, default=[8], nargs='+')
+    parser.add_argument('--rpr_value_on', type=str2bool, default=True,
+                        help="Whether have value correction due to relative position")
+    parser.add_argument('--alibi', type=str2bool, default=False, help="Whether use ALiBi relative attention")
     parser.add_argument("--npz", help="Should we write out NPZ files?", type=str2bool, default=False)
     parser.add_argument("--tb", help="Turn on tensorboard?", type=str2bool, default=False)
     parser.add_argument("--convert_only", help="Should we just convert this file to NPZ and exit?", type=str2bool, default=False)
@@ -265,7 +268,9 @@ def train():
            "decoder_type": "transformer",
            "src_lengths_key": "x_lengths",
            "d_k": args.d_k,
-           "rpr_k": rpr_k}
+           "rpr_k": rpr_k,
+           "rpr_value_on": args.rpr_value_on,
+           "alibi": args.alibi}
     model = TiedEmbeddingsSeq2SeqModel(embeddings, **hps)
 
     logger.info("Loaded model and loss")

--- a/tests/test_crf_pytorch.py
+++ b/tests/test_crf_pytorch.py
@@ -204,7 +204,7 @@ def test_score_sentence_batch_stable(generate_examples_and_batch):
     score2 = crf.score_sentence(i2, t2, l2)
     one_x_one = torch.cat([score1, score2], dim=0)
     batched = crf.score_sentence(i, t, l)
-    np.testing.assert_allclose(one_x_one.detach().numpy(), batched.detach().numpy())
+    np.testing.assert_allclose(one_x_one.detach().numpy(), batched.detach().numpy(), rtol=1e-6)
 
 
 def test_score_sentence_shape(generate_batch):
@@ -439,8 +439,8 @@ def test_viterbi_degenerates_to_argmax(generate_batch):
         s_gold[sl:, i] = 0
         p_gold[sl:, i] = 0
     s_gold = torch.sum(s_gold, 0)
-    np.testing.assert_allclose(p.detach().numpy(), p_gold.detach().numpy())
-    np.testing.assert_allclose(s.detach().numpy(), s_gold.detach().numpy())
+    np.testing.assert_allclose(p.detach().numpy(), p_gold.detach().numpy(), rtol=1e-6)
+    np.testing.assert_allclose(s.detach().numpy(), s_gold.detach().numpy(), rtol=1e-6)
 
 
 def test_decode_shape(generate_batch):

--- a/tests/test_rel_bias_pytorch.py
+++ b/tests/test_rel_bias_pytorch.py
@@ -1,0 +1,83 @@
+from collections import namedtuple
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from eight_mile.pytorch.layers import (
+    SeqDotProductAttentionT5,
+    SeqScaledDotProductAttentionT5,
+)
+NH = 4
+NQ = 7
+NK = 6
+NB = 32
+
+@pytest.fixture
+def generate_buckets_values():
+    REL_BUCKETS = torch.tensor([[0, 17, 18, 19, 20, 21],
+                                [1, 0, 17, 18, 19, 20],
+                                [2, 1, 0, 17, 18, 19],
+                                [3, 2, 1, 0, 17, 18],
+                                [4, 3, 2, 1, 0, 17],
+                                [5, 4, 3, 2, 1, 0],
+                                [6, 5, 4, 3, 2, 1]])
+
+    REL_EMB = torch.tensor([[[0., 17., 18., 19., 20., 21.],
+                             [1., 0., 17., 18., 19., 20.],
+                             [2., 1., 0., 17., 18., 19.],
+                             [3., 2., 1., 0., 17., 18.],
+                             [4., 3., 2., 1., 0., 17.],
+                             [5., 4., 3., 2., 1., 0.],
+                             [6., 5., 4., 3., 2., 1.]],
+
+                            [[32., 49., 50., 51., 52., 53.],
+                             [33., 32., 49., 50., 51., 52.],
+                             [34., 33., 32., 49., 50., 51.],
+                             [35., 34., 33., 32., 49., 50.],
+                             [36., 35., 34., 33., 32., 49.],
+                             [37., 36., 35., 34., 33., 32.],
+                             [38., 37., 36., 35., 34., 33.]],
+
+                            [[64., 81., 82., 83., 84., 85.],
+                             [65., 64., 81., 82., 83., 84.],
+                             [66., 65., 64., 81., 82., 83.],
+                             [67., 66., 65., 64., 81., 82.],
+                             [68., 67., 66., 65., 64., 81.],
+                             [69., 68., 67., 66., 65., 64.],
+                             [70., 69., 68., 67., 66., 65.]],
+
+                            [[96., 113., 114., 115., 116., 117.],
+                             [97., 96., 113., 114., 115., 116.],
+                             [98., 97., 96., 113., 114., 115.],
+                             [99., 98., 97., 96., 113., 114.],
+                             [100., 99., 98., 97., 96., 113.],
+                             [101., 100., 99., 98., 97., 96.],
+                             [102., 101., 100., 99., 98., 97.]]])
+
+    return REL_BUCKETS, REL_EMB
+
+
+
+def test_rel_buckets_dp(generate_buckets_values):
+    buckets, rel_emb = generate_buckets_values
+    dp = SeqDotProductAttentionT5(0, NH)
+    dp.rel_embedding = torch.tensor(np.arange((NH*NB), dtype=np.float32).reshape(NH, NB))
+    memory_position = torch.arange(NK).view(1, -1)
+    query_position = torch.arange(NQ).view(-1, 1)
+    relative_position = memory_position - query_position
+    rp_bucket = dp._relative_position_bucket(relative_position)
+    np.allclose(rp_bucket.numpy(), buckets.numpy())
+    np.allclose(rel_emb, dp.rel_embedding[:, rp_bucket])
+
+
+def test_rel_buckets_sdp(generate_buckets_values):
+    buckets, rel_emb = generate_buckets_values
+    sdp = SeqScaledDotProductAttentionT5(0, NH)
+    sdp.rel_embedding = torch.tensor(np.arange((NH*NB), dtype=np.float32).reshape(NH, NB))
+    memory_position = torch.arange(NK).view(1, -1)
+    query_position = torch.arange(NQ).view(-1, 1)
+    relative_position = memory_position - query_position
+    rp_bucket = sdp._relative_position_bucket(relative_position)
+    np.allclose(rp_bucket.numpy(), buckets.numpy())
+    np.allclose(rel_emb, sdp.rel_embedding[:, rp_bucket])

--- a/tests/test_rel_bias_pytorch.py
+++ b/tests/test_rel_bias_pytorch.py
@@ -62,22 +62,22 @@ def generate_buckets_values():
 def test_rel_buckets_dp(generate_buckets_values):
     buckets, rel_emb = generate_buckets_values
     dp = SeqDotProductAttentionT5(0, NH)
-    dp.rel_embedding = torch.tensor(np.arange((NH*NB), dtype=np.float32).reshape(NH, NB))
+    dp.rel_embedding = torch.nn.Parameter(torch.tensor(np.arange((NH*NB), dtype=np.float32).reshape(NH, NB)))
     memory_position = torch.arange(NK).view(1, -1)
     query_position = torch.arange(NQ).view(-1, 1)
     relative_position = memory_position - query_position
     rp_bucket = dp._relative_position_bucket(relative_position)
     np.allclose(rp_bucket.numpy(), buckets.numpy())
-    np.allclose(rel_emb, dp.rel_embedding[:, rp_bucket])
+    np.allclose(rel_emb.numpy(), dp.rel_embedding[:, rp_bucket].detach().numpy())
 
 
 def test_rel_buckets_sdp(generate_buckets_values):
     buckets, rel_emb = generate_buckets_values
     sdp = SeqScaledDotProductAttentionT5(0, NH)
-    sdp.rel_embedding = torch.tensor(np.arange((NH*NB), dtype=np.float32).reshape(NH, NB))
+    sdp.rel_embedding = torch.nn.Parameter(torch.tensor(np.arange((NH*NB), dtype=np.float32).reshape(NH, NB)))
     memory_position = torch.arange(NK).view(1, -1)
     query_position = torch.arange(NQ).view(-1, 1)
     relative_position = memory_position - query_position
     rp_bucket = sdp._relative_position_bucket(relative_position)
     np.allclose(rp_bucket.numpy(), buckets.numpy())
-    np.allclose(rel_emb, sdp.rel_embedding[:, rp_bucket])
+    np.allclose(rel_emb.numpy(), sdp.rel_embedding[:, rp_bucket].detach().numpy())

--- a/tests/test_rel_bias_tf.py
+++ b/tests/test_rel_bias_tf.py
@@ -1,0 +1,89 @@
+from collections import namedtuple
+import numpy as np
+import pytest
+
+tf = pytest.importorskip("tensorflow")
+
+from eight_mile.tf.layers import (
+    SeqDotProductAttentionT5,
+    SeqScaledDotProductAttentionT5,
+)
+
+NH = 4
+NQ = 7
+NK = 6
+NB = 32
+
+
+@pytest.fixture
+def generate_buckets_values():
+    REL_BUCKETS = np.array([[0, 17, 18, 19, 20, 21],
+                            [1, 0, 17, 18, 19, 20],
+                            [2, 1, 0, 17, 18, 19],
+                            [3, 2, 1, 0, 17, 18],
+                            [4, 3, 2, 1, 0, 17],
+                            [5, 4, 3, 2, 1, 0],
+                            [6, 5, 4, 3, 2, 1]], dtype=np.float32)
+
+    REL_EMB = np.array([[[0., 17., 18., 19., 20., 21.],
+                         [1., 0., 17., 18., 19., 20.],
+                         [2., 1., 0., 17., 18., 19.],
+                         [3., 2., 1., 0., 17., 18.],
+                         [4., 3., 2., 1., 0., 17.],
+                         [5., 4., 3., 2., 1., 0.],
+                         [6., 5., 4., 3., 2., 1.]],
+
+                        [[32., 49., 50., 51., 52., 53.],
+                         [33., 32., 49., 50., 51., 52.],
+                         [34., 33., 32., 49., 50., 51.],
+                         [35., 34., 33., 32., 49., 50.],
+                         [36., 35., 34., 33., 32., 49.],
+                         [37., 36., 35., 34., 33., 32.],
+                         [38., 37., 36., 35., 34., 33.]],
+
+                        [[64., 81., 82., 83., 84., 85.],
+                         [65., 64., 81., 82., 83., 84.],
+                         [66., 65., 64., 81., 82., 83.],
+                         [67., 66., 65., 64., 81., 82.],
+                         [68., 67., 66., 65., 64., 81.],
+                         [69., 68., 67., 66., 65., 64.],
+                         [70., 69., 68., 67., 66., 65.]],
+
+                        [[96., 113., 114., 115., 116., 117.],
+                         [97., 96., 113., 114., 115., 116.],
+                         [98., 97., 96., 113., 114., 115.],
+                         [99., 98., 97., 96., 113., 114.],
+                         [100., 99., 98., 97., 96., 113.],
+                         [101., 100., 99., 98., 97., 96.],
+                         [102., 101., 100., 99., 98., 97.]]], dtype=np.float32)
+
+    return REL_BUCKETS, REL_EMB
+
+
+def test_rel_buckets_dp(generate_buckets_values):
+    buckets, rel_emb = generate_buckets_values
+    dp = SeqDotProductAttentionT5(0, NH)
+    dp.set_weights([np.arange((NH * NB), dtype=np.float32).reshape(NH, NB)])
+    query_position = tf.reshape(tf.range(NQ), [-1, 1])
+    memory_position = tf.reshape(tf.range(NK), [1, -1])
+    relative_position = memory_position - query_position
+    rp_bucket = dp._relative_position_bucket(relative_position)
+    np.allclose(rp_bucket.numpy(), buckets)
+    rel_emb_dp = tf.expand_dims(tf.gather(dp.get_weights()[0], rp_bucket, axis=-1), 0)
+    np.allclose(rel_emb, rel_emb_dp)
+
+
+
+def test_rel_buckets_sdp(generate_buckets_values):
+    buckets, rel_emb = generate_buckets_values
+    sdp = SeqScaledDotProductAttentionT5(0, NH)
+    sdp.set_weights([np.arange((NH * NB), dtype=np.float32).reshape(NH, NB)])
+    query_position = tf.reshape(tf.range(NQ), [-1, 1])
+    memory_position = tf.reshape(tf.range(NK), [1, -1])
+    relative_position = memory_position - query_position
+    rp_bucket = sdp._relative_position_bucket(relative_position)
+    np.allclose(rp_bucket.numpy(), buckets)
+    rel_emb_sdp = tf.expand_dims(tf.gather(sdp.get_weights()[0], rp_bucket, axis=-1), 0)
+    np.allclose(rel_emb, rel_emb_sdp)
+
+

--- a/tests/test_rel_bias_tf.py
+++ b/tests/test_rel_bias_tf.py
@@ -63,6 +63,7 @@ def generate_buckets_values():
 def test_rel_buckets_dp(generate_buckets_values):
     buckets, rel_emb = generate_buckets_values
     dp = SeqDotProductAttentionT5(0, NH)
+    dp.build((None,))
     dp.set_weights([np.arange((NH * NB), dtype=np.float32).reshape(NH, NB)])
     query_position = tf.reshape(tf.range(NQ), [-1, 1])
     memory_position = tf.reshape(tf.range(NK), [1, -1])
@@ -77,6 +78,7 @@ def test_rel_buckets_dp(generate_buckets_values):
 def test_rel_buckets_sdp(generate_buckets_values):
     buckets, rel_emb = generate_buckets_values
     sdp = SeqScaledDotProductAttentionT5(0, NH)
+    sdp.build((None,))
     sdp.set_weights([np.arange((NH * NB), dtype=np.float32).reshape(NH, NB)])
     query_position = tf.reshape(tf.range(NQ), [-1, 1])
     memory_position = tf.reshape(tf.range(NK), [1, -1])


### PR DESCRIPTION
Add support for bias-based attention methods including T5 and ALiBi and updates the serialization lib
This branch builds on the ALiBi branch from @wenshuoliu, and further abstracts it while adding T5 bucketed RA support.
T5 impl was compared against the flaxformer impl and the mesh TF impl.
Note that the T5 impl is currently only callable with bidirectional on (and defaults from paper).  This should be fixed in a future PR.