### PR TITLE
refactor transformer layer -> easier understanding

### DIFF
--- a/baseline/pytorch/lm/model.py
+++ b/baseline/pytorch/lm/model.py
@@ -217,6 +217,7 @@ class TransformerLanguageModel(AbstractGeneratorLanguageModel):
         windowed_ra = kwargs.get('windowed_ra', False)
         rpr_value_on = kwargs.get('rpr_value_on', True)
         ra_type = kwargs.get('ra_type')
+        transformer_type = kwargs.get('transformer_type')
         self.mask_pad = kwargs.get('mask_pad', False)
         return TransformerEncoderStack(num_heads, d_model=d_model, pdrop=pdrop, scale=scale,
                                        layers=layers, d_ff=d_ff, rpr_k=rpr_k, d_k=d_k,
@@ -225,7 +226,7 @@ class TransformerLanguageModel(AbstractGeneratorLanguageModel):
                                        layer_norm_eps=layer_norm_eps,
                                        layer_norms_after=layer_norms_after, windowed_ra=windowed_ra,
                                        rpr_value_on=rpr_value_on, ra_type=ra_type,
-                                       layer_drop=layer_drop)
+                                       layer_drop=layer_drop, transformer_type=transformer_type)
 
     def create_layers(self, embeddings, **kwargs):
         super().create_layers(embeddings, **kwargs)

--- a/baseline/pytorch/seq2seq/decoders.py
+++ b/baseline/pytorch/seq2seq/decoders.py
@@ -327,12 +327,13 @@ class RNNDecoderWithAttn(RNNDecoder):
 class TransformerDecoderWrapper(torch.nn.Module):
 
     def __init__(self, tgt_embeddings, dropout=0.5, layers=1, hsz=None, num_heads=4,
-                 activation='relu',
+                 activation='gelu',
                  rpr_k=None,
                  layer_norm_eps=1e-6,
                  layer_drop=0.0, scale=True, rpr_value_on=True, ra_type=None,
                  d_k=None,
                  d_ff=None,
+                 transformer_type=None,
                  **kwargs):
         super().__init__()
         self.tgt_embeddings = tgt_embeddings
@@ -347,7 +348,7 @@ class TransformerDecoderWrapper(torch.nn.Module):
                                                            pdrop=dropout, scale=scale, layers=layers,
                                                            rpr_k=rpr_k, d_k=d_k, activation_type=activation,
                                                            layer_drop=layer_drop, layer_norm_eps=layer_norm_eps,
-                                                           rpr_value_on=rpr_value_on, ra_type=ra_type)
+                                                           rpr_value_on=rpr_value_on, ra_type=ra_type, transformer_type=transformer_type)
 
         self.proj_to_hsz = self._identity
         self.proj_to_dsz = self._identity

--- a/baseline/pytorch/seq2seq/encoders.py
+++ b/baseline/pytorch/seq2seq/encoders.py
@@ -46,6 +46,7 @@ class TransformerEncoderWrapper(torch.nn.Module):
                  layer_drop=0.0, scale=True, rpr_value_on=True, ra_type=None,
                  d_k=None,
                  d_ff=None,
+                 transformer_type=None,
                  **kwargs):
         super().__init__()
         if hsz is None:
@@ -58,7 +59,7 @@ class TransformerEncoderWrapper(torch.nn.Module):
                                                    pdrop=dropout, scale=scale, layers=layers,
                                                    rpr_k=rpr_k, d_k=d_k, activation=activation, layer_drop=layer_drop,
                                                    layer_norm_eps=layer_norm_eps,
-                                                   rpr_value_on=rpr_value_on, ra_type=ra_type)
+                                                   rpr_value_on=rpr_value_on, ra_type=ra_type, transformer_type=transformer_type)
 
     def _identity(self, x):
         return x

--- a/baseline/tf/lm/model.py
+++ b/baseline/tf/lm/model.py
@@ -326,6 +326,7 @@ class TransformerLanguageModel(AbstractGeneratorModel):
         windowed_ra = kwargs.get('windowed_ra', False)
         rpr_value_on = kwargs.get('rpr_value_on', True)
         ra_type = kwargs.get('ra_type')
+        transformer_type = kwargs.get('transformer_type')
         self.mask_pad = kwargs.get('mask_pad', False)
         return TransformerEncoderStack(num_heads, d_model=d_model, pdrop=pdrop, scale=scale,
                                        layers=layers, d_ff=d_ff, rpr_k=rpr_k, d_k=d_k,
@@ -334,7 +335,8 @@ class TransformerLanguageModel(AbstractGeneratorModel):
                                        layer_norm_eps=layer_norm_eps,
                                        layer_norms_after=layer_norms_after, windowed_ra=windowed_ra,
                                        rpr_value_on=rpr_value_on, ra_type=ra_type,
-                                       layer_drop=layer_drop)
+                                       layer_drop=layer_drop,
+                                       transformer_type=transformer_type)
 
     def create_mask(self, bth, inputs):
         max_seqlen = get_shape_as_list(bth)[1]

--- a/baseline/tf/seq2seq/decoders.py
+++ b/baseline/tf/seq2seq/decoders.py
@@ -240,16 +240,17 @@ class TransformerDecoderWrapper(tf.keras.layers.Layer):
         d_ff = int(kwargs.get('d_ff', 4 * hsz))
         rpr_k = kwargs.get('rpr_k')
         d_k = kwargs.get('d_k')
-        activation = kwargs.get('activation', 'relu')
+        activation = kwargs.get('activation', 'gelu')
         scale = bool(kwargs.get('scale', True))
         layer_drop = float(kwargs.get('layer_drop', 0.0))
         ra_type = kwargs.get('ra_type')
+        transformer_type = kwargs.get('transformer_type')
 
         self.transformer_decoder = TransformerDecoderStack(num_heads, d_model=hsz, d_ff=d_ff,
                                                            pdrop=dropout, scale=scale,
                                                            layers=layers, rpr_k=rpr_k, d_k=d_k,
                                                            activation_type=activation, layer_drop=layer_drop,
-                                                           ra_type=ra_type)
+                                                           ra_type=ra_type, transformer_type=transformer_type)
 
         self.proj_to_dsz = self._identity
         self.proj_to_hsz = self._identity

--- a/baseline/tf/seq2seq/encoders.py
+++ b/baseline/tf/seq2seq/encoders.py
@@ -47,14 +47,15 @@ class TransformerEncoderWrapper(tf.keras.layers.Layer):
         d_ff = int(kwargs.get('d_ff', 4 * hsz))
         rpr_k = kwargs.get('rpr_k')
         d_k = kwargs.get('d_k')
-        activation = kwargs.get('activation', 'relu')
+        activation = kwargs.get('activation', 'gelu')
         scale = bool(kwargs.get('scale', True))
         layer_drop = float(kwargs.get('layer_drop', 0.0))
         ra_type = kwargs.get('ra_type')
+        transformer_type = kwargs.get('transformer_type')
         self.transformer = TransformerEncoderStack(num_heads, d_model=hsz, d_ff=d_ff,
                                                    pdrop=dropout, scale=scale, layers=layers,
                                                    rpr_k=rpr_k, d_k=d_k, activation=activation, layer_drop=layer_drop,
-                                                   ra_type=ra_type, scope=scope)
+                                                   ra_type=ra_type, transformer_type=transformer_type, scope=scope)
 
 
     def _identity(self, x):

--- a/layers/eight_mile/pytorch/layers.py
+++ b/layers/eight_mile/pytorch/layers.py
@@ -3622,7 +3622,7 @@ class TransformerEncoderStack(nn.Module):
         super().__init__()
         self.encoders = nn.ModuleList()
         if layer_norms_after or transformer_type == "post-layer-norm":
-            logger.info("Using post-layer-norm transformer")
+            logger.info("Using post-layer-norm transformer (encoder)")
             TransformerEncoder = PostLNTransformerEncoder
             self.ln = nn.Identity()
         elif transformer_type == "pre-layer-norm":
@@ -3630,7 +3630,7 @@ class TransformerEncoderStack(nn.Module):
             self.ln = nn.LayerNorm(d_model, eps=layer_norm_eps)
 
         else:  # transformer_type == "pre-layer-norm-before-resconn"
-            logger.info("Using layer norm before residual connections")
+            logger.info("Using layer norm before residual connections (encoder)")
             if layer_norms_after:
                 raise Exception(f"Mutually exclusive options ({transformer_type}) and layer_norms_after=True)",)
             TransformerEncoder = PreLNBeforeResConnTransformerEncoder
@@ -3796,14 +3796,14 @@ class TransformerDecoderStack(nn.Module):
         self.decoders = nn.ModuleList()
         self.layer_drop = layer_drop
         if layer_norms_after or transformer_type == "post-layer-norm":
-            logger.debug("Using post-layer-norm transformer")
+            logger.info("Using post-layer-norm transformer (decoder)")
             TransformerDecoder = PostLNTransformerDecoder
             self.ln = nn.Identity()
         elif transformer_type == "pre-layer-norm":
             TransformerDecoder = PreLNTransformerDecoder
             self.ln = nn.LayerNorm(d_model, eps=layer_norm_eps)
         else:  # transformer_type == "pre-layer-norm-before-resconn"
-            logger.debug("Using layer norm before residual connections")
+            logger.info("Using layer norm before residual connections (decoder)")
             if layer_norms_after:
                 raise Exception(f"Mutually exclusive options ({transformer_type}) and layer_norms_after=True)",)
             TransformerDecoder = PreLNBeforeResConnTransformerDecoder

--- a/layers/eight_mile/pytorch/layers.py
+++ b/layers/eight_mile/pytorch/layers.py
@@ -3346,21 +3346,21 @@ class MultiHeadedRelativeAttention(nn.Module):
 
 class TransformerEncoderBase(nn.Module):
     def __init__(
-            self,
-            num_heads: int,
-            d_model: int,
-            pdrop: float,
-            scale: bool = True,
-            activation_type: str = "gelu",
-            d_ff: Optional[int] = None,
-            d_k: Optional[int] = None,
-            rpr_k: Optional[int] = None,
-            ffn_pdrop: Optional[float] = 0.0,
-            layer_norm_eps: float = 1.0e-6,
-            windowed_ra: Optional[bool] = False,
-            rpr_value_on: bool = True,
-            ra_type: Optional[str] = None,
-            **kwargs,
+        self,
+        num_heads: int,
+        d_model: int,
+        pdrop: float,
+        scale: bool = True,
+        activation_type: str = "gelu",
+        d_ff: Optional[int] = None,
+        d_k: Optional[int] = None,
+        rpr_k: Optional[int] = None,
+        ffn_pdrop: Optional[float] = 0.0,
+        layer_norm_eps: float = 1.0e-6,
+        windowed_ra: Optional[bool] = False,
+        rpr_value_on: bool = True,
+        ra_type: Optional[str] = None,
+        **kwargs,
     ):
         super().__init__()
         self.d_model = d_model
@@ -3423,6 +3423,7 @@ class PostLNTransformerEncoder(TransformerEncoderBase):
         x = x + self.dropout(h)
         x = self.ln2(x)
         x = x + self.dropout(self.ffn(x))
+        x = self.ln1(x)
         return x
 
 
@@ -3625,10 +3626,10 @@ class TransformerEncoderStack(nn.Module):
         self.ln = nn.Identity() if layer_norms_after else nn.LayerNorm(d_model, eps=layer_norm_eps)
         TransformerEncoder = PreLNTransformerEncoder
         if layer_norms_after:
-            logger.info("Using post-layer-norm transformer")
+            logger.debug("Using post-layer-norm transformer")
             TransformerEncoder = PostLNTransformerEncoder
         if layer_norms_before_resconn:
-            logger.info("Using layer norm before residual connections")
+            logger.debug("Using layer norm before residual connections")
             if layer_norms_after:
                 raise Exception("Mutually exclusive options (layer_norms_before_resconn=True and layer_norms_after=True)")
             TransformerEncoder = PreLNPreResConnTransformerEncoder

--- a/layers/eight_mile/pytorch/serialize.py
+++ b/layers/eight_mile/pytorch/serialize.py
@@ -5,9 +5,9 @@ from typing import Dict, List
 from eight_mile.pytorch.layers import (
     Dense,
     TransformerEncoderStack,
-    TransformerEncoder,
+    TransformerEncoderBase,
     TransformerDecoderStack,
-    TransformerDecoder,
+    TransformerDecoderBase,
     EmbeddingsStack,
     WithDropout,
     SingleHeadReduction,
@@ -313,8 +313,8 @@ def from_attn_array(pytorch_attn: nn.Module, d: Dict, name: str):
         pytorch_attn.rpr_value.weight = torch.nn.Parameter(torch.from_numpy(d[f"{name}/rpr_value"]).to(device=device))
 
 
-def to_encoder_array(pytorch_encoder: TransformerEncoder, name: str) -> Dict:
-    """Convert a `TransformerEncoder` layer to an set of numpy arrays
+def to_encoder_array(pytorch_encoder: TransformerEncoderBase, name: str) -> Dict:
+    """Convert a `TransformerEncoderBase` layer to an set of numpy arrays
 
     :param pytorch_encoder: A `TransformerEncoder` layer
     :param name: The layer name
@@ -332,6 +332,7 @@ def from_sgu_array(pytorch_sgu: SpatialGatingUnit, d: Dict, name: str) -> Dict:
     from_weight_array(pytorch_sgu.norm, d, f"{name}/norm")
     from_weight_array(pytorch_sgu.proj, d, f"{name}/proj")
 
+
 def from_gmlp_encoder_array(pytorch_encoder: GatedMLPEncoder, d: Dict, name: str):
     """Restore a `TransformerEncoder` layer from a set of numpy arrays
 
@@ -347,10 +348,10 @@ def from_gmlp_encoder_array(pytorch_encoder: GatedMLPEncoder, d: Dict, name: str
 
 
 
-def from_encoder_array(pytorch_encoder: TransformerEncoder, d: Dict, name: str):
+def from_encoder_array(pytorch_encoder: TransformerEncoderBase, d: Dict, name: str):
     """Restore a `TransformerEncoder` layer from a set of numpy arrays
 
-    :param pytorch_encoder: A `TransformerEncoder` layer
+    :param pytorch_encoder: A `TransformerEncoderBase` layer
     :param d: A Dict of arrays by key
     :param name: The layer name
     :return: None
@@ -361,10 +362,10 @@ def from_encoder_array(pytorch_encoder: TransformerEncoder, d: Dict, name: str):
     from_ffn_array(pytorch_encoder.ffn, d, f"{name}/ffn")
 
 
-def from_decoder_array(pytorch_decoder: TransformerDecoder, d: Dict, name: str):
+def from_decoder_array(pytorch_decoder: TransformerDecoderBase, d: Dict, name: str):
     """Restore a `TransformerDecoder` layer from a set of numpy arrays
 
-    :param pytorch_decoder: A `TransformerDecoder` layer
+    :param pytorch_decoder: A `TransformerDecoderBase` layer
     :param d: A Dict of arrays by key
     :param name: The layer name
     :return: None
@@ -377,7 +378,7 @@ def from_decoder_array(pytorch_decoder: TransformerDecoder, d: Dict, name: str):
     from_ffn_array(pytorch_decoder.ffn, d, f"{name}/ffn")
 
 
-def to_decoder_array(pytorch_decoder: TransformerDecoder, name: str) -> Dict:
+def to_decoder_array(pytorch_decoder: TransformerDecoderBase, name: str) -> Dict:
     """Convert a `TransformerDeccoder` layer to an set of numpy arrays
 
     :param pytorch_decoder: A `TransformerDecoder` layer

--- a/layers/eight_mile/tf/layers.py
+++ b/layers/eight_mile/tf/layers.py
@@ -2629,7 +2629,7 @@ class TransformerEncoderStack(tf.keras.layers.Layer):
             rpr_k = [rpr_k] * layers
 
         if layer_norms_after or transformer_type == "post-layer-norm":
-            LOGGER.debug("Using post-layer-norm transformer")
+            LOGGER.info("Using post-layer-norm transformer (encoder)")
             TransformerEncoder = PostLNTransformerEncoder
             self.ln = tf.identity
 
@@ -2638,7 +2638,7 @@ class TransformerEncoderStack(tf.keras.layers.Layer):
             self.ln = tf.keras.layers.LayerNormalization(epsilon=layer_norm_eps)
 
         else:  # transformer_type == "pre-layer-norm-before-resconn":
-            LOGGER.debug("Using layer norm before residual connections")
+            LOGGER.info("Using layer norm before residual connections (encoder)")
             if layer_norms_after:
                 raise Exception(f"Mutually exclusive options ({transformer_type}) and layer_norms_after=True)",)
             TransformerEncoder = PreLNBeforeResConnTransformerEncoder
@@ -3145,7 +3145,7 @@ class TransformerDecoderStack(tf.keras.layers.Layer):
             rpr_k = [rpr_k] * layers
 
         if layer_norms_after or transformer_type == "post-layer-norm":
-            LOGGER.debug("Using post-layer-norm transformer")
+            LOGGER.info("Using post-layer-norm transformer (decoder)")
             TransformerDecoder = PostLNTransformerDecoder
             self.ln = tf.identity
 
@@ -3154,7 +3154,7 @@ class TransformerDecoderStack(tf.keras.layers.Layer):
             self.ln = tf.keras.layers.LayerNormalization(epsilon=layer_norm_eps)
 
         else:  # transformer_type == "pre-layer-norm-before-resconn":
-            LOGGER.debug("Using layer norm before residual connections")
+            LOGGER.info("Using layer norm before residual connections (decoder)")
             if layer_norms_after:
                 raise Exception(f"Mutually exclusive options ({transformer_type}) and layer_norms_after=True)",)
             TransformerDecoder = PreLNBeforeResConnTransformerDecoder

--- a/layers/eight_mile/tf/layers.py
+++ b/layers/eight_mile/tf/layers.py
@@ -2473,22 +2473,22 @@ class GatedMLPEncoder(tf.keras.layers.Layer):
 
 class TransformerDecoderBase(tf.keras.layers.Layer):
     def __init__(
-            self,
-            num_heads: int,
-            d_model: int,
-            pdrop: float,
-            scale: bool = True,
-            activation_type: str = "relu",
-            d_ff: Optional[int] = None,
-            d_k: Optional[int] = None,
-            rpr_k: Optional[int] = None,
-            ffn_pdrop: Optional[float] = 0.0,
-            layer_norms_after: bool = False,
-            layer_norm_eps: float = 1.0e-6,
-            layer_drop: float = 0.0,
-            rpr_value_on: bool = True,
-            ra_type: Optional[str] = None,
-            name: Optional[str] = None
+        self,
+        num_heads: int,
+        d_model: int,
+        pdrop: float,
+        scale: bool = True,
+        activation_type: str = "gelu",
+        d_ff: Optional[int] = None,
+        d_k: Optional[int] = None,
+        rpr_k: Optional[int] = None,
+        ffn_pdrop: Optional[float] = 0.0,
+        layer_norms_after: bool = False,
+        layer_norm_eps: float = 1.0e-6,
+        layer_drop: float = 0.0,
+        rpr_value_on: bool = True,
+        ra_type: Optional[str] = None,
+        name: Optional[str] = None
     ):
         super().__init__(name=name)
         self.d_model = d_model
@@ -2606,7 +2606,7 @@ class TransformerEncoderStack(tf.keras.layers.Layer):
         pdrop: float,
         scale: bool = True,
         layers: int = 1,
-        activation: str = "relu",
+        activation: str = "gelu",
         d_ff: Optional[int] = None,
         d_k: Optional[int] = None,
         rpr_k: Optional[Union[int, List[int]]] = None,

--- a/layers/eight_mile/tf/serialize.py
+++ b/layers/eight_mile/tf/serialize.py
@@ -2,9 +2,9 @@ import numpy as np
 from typing import Dict, List
 from eight_mile.tf.layers import (
     TransformerEncoderStack,
-    TransformerEncoder,
+    TransformerEncoderBase,
     TransformerDecoderStack,
-    TransformerDecoder,
+    TransformerDecoderBase,
     MultiHeadedAttention,
     PassThru,
     FFN,
@@ -146,7 +146,7 @@ def to_gmlp_encoder_array(tf_encoder: GatedMLPEncoder, name: str) -> Dict:
     d.update(to_sgu_array(tf_encoder.spatial_gating_unit, f"{name}/spatial_gating_unit"))
     return d
 
-def to_encoder_array(tf_encoder: TransformerEncoder, name: str) -> Dict:
+def to_encoder_array(tf_encoder: TransformerEncoderBase, name: str) -> Dict:
     """Convert a `TransformerEncoder` layer to an set of numpy arrays
 
     :param tf_encoder: A `TransformerEncoder` layer
@@ -161,7 +161,7 @@ def to_encoder_array(tf_encoder: TransformerEncoder, name: str) -> Dict:
     return d
 
 
-def from_encoder_array(tf_encoder: TransformerEncoder, d: Dict, name: str):
+def from_encoder_array(tf_encoder: TransformerEncoderBase, d: Dict, name: str):
     """Restore a `TransformerEncoder` layer from a set of numpy arrays
 
     :param tf_encoder: A `TransformerEncoder` layer
@@ -175,7 +175,7 @@ def from_encoder_array(tf_encoder: TransformerEncoder, d: Dict, name: str):
     from_ffn_array(tf_encoder.ffn, d, f"{name}/ffn")
 
 
-def to_decoder_array(tf_decoder: TransformerDecoder, name: str) -> Dict:
+def to_decoder_array(tf_decoder: TransformerDecoderBase, name: str) -> Dict:
     """Convert a `TransformerDeccoder` layer to an set of numpy arrays
 
     :param tf_decoder: A `TransformerDecoder` layer
@@ -302,7 +302,7 @@ def to_decoder_stack_array(
         d.update(to_decoder_array(dec_tf, f"{name}/{i}"))
     return d
 
-def from_decoder_array(tf_decoder: TransformerDecoder, d: Dict, name: str):
+def from_decoder_array(tf_decoder: TransformerDecoderBase, d: Dict, name: str):
     """Restore a `TransformerDecoder` layer from a set of numpy arrays
 
     :param tf_decoder: A `TransformerDecoder` layer

--- a/mead/api_examples/pretrain_paired_pytorch.py
+++ b/mead/api_examples/pretrain_paired_pytorch.py
@@ -31,7 +31,8 @@ This file uses Baseline to train a Transformer model using fastBPE with query-re
   
 """
 def create_model(embeddings, d_model, d_ff, dropout, num_heads, num_layers, model_type, rpr_k, d_k, reduction_d_k,
-                 stacking_layers, ff_pdrop, windowed_ra, reduction_type, shared_output, logger, layer_norms_after=False):
+                 stacking_layers, ff_pdrop, windowed_ra, reduction_type, shared_output, logger, layer_norms_after=False,
+                 ra_type=None, transformer_type=None):
 
     if model_type == 'transformer-bow':
         model = TransformerBoWPairedModel(embeddings, d_model, d_ff, dropout, num_heads, num_layers, rpr_k=rpr_k, d_k=d_k,
@@ -44,7 +45,7 @@ def create_model(embeddings, d_model, d_ff, dropout, num_heads, num_layers, mode
                             reduction_d_k=reduction_d_k, stacking_layers=stacking_layers, ffn_pdrop=ff_pdrop,
                             windowed_ra=windowed_ra, reduction_type=reduction_type, freeze_encoders=True,
                             output_shared=shared_output, output_layer=shared_output,
-                            layer_norms_after=layer_norms_after)
+                            layer_norms_after=layer_norms_after, transformer_type=transformer_type)
 
     logger.info(model)
     return model
@@ -146,6 +147,7 @@ def parse_args(argv):
                         help="Local rank for distributed training (-1 means use the environment variables to find)")
     parser.add_argument("--shared_output", action='store_true')
     parser.add_argument("--extra_tokens", help="What extra tokens should we use", nargs="+", default=["[CLS]", "[MASK]"])
+    parser.add_argument("--transformer_type", help="What TransformerEncoder type to use", default="pre-layer-norm")
     parser.add_argument("--save_npz", type=str2bool, default=False, help="Whether save npz checkpoint")
     args = parser.parse_args(argv)
     return args

--- a/mead/api_examples/pretrain_tlm_grad_accum_tf.py
+++ b/mead/api_examples/pretrain_tlm_grad_accum_tf.py
@@ -255,7 +255,7 @@ def main():
     parser.add_argument("--eps", help="Epsilon", default=1e-6, type=float)
     parser.add_argument("--beta2", help="Epsilon", default=0.98, type=float)
     parser.add_argument("--grad_accum", help="Number of iterations to accum grads", default=1, type=int)
-
+    parser.add_argument("--transformer_type", help="Transformer layer type")
     args = parser.parse_args()
     SET_TRAIN_FLAG(True)
 
@@ -560,6 +560,7 @@ def create_model(args, embeddings):
                            rpr_value_on=args.rpr_value_on,
                            layer_drop=args.layer_drop,
                            ra_type=args.ra_type,
+                           transformer_type=args.transformer_type,
                            src_keys=['x'], tgt_key='x')
     return model
 

--- a/mead/api_examples/pretrain_tlm_pytorch.py
+++ b/mead/api_examples/pretrain_tlm_pytorch.py
@@ -49,7 +49,7 @@ def run(basedir=None, train_file=None, valid_file=None, dataset_key='tlm', embed
         restart_tt=None, warmup_steps=10000, saves_per_epoch=10, mlm=True, preprocessed=True, rpr_k=[8],
         rpr_value_on=False, windowed_ra=False, device="cuda", distributed=False, local_rank=-1,
         extra_tokens=["[CLS]", "[MASK]"], do_early_stopping=False, model_type='transformer-mlm', modules=[],
-        ra_type=None, **kwargs):
+        ra_type=None, transformer_type=None, **kwargs):
     if basedir is None:
         basedir = 'lm-{}-bpe-{}'.format(dataset_key, os.getpid())
     logging.basicConfig(level=logging.INFO if local_rank in [-1, 0] else logging.WARN)
@@ -136,6 +136,7 @@ def run(basedir=None, train_file=None, valid_file=None, dataset_key='tlm', embed
         layer_drop=layer_drop,
         model_type=model_type,
         ra_type=ra_type,
+        transformer_type=transformer_type,
         src_keys=['x'], tgt_key='x')
     model.to(device)
 
@@ -369,6 +370,8 @@ def parse_args(argv):
                         default=["[CLS]", "[MASK]"])
     parser.add_argument("--do_early_stopping", type=str2bool, default=False,
                         help="if True, only save checkpoint when valid loss improves")
+    parser.add_argument("--transformer_type", help="What TransformerEncoder type to use")
+
     args = parser.parse_args(argv)
     return args
 

--- a/mead/api_examples/pretrain_tlm_tf.py
+++ b/mead/api_examples/pretrain_tlm_tf.py
@@ -177,6 +177,7 @@ def main():
     parser.add_argument("--tb", help="Turn on tensorboard?", type=str2bool, default=False)
     parser.add_argument("--convert_only", help="Should we just convert this file to NPZ and exit?", type=str2bool, default=False)
     parser.add_argument("--extra_tokens", help="What extra tokens should we use", nargs="+", default=["[CLS]", "[MASK]"])
+    parser.add_argument("--transformer_type", help="What TransformerEncoder type to use")
     parser.add_argument("--eps", help="Epsilon", default=1e-6, type=float)
     parser.add_argument("--beta2", help="Epsilon", default=0.98, type=float)
     args = parser.parse_args()
@@ -454,6 +455,7 @@ def create_model(args, embeddings):
                            rpr_value_on=args.rpr_value_on,
                            layer_drop=args.layer_drop,
                            ra_type=args.ra_type,
+                           transformer_type=args.transformer_type,
                            src_keys=['x'], tgt_key='x')
     return model
 

--- a/mead/api_examples/pretrain_transformer_seq2seq_pytorch.py
+++ b/mead/api_examples/pretrain_transformer_seq2seq_pytorch.py
@@ -115,6 +115,8 @@ def parse_args(argv):
                         help="Local rank for distributed training (-1 means use the environment variables to find)")
     parser.add_argument("--extra_tokens", help="What extra tokens should we use", nargs="+",
                         default=["[CLS]", "[MASK]"])
+    parser.add_argument("--transformer_type", help="What TransformerEncoder type to use")
+
     parser.add_argument("--save_npz", type=str2bool, default=False, help="Whether save npz checkpoint")
     args = parser.parse_args(argv)
     return args
@@ -129,7 +131,7 @@ def run(basedir=None, train_file=None, valid_file=None, dataset_key='paired', em
         layer_drop=0.0, reader_type='preprocessed', src_begin_tok=[], src_end_tok=['<EOS>'],
         tgt_begin_tok=['<GO>'], tgt_end_tok=['<EOS>'], lower=False,
         rpr_k=[8], device='cuda', distributed=False, local_rank=-1, save_npz=False,
-        extra_tokens=["[CLS]", "[MASK]"], subword_type='bpe', label_smoothing=None, **kwargs):
+        extra_tokens=["[CLS]", "[MASK]"], subword_type='bpe', label_smoothing=None, ra_type=None, transformer_type=None, **kwargs):
     if basedir is None:
         basedir = f's2s-{reader_type}-paired-{dataset_key}-bpe-{os.getpid()}'
     logging.basicConfig(level=logging.INFO if local_rank in [-1, 0] else logging.WARN)
@@ -180,7 +182,9 @@ def run(basedir=None, train_file=None, valid_file=None, dataset_key='paired', em
            "src_lengths_key": "x_lengths",
            "d_k": d_k,
            "layer_drop": layer_drop,
-           "rpr_k": rpr_k}
+           "rpr_k": rpr_k,
+           "ra_type": ra_type,
+           "transformer_type": transformer_type}
     model = TiedEmbeddingsSeq2SeqModel({'x': embeddings}, None, **hps)
     model.to(device)
 

--- a/mead/api_examples/pretrain_transformer_seq2seq_tf.py
+++ b/mead/api_examples/pretrain_transformer_seq2seq_tf.py
@@ -160,6 +160,8 @@ def train():
     parser.add_argument("--tb", help="Turn on tensorboard?", type=str2bool, default=False)
     parser.add_argument("--convert_only", help="Should we just convert this file to NPZ and exit?", type=str2bool, default=False)
     parser.add_argument("--extra_tokens", help="What extra tokens should we use", nargs="+", default=["[CLS]", "[MASK]"])
+    parser.add_argument("--transformer_type", help="What TransformerEncoder type to use")
+
     args = parser.parse_args()
 
     if args.tpu_ep is not None and args.file_type != 'tfrecord':
@@ -275,7 +277,8 @@ def train():
            "d_k": args.d_k,
            "rpr_k": rpr_k,
            "rpr_value_on": args.rpr_value_on,
-           "ra_type": args.ra_type}
+           "ra_type": args.ra_type,
+           "transformer_type": args.transformer_type}
     model = TiedEmbeddingsSeq2SeqModel(embeddings, **hps)
 
     logger.info("Loaded model and loss")


### PR DESCRIPTION
Right now we try to handle all paths through the
same path.  This is error prone and difficult to reading.
Compounding this, our pre-LN models to date are non-std,
which means its even harder to get whats going on.

This refactoring pulls up an ABC for both, and provides
separate implementations for all 3 that are supported
preLN, postLN, TPT style