### PR TITLE
For known args, we should add them as lists once

### DIFF
--- a/mead/utils.py
+++ b/mead/utils.py
@@ -180,13 +180,10 @@ def parse_overrides(overrides, pre):
     parser = argparse.ArgumentParser()
 
     known_args = set(filter(lambda x: pre in x, overrides))
-
+    for key in known_args:
+        parser.add_argument(key, action='append', type=_infer_numeric_or_str)
     for key in overrides:
-        if key in known_args:
-            # Append action collect each value into a list allowing us to override a
-            # yaml list by repeating the key.
-            parser.add_argument(key, action='append', type=_infer_numeric_or_str)
-        elif key.startswith("--"):
+        if key not in known_args and key.startswith('--'):
             logger.warning("Unexpected argument: %s.  Ignoring", key)
     args = parser.parse_known_args(overrides)[0]
     return {k.split(":")[1]: v[0] if len(v) == 1 else v for k, v in vars(args).items()}


### PR DESCRIPTION
Previously we would add the same argument as many
times as we got repetitions of the argument.